### PR TITLE
Add agent support to registry and installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,13 @@ npx awos skill modern-python-development
 # Install an MCP server definition
 npx awos mcp context7
 
+# Install an agent (also auto-installs its referenced skills)
+npx awos agent test-agent
+
 # Install multiple at once
 npx awos skill modern-python-development typescript-development
 npx awos mcp context7 playwright
+npx awos agent test-agent another-agent
 ```
 
 ## Quick Start
@@ -50,7 +54,7 @@ just serve
 The server starts on `http://0.0.0.0:8000` with:
 - **MCP endpoint:** `POST /mcp` (Streamable HTTP)
 - **Health check:** `GET /health`
-- **Bundle endpoints:** `POST /bundle/skills`, `POST /bundle/mcp`
+- **Bundle endpoints:** `POST /bundle/skills`, `POST /bundle/mcp`, `POST /bundle/agents`
 
 ## Documentation
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@provectusinc/awos-recruitment",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@provectusinc/awos-recruitment",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "tar": "^7.0.0",
         "yaml": "^2.0.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,12 +1,16 @@
 {
   "name": "@provectusinc/awos-recruitment",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "bin": "dist/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "tar": "^7.0.0",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -1,3 +1,4 @@
+import { installAgents } from "./commands/agent.js";
 import { installMcpServers } from "./commands/mcp.js";
 import { installSkills } from "./commands/skill.js";
 import { CliError } from "./lib/errors.js";
@@ -6,7 +7,8 @@ const USAGE = `Usage: awos <command> <names...>
 
 Commands:
   skill   Install skills into .claude/skills/
-  mcp     Install MCP servers into .mcp.json`;
+  mcp     Install MCP servers into .mcp.json
+  agent   Install agents into .claude/agents/`;
 
 export async function run(): Promise<void> {
   const args = process.argv.slice(2);
@@ -18,7 +20,7 @@ export async function run(): Promise<void> {
     process.exit(1);
   }
 
-  if (subcommand !== "skill" && subcommand !== "mcp") {
+  if (subcommand !== "skill" && subcommand !== "mcp" && subcommand !== "agent") {
     throw new CliError(
       `Error: unknown command '${subcommand}'. Run 'awos' for usage.`,
     );
@@ -36,6 +38,9 @@ export async function run(): Promise<void> {
       break;
     case "mcp":
       await installMcpServers(names);
+      break;
+    case "agent":
+      await installAgents(names);
       break;
   }
 }

--- a/cli/src/commands/__tests__/agent.test.ts
+++ b/cli/src/commands/__tests__/agent.test.ts
@@ -1,0 +1,254 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+
+import { installAgents } from "../agent.js";
+
+// ---------------------------------------------------------------------------
+// Mock downloadBundle -- vi.hoisted ensures the variable is available
+// inside the hoisted vi.mock factory.
+// ---------------------------------------------------------------------------
+
+const { mockDownloadBundle } = vi.hoisted(() => ({
+  mockDownloadBundle: vi.fn<(url: string, names: string[]) => Promise<string>>(),
+}));
+
+vi.mock("../../lib/download.js", () => ({
+  downloadBundle: mockDownloadBundle,
+}));
+
+// ---------------------------------------------------------------------------
+// Shared state
+// ---------------------------------------------------------------------------
+
+/** Temp directories to clean up after each test. */
+const tempDirs: string[] = [];
+
+/** Helper: create a fresh temp dir and register it for cleanup. */
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/** Sample agent markdown content. */
+const agentMarkdown = `---
+name: code-reviewer
+description: Reviews code for best practices
+model: claude-sonnet
+skills:
+  - typescript
+---
+
+# Code Reviewer
+
+You are a code review agent.
+`;
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+describe("installAgents", () => {
+  beforeEach(() => {
+    // Prevent process.exit from actually killing the test runner.
+    vi.spyOn(process, "exit").mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      (_code?: string | number | null) => undefined as never,
+    );
+
+    // Silence stdout / stderr output from printResults.
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const dir of tempDirs) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+    tempDirs.length = 0;
+  });
+
+  // -----------------------------------------------------------------------
+  // 1. Successful install
+  // -----------------------------------------------------------------------
+  it("copies a found agent .md file into .claude/agents/<name>.md", async () => {
+    // Prepare a temp dir simulating the extracted bundle.
+    const bundleDir = makeTempDir("agent-bundle-");
+    fs.writeFileSync(
+      path.join(bundleDir, "code-reviewer.md"),
+      agentMarkdown,
+      "utf-8",
+    );
+
+    mockDownloadBundle.mockResolvedValue(bundleDir);
+
+    // Prepare a fake cwd.
+    const fakeCwd = makeTempDir("agent-cwd-");
+    vi.spyOn(process, "cwd").mockReturnValue(fakeCwd);
+
+    await installAgents(["code-reviewer"]);
+
+    // The agent file should have been copied into the expected location.
+    const installed = path.join(
+      fakeCwd,
+      ".claude",
+      "agents",
+      "code-reviewer.md",
+    );
+    expect(fs.existsSync(installed)).toBe(true);
+    expect(fs.readFileSync(installed, "utf-8")).toBe(agentMarkdown);
+
+    // process.exit should NOT have been called (no failures).
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // 2. Skip existing
+  // -----------------------------------------------------------------------
+  it("skips install when .claude/agents/<name>.md already exists (no error exit)", async () => {
+    // Prepare a bundle with an agent.
+    const bundleDir = makeTempDir("agent-bundle-");
+    fs.writeFileSync(
+      path.join(bundleDir, "code-reviewer.md"),
+      agentMarkdown,
+      "utf-8",
+    );
+
+    mockDownloadBundle.mockResolvedValue(bundleDir);
+
+    // Pre-create the agent file in the fake cwd to trigger skip.
+    const fakeCwd = makeTempDir("agent-cwd-");
+    const existingDir = path.join(fakeCwd, ".claude", "agents");
+    fs.mkdirSync(existingDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(existingDir, "code-reviewer.md"),
+      "# Original Agent",
+      "utf-8",
+    );
+
+    vi.spyOn(process, "cwd").mockReturnValue(fakeCwd);
+
+    await installAgents(["code-reviewer"]);
+
+    // Should NOT exit with failure — skips are informational, not errors.
+    expect(process.exit).not.toHaveBeenCalled();
+
+    // Original file should be untouched.
+    expect(
+      fs.readFileSync(
+        path.join(existingDir, "code-reviewer.md"),
+        "utf-8",
+      ),
+    ).toBe("# Original Agent");
+  });
+
+  // -----------------------------------------------------------------------
+  // 3. Not found
+  // -----------------------------------------------------------------------
+  it("calls process.exit(1) when a requested agent is not in the bundle", async () => {
+    // Return an empty bundle directory -- the agent doesn't exist.
+    const bundleDir = makeTempDir("agent-bundle-");
+    mockDownloadBundle.mockResolvedValue(bundleDir);
+
+    const fakeCwd = makeTempDir("agent-cwd-");
+    vi.spyOn(process, "cwd").mockReturnValue(fakeCwd);
+
+    await installAgents(["nonexistent"]);
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // 4. Mixed results
+  // -----------------------------------------------------------------------
+  it("handles mixed results: installed, skipped, and not-found", async () => {
+    // Prepare a bundle with two agents (but not "missing-agent").
+    const bundleDir = makeTempDir("agent-bundle-");
+    fs.writeFileSync(
+      path.join(bundleDir, "new-agent.md"),
+      "# New Agent",
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(bundleDir, "existing-agent.md"),
+      "# Existing Agent (new version)",
+      "utf-8",
+    );
+
+    mockDownloadBundle.mockResolvedValue(bundleDir);
+
+    // Pre-create one agent to trigger skip.
+    const fakeCwd = makeTempDir("agent-cwd-");
+    const agentsDir = path.join(fakeCwd, ".claude", "agents");
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(agentsDir, "existing-agent.md"),
+      "# Existing Agent (original)",
+      "utf-8",
+    );
+
+    vi.spyOn(process, "cwd").mockReturnValue(fakeCwd);
+
+    await installAgents(["new-agent", "existing-agent", "missing-agent"]);
+
+    // Should exit with failure because of the not-found agent.
+    expect(process.exit).toHaveBeenCalledWith(1);
+
+    // New agent should be installed.
+    expect(
+      fs.readFileSync(
+        path.join(agentsDir, "new-agent.md"),
+        "utf-8",
+      ),
+    ).toBe("# New Agent");
+
+    // Existing agent should be untouched.
+    expect(
+      fs.readFileSync(
+        path.join(agentsDir, "existing-agent.md"),
+        "utf-8",
+      ),
+    ).toBe("# Existing Agent (original)");
+  });
+
+  // -----------------------------------------------------------------------
+  // 5. Directory creation
+  // -----------------------------------------------------------------------
+  it("creates .claude/agents/ directory if it does not exist", async () => {
+    // Prepare a bundle with an agent.
+    const bundleDir = makeTempDir("agent-bundle-");
+    fs.writeFileSync(
+      path.join(bundleDir, "my-agent.md"),
+      "# My Agent",
+      "utf-8",
+    );
+
+    mockDownloadBundle.mockResolvedValue(bundleDir);
+
+    // Fake cwd with NO .claude directory at all.
+    const fakeCwd = makeTempDir("agent-cwd-");
+    vi.spyOn(process, "cwd").mockReturnValue(fakeCwd);
+
+    await installAgents(["my-agent"]);
+
+    // The .claude/agents/ directory should have been created.
+    const agentsDir = path.join(fakeCwd, ".claude", "agents");
+    expect(fs.existsSync(agentsDir)).toBe(true);
+    expect(fs.statSync(agentsDir).isDirectory()).toBe(true);
+
+    // The file should be there.
+    expect(
+      fs.readFileSync(
+        path.join(agentsDir, "my-agent.md"),
+        "utf-8",
+      ),
+    ).toBe("# My Agent");
+  });
+});

--- a/cli/src/commands/__tests__/agent.test.ts
+++ b/cli/src/commands/__tests__/agent.test.ts
@@ -32,7 +32,7 @@ function makeTempDir(prefix: string): string {
   return dir;
 }
 
-/** Sample agent markdown content. */
+/** Sample agent markdown content (with skills). */
 const agentMarkdown = `---
 name: code-reviewer
 description: Reviews code for best practices
@@ -45,6 +45,45 @@ skills:
 
 You are a code review agent.
 `;
+
+/** Agent markdown that references two skills. */
+const agentWithTwoSkills = `---
+name: full-stack-dev
+description: Full stack development agent
+skills:
+  - skill-a
+  - skill-b
+---
+
+# Full Stack Dev
+
+You are a full stack development agent.
+`;
+
+/** Agent markdown with no skills field. */
+const agentNoSkills = `---
+name: simple-agent
+description: An agent with no skills
+---
+
+# Simple Agent
+
+You are a simple agent.
+`;
+
+/**
+ * Helper: create a skill directory inside a temp dir,
+ * simulating an extracted skill bundle entry.
+ */
+function createSkillInDir(dir: string, skillName: string): void {
+  const skillDir = path.join(dir, skillName);
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillDir, "SKILL.md"),
+    `# ${skillName}`,
+    "utf-8",
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Setup / teardown
@@ -87,7 +126,14 @@ describe("installAgents", () => {
       "utf-8",
     );
 
-    mockDownloadBundle.mockResolvedValue(bundleDir);
+    // The agent frontmatter references the "typescript" skill, so
+    // Phase 2 will attempt a second downloadBundle call for skills.
+    const skillBundleDir = makeTempDir("skill-bundle-");
+    createSkillInDir(skillBundleDir, "typescript");
+
+    mockDownloadBundle
+      .mockResolvedValueOnce(bundleDir)
+      .mockResolvedValueOnce(skillBundleDir);
 
     // Prepare a fake cwd.
     const fakeCwd = makeTempDir("agent-cwd-");
@@ -250,5 +296,259 @@ describe("installAgents", () => {
         "utf-8",
       ),
     ).toBe("# My Agent");
+  });
+
+  // =======================================================================
+  // Phase 2: Auto-install referenced skills
+  // =======================================================================
+
+  // -----------------------------------------------------------------------
+  // 6. Skills auto-installed from frontmatter
+  // -----------------------------------------------------------------------
+  it("auto-installs skills referenced in agent frontmatter", async () => {
+    // First call: agent bundle with an agent referencing two skills.
+    const agentBundleDir = makeTempDir("agent-bundle-");
+    fs.writeFileSync(
+      path.join(agentBundleDir, "full-stack-dev.md"),
+      agentWithTwoSkills,
+      "utf-8",
+    );
+
+    // Second call: skill bundle with both skills.
+    const skillBundleDir = makeTempDir("skill-bundle-");
+    createSkillInDir(skillBundleDir, "skill-a");
+    createSkillInDir(skillBundleDir, "skill-b");
+
+    mockDownloadBundle
+      .mockResolvedValueOnce(agentBundleDir)
+      .mockResolvedValueOnce(skillBundleDir);
+
+    const fakeCwd = makeTempDir("agent-cwd-");
+    vi.spyOn(process, "cwd").mockReturnValue(fakeCwd);
+
+    await installAgents(["full-stack-dev"]);
+
+    // Agent should be installed.
+    const agentFile = path.join(
+      fakeCwd,
+      ".claude",
+      "agents",
+      "full-stack-dev.md",
+    );
+    expect(fs.existsSync(agentFile)).toBe(true);
+
+    // Both skills should be installed.
+    const skillAFile = path.join(
+      fakeCwd,
+      ".claude",
+      "skills",
+      "skill-a",
+      "SKILL.md",
+    );
+    const skillBFile = path.join(
+      fakeCwd,
+      ".claude",
+      "skills",
+      "skill-b",
+      "SKILL.md",
+    );
+    expect(fs.existsSync(skillAFile)).toBe(true);
+    expect(fs.existsSync(skillBFile)).toBe(true);
+
+    // downloadBundle should have been called twice: once for agents, once for skills.
+    expect(mockDownloadBundle).toHaveBeenCalledTimes(2);
+    expect(mockDownloadBundle).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("/bundle/agents"),
+      ["full-stack-dev"],
+    );
+    expect(mockDownloadBundle).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("/bundle/skills"),
+      expect.arrayContaining(["skill-a", "skill-b"]),
+    );
+
+    // Skills section header should be printed.
+    expect(process.stdout.write).toHaveBeenCalledWith(
+      "\nSkills (auto-installed):\n",
+    );
+
+    // No exit(1) -- everything succeeded.
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // 7. Existing skills are skipped
+  // -----------------------------------------------------------------------
+  it("skips skills that already exist locally", async () => {
+    // Agent bundle with an agent referencing skill-a.
+    const agentBundleDir = makeTempDir("agent-bundle-");
+    const agentWithOneSkill = `---
+name: my-agent
+description: A test agent
+skills:
+  - skill-a
+---
+
+# My Agent
+`;
+    fs.writeFileSync(
+      path.join(agentBundleDir, "my-agent.md"),
+      agentWithOneSkill,
+      "utf-8",
+    );
+
+    mockDownloadBundle.mockResolvedValueOnce(agentBundleDir);
+
+    // Pre-create skill-a in the fake cwd.
+    const fakeCwd = makeTempDir("agent-cwd-");
+    const existingSkillDir = path.join(
+      fakeCwd,
+      ".claude",
+      "skills",
+      "skill-a",
+    );
+    fs.mkdirSync(existingSkillDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(existingSkillDir, "SKILL.md"),
+      "# Existing skill-a",
+      "utf-8",
+    );
+
+    vi.spyOn(process, "cwd").mockReturnValue(fakeCwd);
+
+    await installAgents(["my-agent"]);
+
+    // downloadBundle should have been called only once (for agents).
+    // No second call for skills since all are already present.
+    expect(mockDownloadBundle).toHaveBeenCalledTimes(1);
+
+    // Existing skill should be untouched.
+    expect(
+      fs.readFileSync(
+        path.join(existingSkillDir, "SKILL.md"),
+        "utf-8",
+      ),
+    ).toBe("# Existing skill-a");
+
+    // Skills section should still be printed (with skipped info).
+    expect(process.stdout.write).toHaveBeenCalledWith(
+      "\nSkills (auto-installed):\n",
+    );
+
+    // No exit(1).
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // 8. All skills already present -- no HTTP call for skills
+  // -----------------------------------------------------------------------
+  it("does not download skills when all referenced skills already exist", async () => {
+    // Agent referencing skill-a and skill-b, both already present.
+    const agentBundleDir = makeTempDir("agent-bundle-");
+    fs.writeFileSync(
+      path.join(agentBundleDir, "full-stack-dev.md"),
+      agentWithTwoSkills,
+      "utf-8",
+    );
+
+    mockDownloadBundle.mockResolvedValueOnce(agentBundleDir);
+
+    const fakeCwd = makeTempDir("agent-cwd-");
+    // Pre-create both skills.
+    for (const skill of ["skill-a", "skill-b"]) {
+      const skillDir = path.join(
+        fakeCwd,
+        ".claude",
+        "skills",
+        skill,
+      );
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(skillDir, "SKILL.md"),
+        `# ${skill}`,
+        "utf-8",
+      );
+    }
+
+    vi.spyOn(process, "cwd").mockReturnValue(fakeCwd);
+
+    await installAgents(["full-stack-dev"]);
+
+    // Only one downloadBundle call (for agents), none for skills.
+    expect(mockDownloadBundle).toHaveBeenCalledTimes(1);
+
+    // No exit(1).
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // 9. No skills referenced -- no skills section in output
+  // -----------------------------------------------------------------------
+  it("does not print skills section when agent has no skills field", async () => {
+    const agentBundleDir = makeTempDir("agent-bundle-");
+    fs.writeFileSync(
+      path.join(agentBundleDir, "simple-agent.md"),
+      agentNoSkills,
+      "utf-8",
+    );
+
+    mockDownloadBundle.mockResolvedValueOnce(agentBundleDir);
+
+    const fakeCwd = makeTempDir("agent-cwd-");
+    vi.spyOn(process, "cwd").mockReturnValue(fakeCwd);
+
+    await installAgents(["simple-agent"]);
+
+    // Only one downloadBundle call (for agents).
+    expect(mockDownloadBundle).toHaveBeenCalledTimes(1);
+
+    // Skills header should NOT be printed.
+    expect(process.stdout.write).not.toHaveBeenCalledWith(
+      "\nSkills (auto-installed):\n",
+    );
+
+    // No exit(1).
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // 10. Referenced skill not found in registry
+  // -----------------------------------------------------------------------
+  it("reports not-found and exits 1 when a referenced skill is missing from the registry", async () => {
+    // Agent references skill-a, but the skill bundle doesn't contain it.
+    const agentBundleDir = makeTempDir("agent-bundle-");
+    const agentWithOneSkill = `---
+name: my-agent
+description: A test agent
+skills:
+  - skill-a
+---
+
+# My Agent
+`;
+    fs.writeFileSync(
+      path.join(agentBundleDir, "my-agent.md"),
+      agentWithOneSkill,
+      "utf-8",
+    );
+
+    // Empty skill bundle -- skill-a is not there.
+    const skillBundleDir = makeTempDir("skill-bundle-");
+
+    mockDownloadBundle
+      .mockResolvedValueOnce(agentBundleDir)
+      .mockResolvedValueOnce(skillBundleDir);
+
+    const fakeCwd = makeTempDir("agent-cwd-");
+    vi.spyOn(process, "cwd").mockReturnValue(fakeCwd);
+
+    await installAgents(["my-agent"]);
+
+    // Should exit(1) because a referenced skill was not found.
+    expect(process.exit).toHaveBeenCalledWith(1);
+
+    // downloadBundle should have been called twice.
+    expect(mockDownloadBundle).toHaveBeenCalledTimes(2);
   });
 });

--- a/cli/src/commands/agent.ts
+++ b/cli/src/commands/agent.ts
@@ -2,40 +2,135 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { downloadBundle } from "../lib/download.js";
-import type { InstallResult } from "../lib/types.js";
+import { parseFrontmatter } from "../lib/frontmatter.js";
+import type { AgentFrontmatter, InstallResult } from "../lib/types.js";
+import { processSkills } from "./skill.js";
 
 /**
  * Installs one or more agents by downloading their `.md` files from the
  * AWOS server and copying them into `.claude/agents/` in the current
  * working directory.
  *
- * Phase 1: agent file installation only (no auto-skill install).
+ * Phase 1: agent file installation.
+ * Phase 2: auto-install skills referenced in installed agents' frontmatter.
  *
- * Exits with code 1 if any requested agent was not found. Skipped
- * (already-existing) agents are NOT treated as errors.
+ * Exits with code 1 if any requested agent or referenced skill has
+ * `"not-found"` status. Skipped (already-existing) agents and skills
+ * are NOT treated as errors.
  */
 export async function installAgents(names: string[]): Promise<void> {
   const serverUrl =
     process.env.AWOS_SERVER_URL || "http://localhost:8000";
 
-  const tempDir = await downloadBundle(
+  // --- Phase 1: Install agents -----------------------------------------------
+  const agentTempDir = await downloadBundle(
     `${serverUrl}/bundle/agents`,
     names,
   );
 
+  let agentResults: InstallResult[];
   try {
-    const results = processAgents(tempDir, names);
-    printResults(results);
-
-    const hasNotFound = results.some(
-      (r) => r.status === "not-found",
-    );
-    if (hasNotFound) {
-      process.exit(1);
-    }
+    agentResults = processAgents(agentTempDir, names);
   } finally {
-    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(agentTempDir, { recursive: true, force: true });
   }
+
+  // --- Phase 2: Auto-install referenced skills --------------------------------
+  const skillResults = await installReferencedSkills(
+    agentResults,
+    serverUrl,
+  );
+
+  // --- Print combined summary -------------------------------------------------
+  printResults(agentResults);
+
+  if (skillResults.length > 0) {
+    process.stdout.write("\nSkills (auto-installed):\n");
+    printResults(skillResults);
+  }
+
+  // --- Exit code --------------------------------------------------------------
+  const allResults = [...agentResults, ...skillResults];
+  const hasNotFound = allResults.some(
+    (r) => r.status === "not-found",
+  );
+  if (hasNotFound) {
+    process.exit(1);
+  }
+}
+
+/**
+ * Reads frontmatter from newly installed agents, collects skill references,
+ * filters out already-existing skills, downloads and installs the rest.
+ */
+async function installReferencedSkills(
+  agentResults: InstallResult[],
+  serverUrl: string,
+): Promise<InstallResult[]> {
+  // 1. Collect skill references from newly installed agents.
+  const referencedSkills = new Set<string>();
+  const agentsDir = path.join(process.cwd(), ".claude", "agents");
+
+  for (const result of agentResults) {
+    if (result.status !== "installed") {
+      continue;
+    }
+
+    const agentFile = path.join(agentsDir, `${result.name}.md`);
+    if (!fs.existsSync(agentFile)) {
+      continue;
+    }
+
+    const content = fs.readFileSync(agentFile, "utf-8");
+    const frontmatter = parseFrontmatter(content) as AgentFrontmatter | null;
+
+    if (frontmatter?.skills) {
+      for (const skill of frontmatter.skills) {
+        referencedSkills.add(skill);
+      }
+    }
+  }
+
+  if (referencedSkills.size === 0) {
+    return [];
+  }
+
+  // 2. Filter out skills that already exist locally.
+  const skillResults: InstallResult[] = [];
+  const missingSkills: string[] = [];
+  const skillsBaseDir = path.join(process.cwd(), ".claude", "skills");
+
+  for (const skill of referencedSkills) {
+    const skillDir = path.join(skillsBaseDir, skill);
+    if (fs.existsSync(skillDir)) {
+      skillResults.push({
+        name: skill,
+        status: "skipped",
+        message: `Skipped skill '${skill}': already exists at .claude/skills/${skill}/`,
+      });
+    } else {
+      missingSkills.push(skill);
+    }
+  }
+
+  if (missingSkills.length === 0) {
+    return skillResults;
+  }
+
+  // 3. Download and install missing skills.
+  const skillTempDir = await downloadBundle(
+    `${serverUrl}/bundle/skills`,
+    missingSkills,
+  );
+
+  try {
+    const installResults = processSkills(skillTempDir, missingSkills);
+    skillResults.push(...installResults);
+  } finally {
+    fs.rmSync(skillTempDir, { recursive: true, force: true });
+  }
+
+  return skillResults;
 }
 
 /**

--- a/cli/src/commands/agent.ts
+++ b/cli/src/commands/agent.ts
@@ -1,0 +1,102 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { downloadBundle } from "../lib/download.js";
+import type { InstallResult } from "../lib/types.js";
+
+/**
+ * Installs one or more agents by downloading their `.md` files from the
+ * AWOS server and copying them into `.claude/agents/` in the current
+ * working directory.
+ *
+ * Phase 1: agent file installation only (no auto-skill install).
+ *
+ * Exits with code 1 if any requested agent was not found. Skipped
+ * (already-existing) agents are NOT treated as errors.
+ */
+export async function installAgents(names: string[]): Promise<void> {
+  const serverUrl =
+    process.env.AWOS_SERVER_URL || "http://localhost:8000";
+
+  const tempDir = await downloadBundle(
+    `${serverUrl}/bundle/agents`,
+    names,
+  );
+
+  try {
+    const results = processAgents(tempDir, names);
+    printResults(results);
+
+    const hasNotFound = results.some(
+      (r) => r.status === "not-found",
+    );
+    if (hasNotFound) {
+      process.exit(1);
+    }
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Compares requested names against what was extracted, copies found
+ * agent files into the target directory, and returns per-item results.
+ */
+function processAgents(
+  tempDir: string,
+  requestedNames: string[],
+): InstallResult[] {
+  const extractedFiles = new Set(
+    fs.readdirSync(tempDir).map((f) => f.replace(/\.md$/, "")),
+  );
+  const results: InstallResult[] = [];
+
+  const agentsDir = path.join(process.cwd(), ".claude", "agents");
+  fs.mkdirSync(agentsDir, { recursive: true });
+
+  for (const name of requestedNames) {
+    if (!extractedFiles.has(name)) {
+      results.push({
+        name,
+        status: "not-found",
+        message: `Error: capability '${name}' not found.`,
+      });
+      continue;
+    }
+
+    const targetFile = path.join(agentsDir, `${name}.md`);
+
+    if (fs.existsSync(targetFile)) {
+      results.push({
+        name,
+        status: "skipped",
+        message: `Skipped agent '${name}': already exists at .claude/agents/${name}.md`,
+      });
+      continue;
+    }
+
+    const sourceFile = path.join(tempDir, `${name}.md`);
+    fs.copyFileSync(sourceFile, targetFile);
+
+    results.push({
+      name,
+      status: "installed",
+      message: `Installed agent '${name}' to .claude/agents/${name}.md`,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Prints each install result to stdout (installed) or stderr (errors/skipped).
+ */
+function printResults(results: InstallResult[]): void {
+  for (const result of results) {
+    if (result.status === "installed") {
+      process.stdout.write(result.message + "\n");
+    } else {
+      process.stderr.write(result.message + "\n");
+    }
+  }
+}

--- a/cli/src/commands/skill.ts
+++ b/cli/src/commands/skill.ts
@@ -37,8 +37,12 @@ export async function installSkills(names: string[]): Promise<void> {
 /**
  * Compares requested names against what was extracted, copies found
  * skills into the target directory, and returns per-item results.
+ *
+ * This is a pure function with no side effects — it does not write to
+ * stdout/stderr and does not call `process.exit`. Callers are responsible
+ * for interpreting the results and performing I/O.
  */
-function processSkills(
+export function processSkills(
   tempDir: string,
   requestedNames: string[],
 ): InstallResult[] {

--- a/cli/src/lib/__tests__/frontmatter.test.ts
+++ b/cli/src/lib/__tests__/frontmatter.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+
+import { parseFrontmatter } from "../frontmatter.js";
+
+describe("parseFrontmatter", () => {
+  // -----------------------------------------------------------------------
+  // 1. Valid frontmatter
+  // -----------------------------------------------------------------------
+  it("returns parsed object with all fields from valid frontmatter", () => {
+    const content = `---
+name: my-agent
+description: A helpful agent
+model: claude-sonnet
+skills:
+  - typescript
+  - testing
+---
+
+# My Agent
+
+Body content here.
+`;
+
+    const result = parseFrontmatter(content);
+
+    expect(result).toEqual({
+      name: "my-agent",
+      description: "A helpful agent",
+      model: "claude-sonnet",
+      skills: ["typescript", "testing"],
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 2. No frontmatter delimiters
+  // -----------------------------------------------------------------------
+  it("returns null when there are no frontmatter delimiters", () => {
+    const content = `# Just a markdown file
+
+No frontmatter here.
+`;
+
+    expect(parseFrontmatter(content)).toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // 3. Malformed YAML
+  // -----------------------------------------------------------------------
+  it("returns null for malformed YAML", () => {
+    const content = `---
+name: [invalid yaml
+  - not: {properly: closed
+---
+
+Body.
+`;
+
+    expect(parseFrontmatter(content)).toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // 4. Empty skills list
+  // -----------------------------------------------------------------------
+  it("returns empty array for empty skills list", () => {
+    const content = `---
+name: minimal-agent
+description: Minimal
+skills: []
+---
+
+Body.
+`;
+
+    const result = parseFrontmatter(content);
+
+    expect(result).not.toBeNull();
+    expect(result!.skills).toEqual([]);
+  });
+
+  // -----------------------------------------------------------------------
+  // 5. Content without closing delimiter
+  // -----------------------------------------------------------------------
+  it("returns null when the closing --- delimiter is missing", () => {
+    const content = `---
+name: incomplete
+description: No closing delimiter
+
+Body content without closing delimiter.
+`;
+
+    expect(parseFrontmatter(content)).toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // 6. Empty YAML block
+  // -----------------------------------------------------------------------
+  it("returns null for an empty YAML block", () => {
+    const content = `---
+---
+
+Body.
+`;
+
+    expect(parseFrontmatter(content)).toBeNull();
+  });
+});

--- a/cli/src/lib/frontmatter.ts
+++ b/cli/src/lib/frontmatter.ts
@@ -1,0 +1,39 @@
+import YAML from "yaml";
+
+/**
+ * Extracts and parses YAML frontmatter from the beginning of a markdown file.
+ *
+ * Frontmatter is the YAML block delimited by `---` at the very start of the
+ * file content. Returns the parsed object, or `null` if no valid frontmatter
+ * is found.
+ */
+export function parseFrontmatter(
+  content: string,
+): Record<string, unknown> | null {
+  // Must start with "---" on the first line.
+  if (!content.startsWith("---")) {
+    return null;
+  }
+
+  // Find the closing "---" delimiter (not the opening one).
+  const closingIndex = content.indexOf("\n---", 3);
+  if (closingIndex === -1) {
+    return null;
+  }
+
+  const yamlBlock = content.slice(3, closingIndex).trim();
+
+  try {
+    const parsed: unknown = YAML.parse(yamlBlock);
+
+    // YAML.parse can return null/undefined for empty blocks, or a
+    // non-object for scalars. Only return actual objects.
+    if (parsed === null || parsed === undefined || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -1,7 +1,14 @@
 export interface InstallResult {
   name: string;
-  status: "installed" | "not-found" | "conflict" | "error";
+  status: "installed" | "not-found" | "conflict" | "skipped" | "error";
   message: string;
+}
+
+export interface AgentFrontmatter {
+  name: string;
+  description: string;
+  model?: string;
+  skills?: string[];
 }
 
 export interface McpServerConfig {

--- a/context/product/roadmap.md
+++ b/context/product/roadmap.md
@@ -30,9 +30,9 @@ _Once the registry is live, add semantic search and zero-friction installation._
   - [x] **Install Discovered Skills:** Install discovered skills into the user's Claude Code configuration via an npx package.
   - [x] **Install MCP Server Definitions:** Install discovered MCP server definitions into the user's `.mcp.json` via an npx package.
 
-- [ ] **Agent Support**
-  - [ ] **Agent Registry & Indexing:** Index and serve agent definitions with structured metadata, enabling agents to be discovered alongside skills and MCP servers.
-  - [ ] **Agent Installation:** Install discovered agents into the user's Claude Code configuration via the npx package.
+- [x] **Agent Support**
+  - [x] **Agent Registry & Indexing:** Index and serve agent definitions with structured metadata, enabling agents to be discovered alongside skills and MCP servers.
+  - [x] **Agent Installation:** Install discovered agents into the user's Claude Code configuration via the npx package.
 
 ---
 

--- a/context/product/roadmap.md
+++ b/context/product/roadmap.md
@@ -30,6 +30,10 @@ _Once the registry is live, add semantic search and zero-friction installation._
   - [x] **Install Discovered Skills:** Install discovered skills into the user's Claude Code configuration via an npx package.
   - [x] **Install MCP Server Definitions:** Install discovered MCP server definitions into the user's `.mcp.json` via an npx package.
 
+- [ ] **Agent Support**
+  - [ ] **Agent Registry & Indexing:** Index and serve agent definitions with structured metadata, enabling agents to be discovered alongside skills and MCP servers.
+  - [ ] **Agent Installation:** Install discovered agents into the user's Claude Code configuration via the npx package.
+
 ---
 
 ### Phase 3

--- a/context/spec/005-agent-support/functional-spec.md
+++ b/context/spec/005-agent-support/functional-spec.md
@@ -1,0 +1,114 @@
+# Functional Specification: Agent Support
+
+- **Roadmap Item:** Support agents in the registry and installer — index and serve agent definitions with structured metadata, and install discovered agents into the user's Claude Code configuration.
+- **Status:** Draft
+- **Author:** Poe (Product Analyst)
+
+---
+
+## 1. Overview and Rationale (The "Why")
+
+The AWOS Recruitment system already enables teams to centrally manage and distribute **skills** and **MCP server definitions** through a full pipeline: a Git-managed registry, semantic search, server-side bundling, and CLI installation. However, **agents** — autonomous sub-agents with specialized expertise, system prompts, and skill bindings — are not yet part of this pipeline.
+
+Without agent support, each developer must manually create or copy agent definition files. This leads to inconsistent agent configurations across the team, duplicated effort, and no way for a tech lead to curate and distribute a standard set of agents the way they already do for skills and MCP servers.
+
+This feature closes that gap by extending the existing capability pipeline to support agents as a first-class capability type — discoverable via semantic search, installable via the CLI, and validated in CI like all other registry entries.
+
+**Success looks like:** A developer can search for agents (e.g., "TypeScript expert"), discover one in the registry, install it with a single CLI command, and have both the agent and all its referenced skills ready to use — with zero manual file management.
+
+---
+
+## 2. Functional Requirements (The "What")
+
+### 2.1. Agent Registry & Indexing
+
+- The Git-managed registry must support a new `registry/agents/` directory containing agent definitions.
+- Each agent is a **single markdown file** at `registry/agents/<name>.md`, mirroring the Claude Code convention.
+- Agent files use YAML frontmatter with the following fields:
+  - `name` (required): kebab-case identifier, 1–64 characters.
+  - `description` (required): non-empty string describing the agent's purpose and expertise.
+  - `model` (optional): target model identifier (e.g., `opus`, `sonnet`, `haiku`).
+  - `skills` (optional): list of skill names this agent references.
+- The markdown body contains the agent's system prompt.
+- The registry loader must scan `registry/agents/` and produce `RegistryCapability` objects with `type="agent"`.
+- Agents must be embedded and indexed in the search index (ChromaDB) alongside skills and MCP servers.
+- The existing `search_capabilities` MCP tool must return agents in search results using the **same result shape** as skills and MCP servers (name, description, score).
+- The existing `type="agent"` filter on the search tool must return matching agents.
+
+  **Acceptance Criteria:**
+  - [ ] Agent `.md` files placed in `registry/agents/` are loaded by the registry loader with `type="agent"`.
+  - [ ] Agents appear in semantic search results when a relevant natural language query is submitted.
+  - [ ] Filtering by `type="agent"` returns only agent results.
+  - [ ] Agents without a description are silently skipped during loading (consistent with skills).
+
+### 2.2. Agent Metadata Validation
+
+- An agent metadata schema must be defined and enforced.
+- CI validation must block merges that introduce agent files with invalid metadata (missing or malformed name, empty description, invalid name format).
+- Validation behavior must be consistent with the existing skill and MCP validation pipeline.
+
+  **Acceptance Criteria:**
+  - [ ] A valid agent file (correct frontmatter, non-empty description, kebab-case name) passes CI validation.
+  - [ ] An agent file with a missing `name` field fails CI validation.
+  - [ ] An agent file with an empty `description` field fails CI validation.
+  - [ ] An agent file with a non-kebab-case name fails CI validation.
+
+### 2.3. Agent Bundling
+
+- The server must expose a new endpoint `POST /bundle/agents` that accepts a list of agent names and returns a tar.gz archive containing the corresponding agent `.md` files.
+- The request body must follow the same validation rules as existing bundle endpoints (1–20 names, kebab-case pattern).
+- If a requested agent is not found in the registry, it is excluded from the archive (not an error), and the CLI handles reporting.
+
+  **Acceptance Criteria:**
+  - [ ] `POST /bundle/agents` with valid agent names returns a tar.gz archive containing the requested `.md` files.
+  - [ ] Requesting a non-existent agent name does not cause a server error; the name is simply absent from the archive.
+  - [ ] The request is rejected if it contains more than 20 names or names with invalid format.
+
+### 2.4. Agent Installation via CLI
+
+- The CLI must support a new command: `npx @provectusinc/awos-recruitment agent <name1> [name2] ...`.
+- The command downloads the agent bundle from the server and installs each agent file to `.claude/agents/<name>.md`.
+- **Conflict handling:** If an agent file already exists at the target path, it is **skipped silently** (no error).
+- **Automatic skill installation:** After installing agents, the CLI must:
+  1. Collect all skill names referenced in the `skills` frontmatter field of the newly installed agents.
+  2. Skip any skills that already exist in `.claude/skills/`.
+  3. Install the remaining missing skills using the existing skill bundle flow.
+- The CLI must print a summary showing:
+  - Agents installed.
+  - Agents skipped (already exist).
+  - Skills auto-installed.
+  - Skills skipped (already exist).
+  - Items not found in the registry.
+
+  **Acceptance Criteria:**
+  - [ ] Running `npx @provectusinc/awos-recruitment agent typescript-expert` installs the agent file to `.claude/agents/typescript-expert.md`.
+  - [ ] If `.claude/agents/typescript-expert.md` already exists, the agent is skipped without error.
+  - [ ] If the installed agent references skills `[typescript, npx-package]` and `typescript` already exists locally, only `npx-package` is installed.
+  - [ ] If the installed agent references skills `[typescript, npx-package]` and both already exist locally, no skills are installed and the summary reflects this.
+  - [ ] If a requested agent name does not exist in the registry, it is reported as "not found" in the summary.
+  - [ ] The `.claude/agents/` directory is created if it does not already exist.
+
+---
+
+## 3. Scope and Boundaries
+
+### In-Scope
+
+- Agent catalog structure in the Git-managed registry (`registry/agents/`).
+- Agent metadata schema definition and CI validation.
+- Registry loader extension to scan and index agents.
+- Semantic search indexing and retrieval for agents.
+- Server-side bundle endpoint for agents (`POST /bundle/agents`).
+- CLI `agent` command for installation.
+- Automatic installation of an agent's referenced skills.
+- Conflict handling (skip existing agents and skills silently).
+
+### Out-of-Scope
+
+- **Usage Telemetry** — tracking agent installs and usage (Phase 3 roadmap item).
+- **Analytics & Reporting** — surfacing agent adoption metrics (Phase 3 roadmap item).
+- Agent authoring, publishing, or update workflows (capabilities are managed directly in Git).
+- Agent versioning or upgrade-in-place mechanisms.
+- A web UI or dashboard for browsing agents.
+- Automatic MCP server installation for agents (agents reference skills, not MCP servers).
+- User authentication or multi-tenant access control.

--- a/context/spec/005-agent-support/functional-spec.md
+++ b/context/spec/005-agent-support/functional-spec.md
@@ -1,7 +1,7 @@
 # Functional Specification: Agent Support
 
 - **Roadmap Item:** Support agents in the registry and installer — index and serve agent definitions with structured metadata, and install discovered agents into the user's Claude Code configuration.
-- **Status:** Draft
+- **Status:** Completed
 - **Author:** Poe (Product Analyst)
 
 ---
@@ -36,10 +36,10 @@ This feature closes that gap by extending the existing capability pipeline to su
 - The existing `type="agent"` filter on the search tool must return matching agents.
 
   **Acceptance Criteria:**
-  - [ ] Agent `.md` files placed in `registry/agents/` are loaded by the registry loader with `type="agent"`.
-  - [ ] Agents appear in semantic search results when a relevant natural language query is submitted.
-  - [ ] Filtering by `type="agent"` returns only agent results.
-  - [ ] Agents without a description are silently skipped during loading (consistent with skills).
+  - [x] Agent `.md` files placed in `registry/agents/` are loaded by the registry loader with `type="agent"`.
+  - [x] Agents appear in semantic search results when a relevant natural language query is submitted.
+  - [x] Filtering by `type="agent"` returns only agent results.
+  - [x] Agents without a description are silently skipped during loading (consistent with skills).
 
 ### 2.2. Agent Metadata Validation
 
@@ -48,10 +48,10 @@ This feature closes that gap by extending the existing capability pipeline to su
 - Validation behavior must be consistent with the existing skill and MCP validation pipeline.
 
   **Acceptance Criteria:**
-  - [ ] A valid agent file (correct frontmatter, non-empty description, kebab-case name) passes CI validation.
-  - [ ] An agent file with a missing `name` field fails CI validation.
-  - [ ] An agent file with an empty `description` field fails CI validation.
-  - [ ] An agent file with a non-kebab-case name fails CI validation.
+  - [x] A valid agent file (correct frontmatter, non-empty description, kebab-case name) passes CI validation.
+  - [x] An agent file with a missing `name` field fails CI validation.
+  - [x] An agent file with an empty `description` field fails CI validation.
+  - [x] An agent file with a non-kebab-case name fails CI validation.
 
 ### 2.3. Agent Bundling
 
@@ -60,9 +60,9 @@ This feature closes that gap by extending the existing capability pipeline to su
 - If a requested agent is not found in the registry, it is excluded from the archive (not an error), and the CLI handles reporting.
 
   **Acceptance Criteria:**
-  - [ ] `POST /bundle/agents` with valid agent names returns a tar.gz archive containing the requested `.md` files.
-  - [ ] Requesting a non-existent agent name does not cause a server error; the name is simply absent from the archive.
-  - [ ] The request is rejected if it contains more than 20 names or names with invalid format.
+  - [x] `POST /bundle/agents` with valid agent names returns a tar.gz archive containing the requested `.md` files.
+  - [x] Requesting a non-existent agent name does not cause a server error; the name is simply absent from the archive.
+  - [x] The request is rejected if it contains more than 20 names or names with invalid format.
 
 ### 2.4. Agent Installation via CLI
 
@@ -81,12 +81,12 @@ This feature closes that gap by extending the existing capability pipeline to su
   - Items not found in the registry.
 
   **Acceptance Criteria:**
-  - [ ] Running `npx @provectusinc/awos-recruitment agent typescript-expert` installs the agent file to `.claude/agents/typescript-expert.md`.
-  - [ ] If `.claude/agents/typescript-expert.md` already exists, the agent is skipped without error.
-  - [ ] If the installed agent references skills `[typescript, npx-package]` and `typescript` already exists locally, only `npx-package` is installed.
-  - [ ] If the installed agent references skills `[typescript, npx-package]` and both already exist locally, no skills are installed and the summary reflects this.
-  - [ ] If a requested agent name does not exist in the registry, it is reported as "not found" in the summary.
-  - [ ] The `.claude/agents/` directory is created if it does not already exist.
+  - [x] Running `npx @provectusinc/awos-recruitment agent typescript-expert` installs the agent file to `.claude/agents/typescript-expert.md`.
+  - [x] If `.claude/agents/typescript-expert.md` already exists, the agent is skipped without error.
+  - [x] If the installed agent references skills `[typescript, npx-package]` and `typescript` already exists locally, only `npx-package` is installed.
+  - [x] If the installed agent references skills `[typescript, npx-package]` and both already exist locally, no skills are installed and the summary reflects this.
+  - [x] If a requested agent name does not exist in the registry, it is reported as "not found" in the summary.
+  - [x] The `.claude/agents/` directory is created if it does not already exist.
 
 ---
 

--- a/context/spec/005-agent-support/tasks.md
+++ b/context/spec/005-agent-support/tasks.md
@@ -1,0 +1,43 @@
+# Tasks: Agent Support (005)
+
+- [ ] **Slice 1: Agent model, registry loader, and search — an agent appears in search results**
+  - [ ] Create `AgentMetadata` Pydantic model in `server/src/awos_recruitment_mcp/models/agent_metadata.py` with `name` (required, regex-validated), `description` (required, min_length=1), `model` (optional string), `skills` (optional list of kebab-case strings). Use `ConfigDict(extra="forbid")`. Export from `models/__init__.py`. **[Agent: python-expert]**
+  - [ ] Expand `RegistryCapability.type` in `server/src/awos_recruitment_mcp/models/capability.py` from `Literal["skill", "tool"]` to `Literal["skill", "tool", "agent"]`. **[Agent: python-expert]**
+  - [ ] Add `_load_agents(root: Path)` function to `server/src/awos_recruitment_mcp/registry.py` — scan `root / "agents"` for `*.md` files, parse with `frontmatter.load()`, extract name/description, skip entries with missing or empty values, return `RegistryCapability(type="agent")`. Call from `load_registry()`. **[Agent: python-expert]**
+  - [ ] Create `registry/agents/` directory with at least one sample agent `.md` file (e.g., `registry/agents/test-agent.md`) containing valid YAML frontmatter (`name`, `description`, `model`, `skills` referencing existing skills) and a system prompt body. **[Agent: python-expert]**
+  - [ ] Write tests in `server/tests/test_registry.py`: agent correct parsing, skip without description, type inference (`type="agent"`), mixed types. Add agent to `sample_capabilities` in `test_search_index.py` and add `type="agent"` filter test. Update real registry smoke test expected count. **[Agent: python-expert]**
+  - [ ] Run all server tests (`pytest`) to verify agents are loaded, indexed, and searchable. Verify `type="agent"` filter returns only agents. **[Agent: qa-tester]**
+  - [ ] **Git commit**
+
+- [ ] **Slice 2: Agent CI validation — invalid agent files are rejected**
+  - [ ] Add `validate_agents(registry_path)` function to `server/src/awos_recruitment_mcp/validate/__init__.py` — scan `agents/*.md`, parse frontmatter, validate against `AgentMetadata.model_validate()`, check filename-name match, check non-empty body, cross-validate `skills` entries against `registry/skills/`. Add to `validate_registry()`. **[Agent: python-expert]**
+  - [ ] Write tests in `server/tests/test_validate.py`: `AgentMetadata` model tests (valid, missing name, empty description, invalid name, extra fields), `validate_agents()` tests (valid passes, invalid fails, name mismatch fails, empty body fails, missing skill reference fails cross-validation). Update real registry smoke test. **[Agent: python-expert]**
+  - [ ] Run all server tests (`pytest`) including validation tests. Verify that the real registry passes validation with the sample agent file. **[Agent: qa-tester]**
+  - [ ] **Git commit**
+
+- [ ] **Slice 3: Agent bundle endpoint — server can serve agent files as tar.gz**
+  - [ ] Add `resolve_agent_paths(names, registry_path)` function to `server/src/awos_recruitment_mcp/registry.py` — for each name, check if `agents/<name>.md` exists, return `(found_paths, not_found_names)`. **[Agent: python-expert]**
+  - [ ] Add `POST /bundle/agents` route to `server/src/awos_recruitment_mcp/server.py` — parse `BundleRequest`, deduplicate, resolve via `resolve_agent_paths()`, build tar.gz with `.md` files, return gzip response. **[Agent: python-expert]**
+  - [ ] Write tests in `server/tests/test_bundle.py`: valid request returns tar.gz with correct `.md` files, partial matches, all not-found returns empty archive, empty names returns 400, too many names returns 400, invalid name pattern returns 400. **[Agent: python-expert]**
+  - [ ] Run all server tests (`pytest`) to verify the bundle endpoint works. **[Agent: qa-tester]**
+  - [ ] **Git commit**
+
+- [ ] **Slice 4: Extract shared skill install logic — refactor without behavior change**
+  - [ ] Extract `processSkills(tempDir: string, requestedNames: string[]): InstallResult[]` from `cli/src/commands/skill.ts` — handles directory existence checks, `fs.cpSync`, and result tracking with no `process.exit` or print side effects. The existing `installSkills` calls `processSkills` internally, preserving current behavior. Export `processSkills`. **[Agent: typescript-expert]**
+  - [ ] Run existing CLI tests (`vitest`) to verify the skill command still works identically after refactor. **[Agent: qa-tester]**
+  - [ ] **Git commit**
+
+- [ ] **Slice 5: CLI agent install (Phase 1) — agents are installed without auto-skill**
+  - [ ] Create `cli/src/lib/frontmatter.ts` — `parseFrontmatter(content: string): Record<string, unknown> | null` utility using the existing `yaml` package. Extracts YAML block between `---` delimiters, returns parsed object or `null`. **[Agent: typescript-expert]**
+  - [ ] Add `AgentFrontmatter` interface to `cli/src/lib/types.ts` — `name: string`, `description: string`, `model?: string`, `skills?: string[]`. **[Agent: typescript-expert]**
+  - [ ] Create `cli/src/commands/agent.ts` with `installAgents(names: string[])` — Phase 1 only: download bundle from `/bundle/agents`, extract `.md` files, copy to `.claude/agents/<name>.md`, skip existing silently, create `.claude/agents/` directory if needed, print summary, exit(1) only on not-found. **[Agent: typescript-expert]**
+  - [ ] Register `agent` subcommand in `cli/src/cli.ts` — add to guard condition, USAGE string, and switch statement. **[Agent: typescript-expert]**
+  - [ ] Write tests: `cli/src/lib/__tests__/frontmatter.test.ts` (valid frontmatter, no frontmatter, malformed YAML, empty skills) and `cli/src/commands/__tests__/agent.test.ts` (successful install, skip existing, not found, mixed results, directory creation). **[Agent: typescript-expert]**
+  - [ ] Run all CLI tests (`vitest`) to verify agent install works. **[Agent: qa-tester]**
+  - [ ] **Git commit**
+
+- [ ] **Slice 6: CLI agent install (Phase 2) — auto-install referenced skills**
+  - [ ] Add Phase 2 logic to `installAgents` in `cli/src/commands/agent.ts` — after installing agents, parse frontmatter of each newly installed agent, collect unique skill names, filter out skills that already exist in `.claude/skills/`, call `downloadBundle` + `processSkills` for missing skills, merge skill results into combined summary. **[Agent: typescript-expert]**
+  - [ ] Write tests in `cli/src/commands/__tests__/agent.test.ts`: skills auto-installed from frontmatter, existing skills skipped, all skills already present (no HTTP call), no skills referenced in frontmatter, referenced skill not found in registry. **[Agent: typescript-expert]**
+  - [ ] Run all CLI tests (`vitest`) to verify the full two-phase install flow. **[Agent: qa-tester]**
+  - [ ] **Git commit**

--- a/context/spec/005-agent-support/tasks.md
+++ b/context/spec/005-agent-support/tasks.md
@@ -1,43 +1,43 @@
 # Tasks: Agent Support (005)
 
-- [ ] **Slice 1: Agent model, registry loader, and search — an agent appears in search results**
-  - [ ] Create `AgentMetadata` Pydantic model in `server/src/awos_recruitment_mcp/models/agent_metadata.py` with `name` (required, regex-validated), `description` (required, min_length=1), `model` (optional string), `skills` (optional list of kebab-case strings). Use `ConfigDict(extra="forbid")`. Export from `models/__init__.py`. **[Agent: python-expert]**
-  - [ ] Expand `RegistryCapability.type` in `server/src/awos_recruitment_mcp/models/capability.py` from `Literal["skill", "tool"]` to `Literal["skill", "tool", "agent"]`. **[Agent: python-expert]**
-  - [ ] Add `_load_agents(root: Path)` function to `server/src/awos_recruitment_mcp/registry.py` — scan `root / "agents"` for `*.md` files, parse with `frontmatter.load()`, extract name/description, skip entries with missing or empty values, return `RegistryCapability(type="agent")`. Call from `load_registry()`. **[Agent: python-expert]**
-  - [ ] Create `registry/agents/` directory with at least one sample agent `.md` file (e.g., `registry/agents/test-agent.md`) containing valid YAML frontmatter (`name`, `description`, `model`, `skills` referencing existing skills) and a system prompt body. **[Agent: python-expert]**
-  - [ ] Write tests in `server/tests/test_registry.py`: agent correct parsing, skip without description, type inference (`type="agent"`), mixed types. Add agent to `sample_capabilities` in `test_search_index.py` and add `type="agent"` filter test. Update real registry smoke test expected count. **[Agent: python-expert]**
-  - [ ] Run all server tests (`pytest`) to verify agents are loaded, indexed, and searchable. Verify `type="agent"` filter returns only agents. **[Agent: qa-tester]**
-  - [ ] **Git commit**
+- [x] **Slice 1: Agent model, registry loader, and search — an agent appears in search results**
+  - [x] Create `AgentMetadata` Pydantic model in `server/src/awos_recruitment_mcp/models/agent_metadata.py` with `name` (required, regex-validated), `description` (required, min_length=1), `model` (optional string), `skills` (optional list of kebab-case strings). Use `ConfigDict(extra="forbid")`. Export from `models/__init__.py`. **[Agent: python-expert]**
+  - [x] Expand `RegistryCapability.type` in `server/src/awos_recruitment_mcp/models/capability.py` from `Literal["skill", "tool"]` to `Literal["skill", "tool", "agent"]`. **[Agent: python-expert]**
+  - [x] Add `_load_agents(root: Path)` function to `server/src/awos_recruitment_mcp/registry.py` — scan `root / "agents"` for `*.md` files, parse with `frontmatter.load()`, extract name/description, skip entries with missing or empty values, return `RegistryCapability(type="agent")`. Call from `load_registry()`. **[Agent: python-expert]**
+  - [x] Create `registry/agents/` directory with at least one sample agent `.md` file (e.g., `registry/agents/test-agent.md`) containing valid YAML frontmatter (`name`, `description`, `model`, `skills` referencing existing skills) and a system prompt body. **[Agent: python-expert]**
+  - [x] Write tests in `server/tests/test_registry.py`: agent correct parsing, skip without description, type inference (`type="agent"`), mixed types. Add agent to `sample_capabilities` in `test_search_index.py` and add `type="agent"` filter test. Update real registry smoke test expected count. **[Agent: python-expert]**
+  - [x] Run all server tests (`pytest`) to verify agents are loaded, indexed, and searchable. Verify `type="agent"` filter returns only agents. **[Agent: qa-tester]**
+  - [x] **Git commit**
 
-- [ ] **Slice 2: Agent CI validation — invalid agent files are rejected**
-  - [ ] Add `validate_agents(registry_path)` function to `server/src/awos_recruitment_mcp/validate/__init__.py` — scan `agents/*.md`, parse frontmatter, validate against `AgentMetadata.model_validate()`, check filename-name match, check non-empty body, cross-validate `skills` entries against `registry/skills/`. Add to `validate_registry()`. **[Agent: python-expert]**
-  - [ ] Write tests in `server/tests/test_validate.py`: `AgentMetadata` model tests (valid, missing name, empty description, invalid name, extra fields), `validate_agents()` tests (valid passes, invalid fails, name mismatch fails, empty body fails, missing skill reference fails cross-validation). Update real registry smoke test. **[Agent: python-expert]**
-  - [ ] Run all server tests (`pytest`) including validation tests. Verify that the real registry passes validation with the sample agent file. **[Agent: qa-tester]**
-  - [ ] **Git commit**
+- [x] **Slice 2: Agent CI validation — invalid agent files are rejected**
+  - [x] Add `validate_agents(registry_path)` function to `server/src/awos_recruitment_mcp/validate/__init__.py` — scan `agents/*.md`, parse frontmatter, validate against `AgentMetadata.model_validate()`, check filename-name match, check non-empty body, cross-validate `skills` entries against `registry/skills/`. Add to `validate_registry()`. **[Agent: python-expert]**
+  - [x] Write tests in `server/tests/test_validate.py`: `AgentMetadata` model tests (valid, missing name, empty description, invalid name, extra fields), `validate_agents()` tests (valid passes, invalid fails, name mismatch fails, empty body fails, missing skill reference fails cross-validation). Update real registry smoke test. **[Agent: python-expert]**
+  - [x] Run all server tests (`pytest`) including validation tests. Verify that the real registry passes validation with the sample agent file. **[Agent: qa-tester]**
+  - [x] **Git commit**
 
-- [ ] **Slice 3: Agent bundle endpoint — server can serve agent files as tar.gz**
-  - [ ] Add `resolve_agent_paths(names, registry_path)` function to `server/src/awos_recruitment_mcp/registry.py` — for each name, check if `agents/<name>.md` exists, return `(found_paths, not_found_names)`. **[Agent: python-expert]**
-  - [ ] Add `POST /bundle/agents` route to `server/src/awos_recruitment_mcp/server.py` — parse `BundleRequest`, deduplicate, resolve via `resolve_agent_paths()`, build tar.gz with `.md` files, return gzip response. **[Agent: python-expert]**
-  - [ ] Write tests in `server/tests/test_bundle.py`: valid request returns tar.gz with correct `.md` files, partial matches, all not-found returns empty archive, empty names returns 400, too many names returns 400, invalid name pattern returns 400. **[Agent: python-expert]**
-  - [ ] Run all server tests (`pytest`) to verify the bundle endpoint works. **[Agent: qa-tester]**
-  - [ ] **Git commit**
+- [x] **Slice 3: Agent bundle endpoint — server can serve agent files as tar.gz**
+  - [x] Add `resolve_agent_paths(names, registry_path)` function to `server/src/awos_recruitment_mcp/registry.py` — for each name, check if `agents/<name>.md` exists, return `(found_paths, not_found_names)`. **[Agent: python-expert]**
+  - [x] Add `POST /bundle/agents` route to `server/src/awos_recruitment_mcp/server.py` — parse `BundleRequest`, deduplicate, resolve via `resolve_agent_paths()`, build tar.gz with `.md` files, return gzip response. **[Agent: python-expert]**
+  - [x] Write tests in `server/tests/test_bundle.py`: valid request returns tar.gz with correct `.md` files, partial matches, all not-found returns empty archive, empty names returns 400, too many names returns 400, invalid name pattern returns 400. **[Agent: python-expert]**
+  - [x] Run all server tests (`pytest`) to verify the bundle endpoint works. **[Agent: qa-tester]**
+  - [x] **Git commit**
 
-- [ ] **Slice 4: Extract shared skill install logic — refactor without behavior change**
-  - [ ] Extract `processSkills(tempDir: string, requestedNames: string[]): InstallResult[]` from `cli/src/commands/skill.ts` — handles directory existence checks, `fs.cpSync`, and result tracking with no `process.exit` or print side effects. The existing `installSkills` calls `processSkills` internally, preserving current behavior. Export `processSkills`. **[Agent: typescript-expert]**
-  - [ ] Run existing CLI tests (`vitest`) to verify the skill command still works identically after refactor. **[Agent: qa-tester]**
-  - [ ] **Git commit**
+- [x] **Slice 4: Extract shared skill install logic — refactor without behavior change**
+  - [x] Extract `processSkills(tempDir: string, requestedNames: string[]): InstallResult[]` from `cli/src/commands/skill.ts` — handles directory existence checks, `fs.cpSync`, and result tracking with no `process.exit` or print side effects. The existing `installSkills` calls `processSkills` internally, preserving current behavior. Export `processSkills`. **[Agent: typescript-expert]**
+  - [x] Run existing CLI tests (`vitest`) to verify the skill command still works identically after refactor. **[Agent: qa-tester]**
+  - [x] **Git commit**
 
-- [ ] **Slice 5: CLI agent install (Phase 1) — agents are installed without auto-skill**
-  - [ ] Create `cli/src/lib/frontmatter.ts` — `parseFrontmatter(content: string): Record<string, unknown> | null` utility using the existing `yaml` package. Extracts YAML block between `---` delimiters, returns parsed object or `null`. **[Agent: typescript-expert]**
-  - [ ] Add `AgentFrontmatter` interface to `cli/src/lib/types.ts` — `name: string`, `description: string`, `model?: string`, `skills?: string[]`. **[Agent: typescript-expert]**
-  - [ ] Create `cli/src/commands/agent.ts` with `installAgents(names: string[])` — Phase 1 only: download bundle from `/bundle/agents`, extract `.md` files, copy to `.claude/agents/<name>.md`, skip existing silently, create `.claude/agents/` directory if needed, print summary, exit(1) only on not-found. **[Agent: typescript-expert]**
-  - [ ] Register `agent` subcommand in `cli/src/cli.ts` — add to guard condition, USAGE string, and switch statement. **[Agent: typescript-expert]**
-  - [ ] Write tests: `cli/src/lib/__tests__/frontmatter.test.ts` (valid frontmatter, no frontmatter, malformed YAML, empty skills) and `cli/src/commands/__tests__/agent.test.ts` (successful install, skip existing, not found, mixed results, directory creation). **[Agent: typescript-expert]**
-  - [ ] Run all CLI tests (`vitest`) to verify agent install works. **[Agent: qa-tester]**
-  - [ ] **Git commit**
+- [x] **Slice 5: CLI agent install (Phase 1) — agents are installed without auto-skill**
+  - [x] Create `cli/src/lib/frontmatter.ts` — `parseFrontmatter(content: string): Record<string, unknown> | null` utility using the existing `yaml` package. Extracts YAML block between `---` delimiters, returns parsed object or `null`. **[Agent: typescript-expert]**
+  - [x] Add `AgentFrontmatter` interface to `cli/src/lib/types.ts` — `name: string`, `description: string`, `model?: string`, `skills?: string[]`. **[Agent: typescript-expert]**
+  - [x] Create `cli/src/commands/agent.ts` with `installAgents(names: string[])` — Phase 1 only: download bundle from `/bundle/agents`, extract `.md` files, copy to `.claude/agents/<name>.md`, skip existing silently, create `.claude/agents/` directory if needed, print summary, exit(1) only on not-found. **[Agent: typescript-expert]**
+  - [x] Register `agent` subcommand in `cli/src/cli.ts` — add to guard condition, USAGE string, and switch statement. **[Agent: typescript-expert]**
+  - [x] Write tests: `cli/src/lib/__tests__/frontmatter.test.ts` (valid frontmatter, no frontmatter, malformed YAML, empty skills) and `cli/src/commands/__tests__/agent.test.ts` (successful install, skip existing, not found, mixed results, directory creation). **[Agent: typescript-expert]**
+  - [x] Run all CLI tests (`vitest`) to verify agent install works. **[Agent: qa-tester]**
+  - [x] **Git commit**
 
-- [ ] **Slice 6: CLI agent install (Phase 2) — auto-install referenced skills**
-  - [ ] Add Phase 2 logic to `installAgents` in `cli/src/commands/agent.ts` — after installing agents, parse frontmatter of each newly installed agent, collect unique skill names, filter out skills that already exist in `.claude/skills/`, call `downloadBundle` + `processSkills` for missing skills, merge skill results into combined summary. **[Agent: typescript-expert]**
-  - [ ] Write tests in `cli/src/commands/__tests__/agent.test.ts`: skills auto-installed from frontmatter, existing skills skipped, all skills already present (no HTTP call), no skills referenced in frontmatter, referenced skill not found in registry. **[Agent: typescript-expert]**
-  - [ ] Run all CLI tests (`vitest`) to verify the full two-phase install flow. **[Agent: qa-tester]**
-  - [ ] **Git commit**
+- [x] **Slice 6: CLI agent install (Phase 2) — auto-install referenced skills**
+  - [x] Add Phase 2 logic to `installAgents` in `cli/src/commands/agent.ts` — after installing agents, parse frontmatter of each newly installed agent, collect unique skill names, filter out skills that already exist in `.claude/skills/`, call `downloadBundle` + `processSkills` for missing skills, merge skill results into combined summary. **[Agent: typescript-expert]**
+  - [x] Write tests in `cli/src/commands/__tests__/agent.test.ts`: skills auto-installed from frontmatter, existing skills skipped, all skills already present (no HTTP call), no skills referenced in frontmatter, referenced skill not found in registry. **[Agent: typescript-expert]**
+  - [x] Run all CLI tests (`vitest`) to verify the full two-phase install flow. **[Agent: qa-tester]**
+  - [x] **Git commit**

--- a/context/spec/005-agent-support/technical-considerations.md
+++ b/context/spec/005-agent-support/technical-considerations.md
@@ -1,7 +1,7 @@
 # Technical Specification: Agent Support
 
 - **Functional Specification:** `context/spec/005-agent-support/functional-spec.md`
-- **Status:** Draft
+- **Status:** Completed
 - **Author(s):** Technical Architect
 
 ---

--- a/context/spec/005-agent-support/technical-considerations.md
+++ b/context/spec/005-agent-support/technical-considerations.md
@@ -1,0 +1,217 @@
+# Technical Specification: Agent Support
+
+- **Functional Specification:** `context/spec/005-agent-support/functional-spec.md`
+- **Status:** Draft
+- **Author(s):** Technical Architect
+
+---
+
+## 1. High-Level Technical Approach
+
+This feature extends the existing capability pipeline to support **agents** as a third capability type alongside skills and MCP servers. The implementation follows established patterns in both the Python server and TypeScript CLI, keeping new abstractions to a minimum.
+
+**Server (Python):** A new `registry/agents/` catalog of `.md` files (YAML frontmatter + system prompt body) is loaded by the registry, indexed in ChromaDB, validated in CI, and bundled via a new endpoint. The search index and search tool require zero changes — agents flow through naturally once loaded.
+
+**CLI (TypeScript):** A new `agent` subcommand downloads agent bundles, installs `.md` files to `.claude/agents/`, parses frontmatter to extract referenced skills, and auto-installs missing skills via the existing skill bundle flow. Shared install logic is extracted from the existing skill command to enable reuse without side effects.
+
+---
+
+## 2. Proposed Solution & Implementation Plan (The "How")
+
+### 2.1. Registry Catalog Structure
+
+New directory in the Git-managed registry:
+
+```
+registry/
+├── skills/<name>/SKILL.md          (existing)
+├── mcp/<name>.yaml                 (existing)
+└── agents/<name>.md                (new)
+```
+
+Each agent is a single markdown file with YAML frontmatter:
+
+| Field | Required | Type | Constraints |
+|-------|----------|------|-------------|
+| `name` | Yes | string | Kebab-case, 1–64 chars (`^[a-z0-9-]{1,64}$`) |
+| `description` | Yes | string | Non-empty (min_length=1) |
+| `model` | No | string | Any non-empty string |
+| `skills` | No | list[string] | Each entry must be kebab-case |
+
+The markdown body (after frontmatter) contains the agent's system prompt.
+
+### 2.2. Server: Data Model
+
+**New file:** `server/src/awos_recruitment_mcp/models/agent_metadata.py`
+
+- Pydantic `BaseModel` named `AgentMetadata`
+- `model_config = ConfigDict(extra="forbid")` — strict, consistent with `SkillMetadata`
+- Fields: `name` (required, regex-validated), `description` (required, min_length=1), `model` (optional string), `skills` (optional list of kebab-case strings)
+
+**Modified file:** `server/src/awos_recruitment_mcp/models/capability.py`
+
+- Expand `RegistryCapability.type` from `Literal["skill", "tool"]` to `Literal["skill", "tool", "agent"]`
+
+### 2.3. Server: Registry Loader
+
+**Modified file:** `server/src/awos_recruitment_mcp/registry.py`
+
+**New function `_load_agents(root: Path)`:** Follows the `_load_skills` pattern:
+1. Scan `root / "agents"` for `*.md` files (sorted)
+2. Parse each with `frontmatter.load()` to extract YAML metadata
+3. Extract `name` and `description`; skip entries with missing or empty values
+4. Return `RegistryCapability(name=..., description=..., type="agent")`
+
+**New function `resolve_agent_paths(names, registry_path)`:** Follows the `resolve_mcp_paths` pattern:
+- For each name, check if `agents/<name>.md` exists
+- Return `(found_paths, not_found_names)` tuple
+
+**Modified function `load_registry()`:** Add `capabilities.extend(_load_agents(root))`
+
+### 2.4. Server: Bundle Endpoint
+
+**Modified file:** `server/src/awos_recruitment_mcp/server.py`
+
+**New route `POST /bundle/agents`:** Follows the existing `/bundle/mcp` pattern:
+1. Parse and validate `BundleRequest` (1–20 kebab-case names)
+2. Deduplicate names
+3. Resolve via `resolve_agent_paths()`
+4. Build tar.gz archive with each agent's `.md` file (arcname: `<name>.md`)
+5. Return `Response(content=..., media_type="application/gzip")`
+
+### 2.5. Server: Validation
+
+**Modified file:** `server/src/awos_recruitment_mcp/validate/__init__.py`
+
+**New function `validate_agents(registry_path)`:** Follows the `validate_mcp_definitions` pattern:
+1. Scan `registry_path / "agents"` for `*.md` files
+2. Parse frontmatter with `frontmatter.load()`
+3. Validate metadata against `AgentMetadata.model_validate()`
+4. Extra check: filename stem must match `name` field
+5. Extra check: markdown body (system prompt) must be non-empty
+6. **Cross-validation:** For each entry in the `skills` list, verify that `registry_path / "skills" / skill_name` exists as a directory. Missing references produce a validation error that blocks the merge.
+
+**Modified function `validate_registry()`:** Add `results.extend(validate_agents(registry_path))`
+
+### 2.6. Server: Search (No Changes)
+
+- `search_index.py` — agents flow through naturally as `RegistryCapability` objects. No code changes.
+- `tools/search.py` — already accepts `type="agent"` in `VALID_TYPES`. No code changes.
+
+### 2.7. CLI: Command Registration
+
+**Modified file:** `cli/src/cli.ts`
+- Add `"agent"` to the subcommand guard condition
+- Add `"agent"` to the `USAGE` string
+- Add `case "agent":` to the switch statement, calling `installAgents(names)`
+
+### 2.8. CLI: Shared Logic Extraction
+
+**Modified file:** `cli/src/commands/skill.ts`
+
+Extract the file-copy and conflict-detection logic into a reusable function:
+
+- `processSkills(tempDir: string, requestedNames: string[]): InstallResult[]` — handles directory existence checks, `fs.cpSync`, and result tracking. No `process.exit` or print side effects.
+- The existing `installSkills` function calls `processSkills` internally, preserving its current behavior.
+
+**New file:** `cli/src/lib/frontmatter.ts`
+
+Small utility (~15 lines) using the existing `yaml` package:
+- `parseFrontmatter(content: string): Record<string, unknown> | null` — extracts YAML block between `---` delimiters, parses with `YAML.parse()`, returns the parsed object or `null` if no frontmatter found.
+
+**Modified file:** `cli/src/lib/types.ts`
+
+Add `AgentFrontmatter` interface:
+- `name: string`, `description: string`, `model?: string`, `skills?: string[]`
+
+### 2.9. CLI: Agent Install Command
+
+**New file:** `cli/src/commands/agent.ts`
+
+`installAgents(names: string[])` — two-phase install:
+
+**Phase 1 — Install agents:**
+1. Call `downloadBundle(serverUrl + "/bundle/agents", names)` to get extracted temp directory
+2. Read extracted `.md` files, map filenames (strip `.md`) to a set of found names
+3. For each requested name:
+   - If not found in archive: record as `"not-found"`
+   - If `.claude/agents/<name>.md` already exists: record as `"skipped"` (silent, no error)
+   - Otherwise: copy file to `.claude/agents/<name>.md`, record as `"installed"`
+4. Create `.claude/agents/` directory if it doesn't exist (`fs.mkdirSync` with `recursive: true`)
+
+**Phase 2 — Auto-install referenced skills:**
+1. For each newly installed agent file, parse frontmatter and collect all unique skill names from `skills` fields
+2. Filter out skills that already exist in `.claude/skills/`
+3. If any missing skills remain, call `downloadBundle(serverUrl + "/bundle/skills", missingSkillNames)` and then `processSkills(tempDir, missingSkillNames)`
+4. Merge skill install results into the overall summary
+
+**Output:** Print a combined summary:
+- Agents: installed / skipped (already exist) / not found
+- Skills: auto-installed / skipped (already exist) / not found
+
+**Exit code:** `process.exit(1)` only if any agent or skill has `"not-found"` status. Skipped items are not errors.
+
+---
+
+## 3. Impact and Risk Analysis
+
+### System Dependencies
+
+- **Search index:** No changes. Agents are indexed identically to skills and MCP servers.
+- **Search tool:** No changes. Already accepts `type="agent"`.
+- **Existing skill command:** Refactored to extract `processSkills`, but external behavior is unchanged.
+- **Bundle infrastructure:** New endpoint follows identical patterns; no changes to shared code (e.g., `BundleRequest` model).
+
+### Potential Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Skill cross-validation creates ordering dependency (agents can't be added before their skills) | Document that skills must be added to the registry before agents that reference them. CI will enforce this. |
+| Frontmatter parsing edge cases (malformed YAML, missing delimiters) | The `parseFrontmatter` utility returns `null` for unparseable content. Agent install treats unparseable agents as installed-but-no-skills (graceful degradation). |
+| Extracting `processSkills` from `skill.ts` could break existing behavior | Existing `installSkills` tests will catch regressions. The refactor is internal only — no API changes. |
+| Auto skill install makes a second HTTP request to the server | Only occurs when referenced skills are missing. The request is identical to a manual `skill` install. No performance concern for typical usage (1–5 skills per agent). |
+
+---
+
+## 4. Testing Strategy
+
+### Server (Python — pytest)
+
+| Area | Test File | Tests |
+|------|-----------|-------|
+| `AgentMetadata` model | `test_validate.py` | Valid metadata, missing name, empty description, invalid name format, extra fields rejected, optional fields |
+| `_load_agents()` | `test_registry.py` | Correct parsing, skip without description, type inference (`type="agent"`), mixed types with skills/tools |
+| `validate_agents()` | `test_validate.py` | Valid agent passes, invalid metadata fails, filename-name mismatch fails, empty body fails, missing skill reference fails cross-validation |
+| `/bundle/agents` | `test_bundle.py` | Valid request returns tar.gz, partial matches, all not-found, empty names (400), too many names (400), invalid name (400) |
+| Search integration | `test_search_index.py`, `test_search_tool.py` | Agent appears in search results, `type="agent"` filter works |
+| Real registry | `test_registry.py`, `test_validate.py` | Smoke tests updated to include agent count |
+
+### CLI (TypeScript — vitest)
+
+| Area | Test File | Tests |
+|------|-----------|-------|
+| Agent install (Phase 1) | `commands/__tests__/agent.test.ts` | Successful install, skip existing, not found, mixed results, `.claude/agents/` directory creation |
+| Auto skill install (Phase 2) | `commands/__tests__/agent.test.ts` | Skills auto-installed, existing skills skipped, all skills already present, no skills referenced, skill not found in registry |
+| Frontmatter parser | `lib/__tests__/frontmatter.test.ts` | Valid frontmatter, no frontmatter, malformed YAML, empty skills list |
+| `processSkills` extraction | `commands/__tests__/skill.test.ts` | Existing tests continue to pass after refactor |
+
+---
+
+## Files Changed Summary
+
+| File | Action |
+|------|--------|
+| `registry/agents/` | **Create** directory |
+| `server/src/awos_recruitment_mcp/models/agent_metadata.py` | **Create** |
+| `server/src/awos_recruitment_mcp/models/capability.py` | Modify — expand type literal |
+| `server/src/awos_recruitment_mcp/models/__init__.py` | Modify — export `AgentMetadata` |
+| `server/src/awos_recruitment_mcp/registry.py` | Modify — add `_load_agents()`, `resolve_agent_paths()` |
+| `server/src/awos_recruitment_mcp/validate/__init__.py` | Modify — add `validate_agents()` with cross-validation |
+| `server/src/awos_recruitment_mcp/server.py` | Modify — add `/bundle/agents` route |
+| `cli/src/cli.ts` | Modify — add `"agent"` subcommand |
+| `cli/src/commands/agent.ts` | **Create** |
+| `cli/src/commands/skill.ts` | Modify — extract `processSkills()` |
+| `cli/src/lib/frontmatter.ts` | **Create** |
+| `cli/src/lib/types.ts` | Modify — add `AgentFrontmatter` |
+| Server tests (5 files) | Modify — add agent test cases |
+| CLI tests (3 files) | **Create** / Modify |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,10 +2,11 @@
 
 This guide explains how to add new capabilities to the AWOS Recruitment registry.
 
-The registry contains two types of capabilities:
+The registry contains three types of capabilities:
 
 - **Skills** — Claude Code skill definitions (YAML front matter + markdown instructions)
 - **MCP Definitions** — MCP server configurations ready to be inserted into `.mcp.json`
+- **Agents** — Claude Code agent definitions (YAML front matter + system prompt)
 
 ---
 
@@ -18,12 +19,15 @@ registry/
 │       ├── SKILL.md              # Required — front matter + instructions
 │       └── references/           # Optional — supporting files
 │           └── *.md
-└── mcp/
-    └── <server-name>.yaml        # One YAML file per MCP server
+├── mcp/
+│   └── <server-name>.yaml        # One YAML file per MCP server
+└── agents/
+    └── <agent-name>.md           # One markdown file per agent
 ```
 
 - Each **skill** lives in its own subdirectory under `registry/skills/`. The directory must contain a `SKILL.md` file and may include additional reference files.
 - Each **MCP definition** is a single `.yaml` file directly under `registry/mcp/`.
+- Each **agent** is a single `.md` file directly under `registry/agents/`.
 
 ---
 
@@ -117,6 +121,53 @@ See `registry/mcp/context7.yaml` for a complete example.
 
 ---
 
+## Adding an Agent
+
+Create a `.md` file under `registry/agents/`:
+
+```markdown
+---
+name: my-agent-name
+description: When to use this agent and what expertise it provides.
+model: sonnet
+skills:
+  - skill-one
+  - skill-two
+---
+
+# My Agent
+
+You are an expert in...
+
+System prompt instructions go here.
+```
+
+### Required Fields
+
+| Field | Type | Rules |
+|-------|------|-------|
+| `name` | string | Kebab-case only (`a-z`, `0-9`, `-`). Max 64 characters. Must match the filename (without `.md`). |
+| `description` | string | Non-empty. Describes the agent's expertise and when to invoke it. |
+
+### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `model` | string | Target model identifier (e.g., `opus`, `sonnet`, `haiku`). |
+| `skills` | list of strings | Skill names this agent references. Each must be kebab-case. **All referenced skills must exist in `registry/skills/`.** |
+
+**No other fields are allowed.** The validator rejects unknown front matter fields.
+
+The markdown body below the front matter must be non-empty — it contains the agent's system prompt.
+
+When a user installs an agent, its referenced skills are automatically installed alongside it.
+
+### Example
+
+See `registry/agents/test-agent.md` for a complete example.
+
+---
+
 ## Validating Your Changes
 
 Before submitting, run the registry validator:
@@ -167,9 +218,10 @@ The command exits with code `0` on success and `1` on any validation failure.
 
 Before submitting a new capability:
 
-- [ ] File is in the correct location (`registry/skills/<name>/SKILL.md` or `registry/mcp/<name>.yaml`)
+- [ ] File is in the correct location (`registry/skills/<name>/SKILL.md`, `registry/mcp/<name>.yaml`, or `registry/agents/<name>.md`)
 - [ ] All required fields are present and non-empty
-- [ ] Skill `name` is kebab-case, max 64 characters
-- [ ] No unknown fields in skill front matter
+- [ ] `name` is kebab-case, max 64 characters
+- [ ] No unknown fields in front matter (skills and agents use `extra="forbid"`)
 - [ ] MCP `config` has exactly one server key with a valid `type`
+- [ ] Agent `skills` references only existing skills in `registry/skills/`
 - [ ] `just validate-registry` passes with exit code 0

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -65,20 +65,21 @@ awos-recruitment/
 │   │   ├── config.py        # Config from env vars
 │   │   ├── registry.py      # Registry loader (scans and parses capabilities)
 │   │   ├── search_index.py  # ChromaDB search index (build + query)
-│   │   ├── models/          # Pydantic models (capabilities, skills, MCP defs)
+│   │   ├── models/          # Pydantic models (capabilities, skills, MCP defs, agents)
 │   │   ├── tools/           # MCP tool implementations
 │   │   └── validate/        # Registry validation CLI
 │   ├── tests/               # pytest test suite
 │   └── pyproject.toml       # Dependencies and project config
 ├── registry/            # Git-managed capability catalog
 │   ├── skills/              # Claude Code skill definitions
-│   └── mcp/                 # MCP server definitions
+│   ├── mcp/                 # MCP server definitions
+│   └── agents/              # Claude Code agent definitions
 ├── cli/                 # TypeScript npx package for capability installation
 │   ├── src/
 │   │   ├── index.ts         # Entry point with error boundary
 │   │   ├── cli.ts           # Argument parsing and subcommand routing
-│   │   ├── commands/        # skill and mcp install commands
-│   │   └── lib/             # download, json-merge, errors, types
+│   │   ├── commands/        # skill, mcp, and agent install commands
+│   │   └── lib/             # download, json-merge, frontmatter, errors, types
 │   ├── package.json
 │   └── tsconfig.json
 ├── context/             # Product docs, specs, and roadmap
@@ -139,7 +140,11 @@ context/spec/
 │   ├── functional-spec.md
 │   ├── technical-considerations.md
 │   └── tasks.md
-└── 004-capability-installation/           # Completed
+├── 004-capability-installation/           # Completed
+│   ├── functional-spec.md
+│   ├── technical-considerations.md
+│   └── tasks.md
+└── 005-agent-support/                    # Completed
     ├── functional-spec.md
     ├── technical-considerations.md
     └── tasks.md

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -41,6 +41,9 @@ All commands run from the **repository root** via `just`:
 | `just validate-registry --format json` | Validate with JSON output (for CI) |
 | `just build-cli` | Build the CLI (TypeScript → `cli/dist/`) |
 | `just test-cli` | Run CLI tests |
+| `just publish-cli` | Bump patch version and publish CLI to npm |
+| `just publish-cli minor` | Bump minor version and publish |
+| `just publish-cli major` | Bump major version and publish |
 
 ## Server Configuration
 

--- a/justfile
+++ b/justfile
@@ -17,3 +17,7 @@ build-cli:
 # Run CLI tests
 test-cli *ARGS:
     cd cli && npm test {{ARGS}}
+
+# Publish CLI to npm (bump: patch, minor, or major)
+publish-cli bump="patch":
+    cd cli && npm version {{bump}} && npm publish --access public

--- a/registry/agents/test-agent.md
+++ b/registry/agents/test-agent.md
@@ -1,0 +1,26 @@
+---
+name: test-agent
+description: A test agent for automated testing and QA workflows
+model: sonnet
+skills:
+  - modern-python-development
+  - typescript-development
+---
+
+# Test Agent
+
+You are a testing and quality assurance agent. Your role is to help developers write, run, and maintain automated tests across Python and TypeScript projects.
+
+## Responsibilities
+
+- Write unit tests, integration tests, and end-to-end tests
+- Identify untested code paths and suggest coverage improvements
+- Review test quality and recommend best practices
+- Debug failing tests and diagnose flaky test behaviour
+
+## Guidelines
+
+- Prefer small, focused test cases with clear assertions
+- Use descriptive test names that explain the expected behaviour
+- Follow the Arrange-Act-Assert pattern
+- Mock external dependencies at the boundary, not deep in the call stack

--- a/server/src/awos_recruitment_mcp/models/__init__.py
+++ b/server/src/awos_recruitment_mcp/models/__init__.py
@@ -1,6 +1,7 @@
 """Data models for the AWOS Recruitment MCP server."""
 
 __all__ = [
+    "AgentMetadata",
     "BundleRequest",
     "CapabilityResult",
     "McpDefinition",
@@ -9,6 +10,7 @@ __all__ = [
     "SkillMetadata",
 ]
 
+from awos_recruitment_mcp.models.agent_metadata import AgentMetadata
 from awos_recruitment_mcp.models.bundle import BundleRequest
 from awos_recruitment_mcp.models.capability import CapabilityResult, RegistryCapability
 from awos_recruitment_mcp.models.mcp_definition import McpDefinition, McpServerConfig

--- a/server/src/awos_recruitment_mcp/models/agent_metadata.py
+++ b/server/src/awos_recruitment_mcp/models/agent_metadata.py
@@ -1,0 +1,32 @@
+"""Pydantic model for validating agent front-matter metadata."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AgentMetadata(BaseModel):
+    """Validated representation of the YAML front matter in an agent ``.md`` file.
+
+    Attributes:
+        name: Kebab-case identifier for the agent (1-64 chars, lowercase
+              alphanumeric and hyphens only).
+        description: Human-readable description of what the agent does.
+        model: Optional model identifier this agent is designed for.
+        skills: Optional list of skill names (kebab-case) the agent depends on.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    name: str = Field(..., pattern=r"^[a-z0-9-]{1,64}$")
+    description: str = Field(..., min_length=1)
+
+    # NOTE: ``model`` does not conflict with Pydantic's reserved ``model_``
+    # prefix — only names starting with ``model_`` are reserved.  The field
+    # name ``model`` is safe and follows the same pattern as SkillMetadata.
+    model: str | None = Field(None)
+    skills: list[
+        Annotated[str, Field(pattern=r"^[a-z0-9-]{1,64}$")]
+    ] | None = Field(None)

--- a/server/src/awos_recruitment_mcp/models/capability.py
+++ b/server/src/awos_recruitment_mcp/models/capability.py
@@ -23,14 +23,14 @@ class CapabilityResult(BaseModel):
 
 
 class RegistryCapability(BaseModel):
-    """A capability loaded from the registry (skill or MCP tool).
+    """A capability loaded from the registry (skill, MCP tool, or agent).
 
     Attributes:
         name: The capability name extracted from registry metadata.
         description: Human-readable description of what the capability does.
-        type: The kind of capability — either ``"skill"`` or ``"tool"``.
+        type: The kind of capability — ``"skill"``, ``"tool"``, or ``"agent"``.
     """
 
     name: str
     description: str
-    type: Literal["skill", "tool"]
+    type: Literal["skill", "tool", "agent"]

--- a/server/src/awos_recruitment_mcp/registry.py
+++ b/server/src/awos_recruitment_mcp/registry.py
@@ -86,6 +86,42 @@ def resolve_mcp_paths(
     return found, not_found
 
 
+def resolve_agent_paths(
+    names: list[str],
+    registry_path: str | Path,
+) -> tuple[list[Path], list[str]]:
+    """Resolve agent names to their Markdown file paths under *registry_path*.
+
+    For each name in *names*, checks whether ``agents/<name>.md`` exists as a
+    file under the registry root.  Names that resolve to an existing file are
+    collected into the first element of the returned tuple; names that do not
+    match any file end up in the second element.
+
+    Args:
+        names: Agent names to look up (without the ``.md`` suffix).
+        registry_path: Root directory of the registry.
+
+    Returns:
+        A ``(found_paths, not_found)`` tuple where *found_paths* is a list of
+        :class:`~pathlib.Path` objects pointing to the matched Markdown files
+        and *not_found* is a list of names with no corresponding file.
+    """
+    root = Path(registry_path)
+    agents_dir = root / "agents"
+
+    found: list[Path] = []
+    not_found: list[str] = []
+
+    for name in names:
+        md_path = agents_dir / f"{name}.md"
+        if md_path.is_file():
+            found.append(md_path)
+        else:
+            not_found.append(name)
+
+    return found, not_found
+
+
 def load_registry(registry_path: str | Path) -> list[RegistryCapability]:
     """Load all capabilities from the registry at *registry_path*.
 

--- a/server/src/awos_recruitment_mcp/registry.py
+++ b/server/src/awos_recruitment_mcp/registry.py
@@ -89,13 +89,16 @@ def resolve_mcp_paths(
 def load_registry(registry_path: str | Path) -> list[RegistryCapability]:
     """Load all capabilities from the registry at *registry_path*.
 
-    Scans two sub-trees:
+    Scans three sub-trees:
 
     * ``skills/*/SKILL.md`` -- YAML front matter is parsed with
       *python-frontmatter*; each entry becomes a capability with
       ``type="skill"``.
     * ``mcp/*.yaml`` -- flat YAML files parsed with *pyyaml*; each entry
       becomes a capability with ``type="tool"``.
+    * ``agents/*.md`` -- YAML front matter is parsed with
+      *python-frontmatter*; each entry becomes a capability with
+      ``type="agent"``.
 
     Entries that have no ``description`` (or an empty/whitespace-only
     description) are silently skipped.
@@ -111,6 +114,7 @@ def load_registry(registry_path: str | Path) -> list[RegistryCapability]:
 
     capabilities.extend(_load_skills(root))
     capabilities.extend(_load_mcp_tools(root))
+    capabilities.extend(_load_agents(root))
 
     return capabilities
 
@@ -192,6 +196,44 @@ def _load_mcp_tools(root: Path) -> list[RegistryCapability]:
                 name=name,
                 description=description,
                 type="tool",
+            )
+        )
+
+    return results
+
+
+def _load_agents(root: Path) -> list[RegistryCapability]:
+    """Parse ``agents/*.md`` files and return agent capabilities."""
+    agents_dir = root / "agents"
+    results: list[RegistryCapability] = []
+
+    if not agents_dir.is_dir():
+        return results
+
+    for md_file in sorted(agents_dir.iterdir()):
+        if not md_file.is_file() or md_file.suffix != ".md":
+            continue
+
+        try:
+            post = frontmatter.load(str(md_file))
+        except Exception:
+            logger.warning("Failed to parse front matter in %s", md_file)
+            continue
+
+        metadata: dict = dict(post.metadata)
+        name = metadata.get("name")
+        description = metadata.get("description")
+
+        if not name or not isinstance(name, str):
+            continue
+        if not description or not isinstance(description, str) or not description.strip():
+            continue
+
+        results.append(
+            RegistryCapability(
+                name=name,
+                description=description,
+                type="agent",
             )
         )
 

--- a/server/src/awos_recruitment_mcp/server.py
+++ b/server/src/awos_recruitment_mcp/server.py
@@ -17,7 +17,12 @@ from starlette.responses import JSONResponse, Response
 
 from awos_recruitment_mcp.config import Config
 from awos_recruitment_mcp.models.bundle import BundleRequest
-from awos_recruitment_mcp.registry import load_registry, resolve_mcp_paths, resolve_skill_paths
+from awos_recruitment_mcp.registry import (
+    load_registry,
+    resolve_agent_paths,
+    resolve_mcp_paths,
+    resolve_skill_paths,
+)
 from awos_recruitment_mcp.search_index import build_index
 
 config = Config.from_env()
@@ -131,6 +136,39 @@ async def bundle_mcp(request: Request) -> Response:
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
         for yaml_path in found_paths:
             tar.add(str(yaml_path), arcname=yaml_path.name)
+
+    return Response(content=buf.getvalue(), media_type="application/gzip")
+
+
+@mcp.custom_route("/bundle/agents", methods=["POST"])
+async def bundle_agents(request: Request) -> Response:
+    """Bundle one or more agent definitions into a tar.gz archive.
+
+    Expects a JSON body matching :class:`BundleRequest`.  Resolves each
+    requested agent name to its on-disk Markdown file, then streams back
+    a gzip-compressed tar archive containing ``<name>.md`` for each
+    found entry.
+
+    Returns 400 with a JSON error body when the request fails validation.
+    """
+    try:
+        body = await request.json()
+        bundle_request = BundleRequest.model_validate(body)
+    except ValidationError as exc:
+        return JSONResponse(
+            {"error": "Validation failed", "detail": exc.errors()},
+            status_code=400,
+        )
+
+    unique_names = list(dict.fromkeys(bundle_request.names))
+    found_paths, _not_found = resolve_agent_paths(
+        unique_names, config.registry_path
+    )
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for md_path in found_paths:
+            tar.add(str(md_path), arcname=md_path.name)
 
     return Response(content=buf.getvalue(), media_type="application/gzip")
 

--- a/server/src/awos_recruitment_mcp/validate/__init__.py
+++ b/server/src/awos_recruitment_mcp/validate/__init__.py
@@ -9,7 +9,7 @@ import frontmatter
 import yaml
 from pydantic import ValidationError as PydanticValidationError
 
-from awos_recruitment_mcp.models import McpDefinition, SkillMetadata
+from awos_recruitment_mcp.models import AgentMetadata, McpDefinition, SkillMetadata
 
 
 @dataclass(frozen=True, slots=True)
@@ -250,6 +250,114 @@ def validate_mcp_definitions(registry_path: Path) -> list[ValidationResult]:
     return results
 
 
+def validate_agents(registry_path: Path) -> list[ValidationResult]:
+    """Validate every agent definition under *registry_path*/agents.
+
+    Each ``.md`` file in the ``agents/`` directory is expected to have YAML
+    front matter conforming to
+    :class:`~awos_recruitment_mcp.models.AgentMetadata` and a non-empty
+    markdown body (the system prompt).
+
+    Returns:
+        A list of :class:`ValidationResult` objects, one per ``.md`` file.
+    """
+
+    agents_dir = registry_path / "agents"
+    results: list[ValidationResult] = []
+
+    if not agents_dir.is_dir():
+        return results
+
+    for md_file in sorted(agents_dir.iterdir()):
+        if not md_file.is_file() or md_file.suffix != ".md":
+            continue
+
+        relative_path = str(md_file.relative_to(registry_path))
+        errors: list[ValidationError] = []
+
+        # Parse front matter.
+        try:
+            post = frontmatter.load(str(md_file))
+        except Exception as exc:
+            errors.append(
+                ValidationError(
+                    file=relative_path,
+                    field=None,
+                    message=f"Failed to parse front matter: {exc}",
+                )
+            )
+            results.append(
+                ValidationResult(file=relative_path, valid=False, errors=errors)
+            )
+            continue
+
+        # Validate metadata against the Pydantic model.
+        metadata = dict(post.metadata)
+        try:
+            AgentMetadata.model_validate(metadata)
+        except PydanticValidationError as exc:
+            for err in exc.errors():
+                loc = ".".join(str(part) for part in err["loc"]) or None
+                errors.append(
+                    ValidationError(
+                        file=relative_path,
+                        field=loc,
+                        message=err["msg"],
+                    )
+                )
+
+        # Ensure the filename stem matches the metadata name.
+        meta_name = metadata.get("name")
+        if meta_name is not None and md_file.stem != meta_name:
+            errors.append(
+                ValidationError(
+                    file=relative_path,
+                    field="name",
+                    message=(
+                        f"Agent filename '{md_file.stem}' does not match "
+                        f"name field '{meta_name}'"
+                    ),
+                )
+            )
+
+        # Ensure the markdown body (system prompt) is non-empty.
+        if not post.content.strip():
+            errors.append(
+                ValidationError(
+                    file=relative_path,
+                    field=None,
+                    message="Agent body (system prompt) is empty",
+                )
+            )
+
+        # Cross-validate skill references against registry/skills/.
+        skills = metadata.get("skills")
+        if isinstance(skills, list):
+            for skill_name in skills:
+                skill_dir = registry_path / "skills" / skill_name
+                if not skill_dir.is_dir():
+                    errors.append(
+                        ValidationError(
+                            file=relative_path,
+                            field="skills",
+                            message=(
+                                f"Referenced skill '{skill_name}' not found "
+                                f"in registry skills directory"
+                            ),
+                        )
+                    )
+
+        results.append(
+            ValidationResult(
+                file=relative_path,
+                valid=len(errors) == 0,
+                errors=errors,
+            )
+        )
+
+    return results
+
+
 def validate_registry(registry_path: Path) -> list[ValidationResult]:
     """Validate the entire registry at *registry_path*.
 
@@ -262,4 +370,5 @@ def validate_registry(registry_path: Path) -> list[ValidationResult]:
     results: list[ValidationResult] = []
     results.extend(validate_skills(registry_path))
     results.extend(validate_mcp_definitions(registry_path))
+    results.extend(validate_agents(registry_path))
     return results

--- a/server/tests/test_bundle.py
+++ b/server/tests/test_bundle.py
@@ -1,4 +1,4 @@
-"""Tests for the POST /bundle/skills and POST /bundle/mcp endpoints."""
+"""Tests for the POST /bundle/skills, POST /bundle/mcp, and POST /bundle/agents endpoints."""
 
 from __future__ import annotations
 
@@ -439,4 +439,181 @@ async def test_mcp_all_not_found_returns_empty_archive(asgi_app):
 
     assert len(members) == 0, (
         f"Expected empty archive, got {len(members)} members: {[m.name for m in members]}"
+    )
+
+
+# ===========================================================================
+# POST /bundle/agents
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# Valid request
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_valid_request_returns_200(asgi_app):
+    """POST a single valid agent name and verify HTTP 200."""
+    transport = httpx.ASGITransport(app=asgi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/bundle/agents",
+            json={"names": ["test-agent"]},
+        )
+
+    assert response.status_code == 200, (
+        f"Expected HTTP 200, got {response.status_code}"
+    )
+
+
+async def test_agent_valid_request_returns_tar_gz(asgi_app):
+    """POST a single valid agent name and verify the archive contains its .md file."""
+    transport = httpx.ASGITransport(app=asgi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/bundle/agents",
+            json={"names": ["test-agent"]},
+        )
+
+    buf = io.BytesIO(response.content)
+    with tarfile.open(fileobj=buf, mode="r:gz") as tar:
+        names = tar.getnames()
+
+    assert "test-agent.md" in names, (
+        f"Expected test-agent.md in archive, got {names}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Partial matches
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_partial_matches_returns_200(asgi_app):
+    """POST a mix of existing and nonexistent agent names and verify HTTP 200."""
+    transport = httpx.ASGITransport(app=asgi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/bundle/agents",
+            json={"names": ["test-agent", "nonexistent-agent"]},
+        )
+
+    assert response.status_code == 200, (
+        f"Expected HTTP 200, got {response.status_code}"
+    )
+
+
+async def test_agent_partial_matches_contains_only_existing(asgi_app):
+    """POST a mix of existing and nonexistent agent names; archive contains only the existing one."""
+    transport = httpx.ASGITransport(app=asgi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/bundle/agents",
+            json={"names": ["test-agent", "nonexistent-agent"]},
+        )
+
+    buf = io.BytesIO(response.content)
+    with tarfile.open(fileobj=buf, mode="r:gz") as tar:
+        names = tar.getnames()
+
+    assert "test-agent.md" in names, (
+        f"Expected test-agent.md in archive, got {names}"
+    )
+    assert "nonexistent-agent.md" not in names, (
+        f"Did not expect nonexistent-agent.md in archive, got {names}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# All not-found
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_all_not_found_returns_200(asgi_app):
+    """POST agent names that do not match any agent and verify HTTP 200."""
+    transport = httpx.ASGITransport(app=asgi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/bundle/agents",
+            json={"names": ["does-not-exist"]},
+        )
+
+    assert response.status_code == 200, (
+        f"Expected HTTP 200, got {response.status_code}"
+    )
+
+
+async def test_agent_all_not_found_returns_empty_archive(asgi_app):
+    """POST agent names that do not match any agent and verify the archive is empty."""
+    transport = httpx.ASGITransport(app=asgi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/bundle/agents",
+            json={"names": ["does-not-exist"]},
+        )
+
+    buf = io.BytesIO(response.content)
+    with tarfile.open(fileobj=buf, mode="r:gz") as tar:
+        members = tar.getmembers()
+
+    assert len(members) == 0, (
+        f"Expected empty archive, got {len(members)} members: {[m.name for m in members]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Empty names list
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_empty_names_returns_400(asgi_app):
+    """POST an empty agent names list and verify HTTP 400."""
+    transport = httpx.ASGITransport(app=asgi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/bundle/agents",
+            json={"names": []},
+        )
+
+    assert response.status_code == 400, (
+        f"Expected HTTP 400, got {response.status_code}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Names exceeding limit
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_too_many_names_returns_400(asgi_app):
+    """POST 21 agent names (exceeding the limit of 20) and verify HTTP 400."""
+    names = [f"agent-{i}" for i in range(21)]
+    transport = httpx.ASGITransport(app=asgi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/bundle/agents",
+            json={"names": names},
+        )
+
+    assert response.status_code == 400, (
+        f"Expected HTTP 400, got {response.status_code}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invalid name pattern
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_invalid_name_pattern_returns_400(asgi_app):
+    """POST an agent name with uppercase letters (invalid pattern) and verify HTTP 400."""
+    transport = httpx.ASGITransport(app=asgi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/bundle/agents",
+            json={"names": ["UPPERCASE"]},
+        )
+
+    assert response.status_code == 400, (
+        f"Expected HTTP 400, got {response.status_code}"
     )

--- a/server/tests/test_registry.py
+++ b/server/tests/test_registry.py
@@ -57,6 +57,25 @@ def _write_mcp_yaml(
     (mcp_dir / filename).write_text("\n".join(lines) + "\n")
 
 
+def _write_agent(
+    registry_root: Path,
+    filename: str,
+    name: str,
+    description: str | None = None,
+    body: str = "# Agent\n\nSystem prompt content.\n",
+) -> None:
+    """Write an agent ``.md`` file inside ``registry_root/agents/``."""
+    agents_dir = registry_root / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+
+    front_matter_lines = [f"name: {name}"]
+    if description is not None:
+        front_matter_lines.append(f"description: {description}")
+
+    content = "---\n" + "\n".join(front_matter_lines) + "\n---\n\n" + body
+    (agents_dir / filename).write_text(content)
+
+
 # ---------------------------------------------------------------------------
 # Correct parsing
 # ---------------------------------------------------------------------------
@@ -98,6 +117,17 @@ class TestCorrectParsing:
         assert cap.name == "My Tool"
         assert cap.description == "Tool description"
         assert cap.type == "tool"
+
+    def test_agent_fields(self, tmp_path: Path) -> None:
+        _write_agent(tmp_path, "qa-agent.md", "qa-agent", "QA automation agent")
+
+        caps = load_registry(tmp_path)
+
+        assert len(caps) == 1
+        cap = caps[0]
+        assert cap.name == "qa-agent"
+        assert cap.description == "QA automation agent"
+        assert cap.type == "agent"
 
 
 # ---------------------------------------------------------------------------
@@ -153,6 +183,33 @@ class TestSkipWithoutDescription:
             f"Expected 0 capabilities (MCP empty description), got {len(caps)}"
         )
 
+    def test_agent_no_description_field(self, tmp_path: Path) -> None:
+        _write_agent(tmp_path, "no-desc.md", "no-desc-agent", description=None)
+
+        caps = load_registry(tmp_path)
+
+        assert len(caps) == 0, (
+            f"Expected 0 capabilities (agent missing description), got {len(caps)}"
+        )
+
+    def test_agent_empty_description(self, tmp_path: Path) -> None:
+        _write_agent(tmp_path, "empty-desc.md", "empty-desc-agent", description="")
+
+        caps = load_registry(tmp_path)
+
+        assert len(caps) == 0, (
+            f"Expected 0 capabilities (agent empty description), got {len(caps)}"
+        )
+
+    def test_agent_whitespace_description(self, tmp_path: Path) -> None:
+        _write_agent(tmp_path, "ws-desc.md", "ws-desc-agent", description="   ")
+
+        caps = load_registry(tmp_path)
+
+        assert len(caps) == 0, (
+            f"Expected 0 capabilities (agent whitespace description), got {len(caps)}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Type inference
@@ -160,7 +217,7 @@ class TestSkipWithoutDescription:
 
 
 class TestTypeInference:
-    """Skills get type='skill', MCP definitions get type='tool'."""
+    """Skills get type='skill', MCP definitions get type='tool', agents get type='agent'."""
 
     def test_skills_have_type_skill(self, tmp_path: Path) -> None:
         _write_skill(tmp_path, "alpha", "alpha-skill", "Alpha description")
@@ -180,6 +237,15 @@ class TestTypeInference:
             f"Expected all types to be 'tool', got {[c.type for c in caps]}"
         )
 
+    def test_agents_have_type_agent(self, tmp_path: Path) -> None:
+        _write_agent(tmp_path, "gamma.md", "gamma-agent", "Gamma description")
+
+        caps = load_registry(tmp_path)
+
+        assert all(c.type == "agent" for c in caps), (
+            f"Expected all types to be 'agent', got {[c.type for c in caps]}"
+        )
+
     def test_mixed_types(self, tmp_path: Path) -> None:
         _write_skill(tmp_path, "s1", "s1-skill", "Skill desc")
         _write_mcp_yaml(tmp_path, "t1.yaml", "T1 Tool", "Tool desc")
@@ -189,6 +255,18 @@ class TestTypeInference:
         types = {c.type for c in caps}
         assert types == {"skill", "tool"}, (
             f"Expected both 'skill' and 'tool' types, got {types}"
+        )
+
+    def test_mixed_types_all_three(self, tmp_path: Path) -> None:
+        _write_skill(tmp_path, "s1", "s1-skill", "Skill desc")
+        _write_mcp_yaml(tmp_path, "t1.yaml", "T1 Tool", "Tool desc")
+        _write_agent(tmp_path, "a1.md", "a1-agent", "Agent desc")
+
+        caps = load_registry(tmp_path)
+
+        types = {c.type for c in caps}
+        assert types == {"skill", "tool", "agent"}, (
+            f"Expected 'skill', 'tool', and 'agent' types, got {types}"
         )
 
 
@@ -217,6 +295,17 @@ class TestEmptyRegistry:
             f"Expected empty list for registry with empty sub-dirs, got {caps}"
         )
 
+    def test_empty_skills_mcp_and_agents_dirs(self, tmp_path: Path) -> None:
+        (tmp_path / "skills").mkdir()
+        (tmp_path / "mcp").mkdir()
+        (tmp_path / "agents").mkdir()
+
+        caps = load_registry(tmp_path)
+
+        assert caps == [], (
+            f"Expected empty list for registry with empty sub-dirs, got {caps}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Smoke test against the real registry
@@ -232,17 +321,21 @@ def test_real_registry_loads_all_capabilities() -> None:
 
     caps = load_registry(real_registry)
 
-    assert len(caps) == 4, (
-        f"Expected 4 capabilities (2 skills + 2 tools), got {len(caps)}: "
+    assert len(caps) == 5, (
+        f"Expected 5 capabilities (2 skills + 2 tools + 1 agent), got {len(caps)}: "
         f"{[(c.name, c.type) for c in caps]}"
     )
 
     skill_caps = [c for c in caps if c.type == "skill"]
     tool_caps = [c for c in caps if c.type == "tool"]
+    agent_caps = [c for c in caps if c.type == "agent"]
 
     assert len(skill_caps) == 2, (
         f"Expected 2 skills, got {len(skill_caps)}: {[c.name for c in skill_caps]}"
     )
     assert len(tool_caps) == 2, (
         f"Expected 2 tools, got {len(tool_caps)}: {[c.name for c in tool_caps]}"
+    )
+    assert len(agent_caps) == 1, (
+        f"Expected 1 agent, got {len(agent_caps)}: {[c.name for c in agent_caps]}"
     )

--- a/server/tests/test_search_index.py
+++ b/server/tests/test_search_index.py
@@ -39,6 +39,11 @@ SAMPLE_CAPABILITIES = [
         description="Automated testing with pytest including fixtures, parametrize, and coverage reports",
         type="skill",
     ),
+    RegistryCapability(
+        name="qa-automation-agent",
+        description="Autonomous QA agent that writes and runs test suites for Python and TypeScript projects",
+        type="agent",
+    ),
 ]
 
 
@@ -177,6 +182,20 @@ class TestTypeFilter:
                 "postgresql-database",
                 "kubernetes-ops",
             }, f"Expected only tools, got {result['name']}"
+
+    def test_filter_agents_only(
+        self,
+        capabilities_collection: Collection,
+    ) -> None:
+        results = query(
+            capabilities_collection,
+            "testing automation",
+            type_filter="agent",
+        )
+        for result in results:
+            assert result["name"] in {
+                "qa-automation-agent",
+            }, f"Expected only agents, got {result['name']}"
 
     def test_filter_excludes_other_type(
         self,

--- a/server/tests/test_validate.py
+++ b/server/tests/test_validate.py
@@ -10,8 +10,14 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from awos_recruitment_mcp.models import McpDefinition, McpServerConfig, SkillMetadata
+from awos_recruitment_mcp.models import (
+    AgentMetadata,
+    McpDefinition,
+    McpServerConfig,
+    SkillMetadata,
+)
 from awos_recruitment_mcp.validate import (
+    validate_agents,
     validate_mcp_definitions,
     validate_registry,
     validate_skills,
@@ -75,6 +81,109 @@ def test_skill_unknown_field():
     messages = [e["msg"] for e in exc_info.value.errors()]
     assert any("extra" in m.lower() for m in messages), (
         f"Expected an 'extra fields not permitted' error, got: {messages}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AgentMetadata model tests
+# ---------------------------------------------------------------------------
+
+
+def test_valid_agent_metadata():
+    """A dict with valid name and description should pass validation."""
+    meta = AgentMetadata.model_validate(
+        {"name": "my-agent", "description": "A useful agent"}
+    )
+    assert meta.name == "my-agent", (
+        f"Expected name 'my-agent', got '{meta.name}'"
+    )
+    assert meta.description == "A useful agent", (
+        f"Expected description 'A useful agent', got '{meta.description}'"
+    )
+
+
+def test_agent_missing_name():
+    """Omitting the required 'name' field should raise ValidationError."""
+    with pytest.raises(ValidationError) as exc_info:
+        AgentMetadata.model_validate({"description": "No name provided"})
+    error_fields = {
+        ".".join(str(p) for p in e["loc"]) for e in exc_info.value.errors()
+    }
+    assert "name" in error_fields, (
+        f"Expected a validation error for 'name', got errors for: {error_fields}"
+    )
+
+
+def test_agent_empty_description():
+    """An empty description should raise ValidationError."""
+    with pytest.raises(ValidationError) as exc_info:
+        AgentMetadata.model_validate({"name": "my-agent", "description": ""})
+    error_fields = {
+        ".".join(str(p) for p in e["loc"]) for e in exc_info.value.errors()
+    }
+    assert "description" in error_fields, (
+        f"Expected a validation error for 'description', got errors for: {error_fields}"
+    )
+
+
+def test_agent_invalid_name_format():
+    """Names with uppercase letters should be rejected."""
+    with pytest.raises(ValidationError) as exc_info:
+        AgentMetadata.model_validate(
+            {"name": "My-Agent", "description": "Bad name"}
+        )
+    error_fields = {
+        ".".join(str(p) for p in e["loc"]) for e in exc_info.value.errors()
+    }
+    assert "name" in error_fields, (
+        f"Expected a validation error for 'name', got errors for: {error_fields}"
+    )
+
+
+def test_agent_extra_fields_rejected():
+    """An unknown field should be rejected (extra='forbid')."""
+    with pytest.raises(ValidationError) as exc_info:
+        AgentMetadata.model_validate(
+            {
+                "name": "good-agent",
+                "description": "Has extra field",
+                "surprise": True,
+            }
+        )
+    messages = [e["msg"] for e in exc_info.value.errors()]
+    assert any("extra" in m.lower() for m in messages), (
+        f"Expected an 'extra fields not permitted' error, got: {messages}"
+    )
+
+
+def test_agent_optional_fields():
+    """Optional fields (model, skills) should work when provided."""
+    meta = AgentMetadata.model_validate(
+        {
+            "name": "full-agent",
+            "description": "Agent with all fields",
+            "model": "sonnet",
+            "skills": ["python-dev", "testing"],
+        }
+    )
+    assert meta.model == "sonnet", (
+        f"Expected model 'sonnet', got '{meta.model}'"
+    )
+    assert meta.skills == ["python-dev", "testing"], (
+        f"Expected skills ['python-dev', 'testing'], got {meta.skills}"
+    )
+
+
+def test_agent_optional_fields_default_none():
+    """Optional fields should default to None when omitted."""
+    meta = AgentMetadata.model_validate(
+        {"name": "minimal-agent", "description": "Minimal"}
+    )
+    assert meta.model is None, (
+        f"Expected model to be None, got '{meta.model}'"
+    )
+    assert meta.skills is None, (
+        f"Expected skills to be None, got {meta.skills}"
     )
 
 
@@ -267,7 +376,7 @@ def test_validate_mcp_valid(tmp_path: Path):
 
 
 def test_validate_registry_finds_all(tmp_path: Path):
-    """validate_registry should discover and validate both skills/ and mcp/ entries."""
+    """validate_registry should discover and validate skills/, mcp/, and agents/ entries."""
     # Create a valid skill.
     skill_dir = tmp_path / "skills" / "demo-skill"
     skill_dir.mkdir(parents=True)
@@ -290,10 +399,25 @@ def test_validate_registry_finds_all(tmp_path: Path):
         ),
     )
 
+    # Create a valid agent definition.
+    _write_agent_md(
+        tmp_path,
+        "demo-agent.md",
+        (
+            "---\n"
+            "name: demo-agent\n"
+            "description: A demo agent.\n"
+            "skills:\n"
+            "  - demo-skill\n"
+            "---\n\n"
+            "# Demo Agent\n\nYou are a demo agent.\n"
+        ),
+    )
+
     results = validate_registry(tmp_path)
 
-    assert len(results) == 2, (
-        f"Expected 2 results (1 skill + 1 MCP), got {len(results)}"
+    assert len(results) == 3, (
+        f"Expected 3 results (1 skill + 1 MCP + 1 agent), got {len(results)}"
     )
     assert all(r.valid for r in results), (
         f"Expected all results to be valid, got errors: "
@@ -327,6 +451,21 @@ def test_json_output_format(tmp_path: Path):
             "  json-test:\n"
             "    type: stdio\n"
             "    command: echo\n"
+        ),
+    )
+
+    # Create a valid agent definition.
+    _write_agent_md(
+        tmp_path,
+        "json-test.md",
+        (
+            "---\n"
+            "name: json-test\n"
+            "description: Agent for JSON output test.\n"
+            "skills:\n"
+            "  - json-test\n"
+            "---\n\n"
+            "# JSON Test Agent\n\nYou are a test agent.\n"
         ),
     )
 
@@ -371,11 +510,11 @@ def test_json_output_format(tmp_path: Path):
     assert isinstance(summary, dict), (
         f"'summary' should be a dict, got {type(summary).__name__}"
     )
-    assert summary["total"] == 2, (
-        f"Expected total=2, got {summary['total']}"
+    assert summary["total"] == 3, (
+        f"Expected total=3, got {summary['total']}"
     )
-    assert summary["passed"] == 2, (
-        f"Expected passed=2, got {summary['passed']}"
+    assert summary["passed"] == 3, (
+        f"Expected passed=3, got {summary['passed']}"
     )
     assert summary["failed"] == 0, (
         f"Expected failed=0, got {summary['failed']}"
@@ -454,6 +593,186 @@ def test_mcp_name_rejects_uppercase():
     }
     assert "name" in error_fields, (
         f"Expected a validation error for 'name', got errors for: {error_fields}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# validate_agents function tests
+# ---------------------------------------------------------------------------
+
+
+def _write_agent_md(registry_root: Path, filename: str, content: str) -> None:
+    """Helper: write an agent .md file inside registry_root/agents/."""
+    agents_dir = registry_root / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    (agents_dir / filename).write_text(content)
+
+
+def test_validate_agent_valid(tmp_path: Path):
+    """A well-formed agent .md file should pass validation with no errors."""
+    # Create skill directories that the agent references.
+    (tmp_path / "skills" / "python-dev").mkdir(parents=True)
+    (tmp_path / "skills" / "testing").mkdir(parents=True)
+
+    _write_agent_md(
+        tmp_path,
+        "good-agent.md",
+        (
+            "---\n"
+            "name: good-agent\n"
+            "description: A valid agent definition.\n"
+            "model: sonnet\n"
+            "skills:\n"
+            "  - python-dev\n"
+            "  - testing\n"
+            "---\n\n"
+            "# Good Agent\n\nYou are a helpful assistant.\n"
+        ),
+    )
+
+    results = validate_agents(tmp_path)
+
+    assert len(results) == 1, (
+        f"Expected exactly 1 result, got {len(results)}"
+    )
+    assert results[0].valid, (
+        f"Expected the result to be valid, got errors: "
+        f"{[e.message for e in results[0].errors]}"
+    )
+    assert results[0].errors == [], (
+        f"Expected no errors, got: {results[0].errors}"
+    )
+
+
+def test_validate_agent_invalid_metadata(tmp_path: Path):
+    """An agent .md with invalid metadata should produce validation errors."""
+    _write_agent_md(
+        tmp_path,
+        "bad-agent.md",
+        (
+            "---\n"
+            "name: Bad Agent!\n"
+            "description: \"\"\n"
+            "---\n\n"
+            "# Bad Agent\n\nSome content.\n"
+        ),
+    )
+
+    results = validate_agents(tmp_path)
+
+    assert len(results) == 1, (
+        f"Expected exactly 1 result, got {len(results)}"
+    )
+    assert not results[0].valid, "Expected invalid result for bad metadata"
+    error_fields = [e.field for e in results[0].errors]
+    assert "name" in error_fields, (
+        f"Expected a 'name' field error, got: {error_fields}"
+    )
+
+
+def test_validate_agent_filename_name_mismatch(tmp_path: Path):
+    """An agent file whose stem differs from the name field should fail."""
+    _write_agent_md(
+        tmp_path,
+        "wrong-file.md",
+        (
+            "---\n"
+            "name: correct-name\n"
+            "description: Filename mismatch test.\n"
+            "---\n\n"
+            "# Agent\n\nSystem prompt content.\n"
+        ),
+    )
+
+    results = validate_agents(tmp_path)
+
+    assert len(results) == 1
+    assert not results[0].valid, "Expected invalid result for filename mismatch"
+    error_fields = [e.field for e in results[0].errors]
+    assert "name" in error_fields, (
+        f"Expected a 'name' field error, got: {error_fields}"
+    )
+    error_messages = [e.message for e in results[0].errors]
+    assert any("does not match" in m for m in error_messages), (
+        f"Expected a 'does not match' error, got: {error_messages}"
+    )
+
+
+def test_validate_agent_empty_body(tmp_path: Path):
+    """An agent .md with valid front matter but an empty body should fail."""
+    _write_agent_md(
+        tmp_path,
+        "empty-body.md",
+        "---\nname: empty-body\ndescription: Agent with no body\n---\n",
+    )
+
+    results = validate_agents(tmp_path)
+
+    assert len(results) == 1, (
+        f"Expected exactly 1 result, got {len(results)}"
+    )
+    assert not results[0].valid, "Expected the result to be invalid (empty body)"
+    error_messages = [e.message for e in results[0].errors]
+    assert any("empty" in m.lower() for m in error_messages), (
+        f"Expected an 'empty' body error, got: {error_messages}"
+    )
+
+
+def test_validate_agent_missing_skill_reference(tmp_path: Path):
+    """An agent referencing a non-existent skill should produce a validation error."""
+    _write_agent_md(
+        tmp_path,
+        "bad-ref.md",
+        (
+            "---\n"
+            "name: bad-ref\n"
+            "description: References a missing skill.\n"
+            "skills:\n"
+            "  - nonexistent-skill\n"
+            "---\n\n"
+            "# Agent\n\nSystem prompt here.\n"
+        ),
+    )
+
+    results = validate_agents(tmp_path)
+
+    assert len(results) == 1
+    assert not results[0].valid, "Expected invalid result for missing skill reference"
+    error_fields = [e.field for e in results[0].errors]
+    assert "skills" in error_fields, (
+        f"Expected a 'skills' field error, got: {error_fields}"
+    )
+    error_messages = [e.message for e in results[0].errors]
+    assert any("nonexistent-skill" in m for m in error_messages), (
+        f"Expected error mentioning 'nonexistent-skill', got: {error_messages}"
+    )
+
+
+def test_validate_agent_valid_skill_reference(tmp_path: Path):
+    """An agent referencing an existing skill directory should pass."""
+    # Create the skill directory.
+    (tmp_path / "skills" / "real-skill").mkdir(parents=True)
+
+    _write_agent_md(
+        tmp_path,
+        "ref-agent.md",
+        (
+            "---\n"
+            "name: ref-agent\n"
+            "description: References an existing skill.\n"
+            "skills:\n"
+            "  - real-skill\n"
+            "---\n\n"
+            "# Agent\n\nSystem prompt content.\n"
+        ),
+    )
+
+    results = validate_agents(tmp_path)
+
+    assert len(results) == 1
+    assert results[0].valid, (
+        f"Expected the result to be valid, got errors: "
+        f"{[e.message for e in results[0].errors]}"
     )
 
 


### PR DESCRIPTION
## Summary

- Add agent capability type to the registry: metadata model, loader, search indexing, validation, and bundling endpoint
- Add `awos install agent` CLI command with frontmatter parsing and automatic skill installation for agent dependencies
- Add `publish-cli` just task and `prepublishOnly` npm script for npm publishing
- Complete spec 005 (agent support) with functional spec, tech spec, tasks, and verification

## Test plan

- [x] Server tests pass (`just test`)
- [x] CLI tests pass (`just test-cli`)
- [x] Registry validation passes (`just validate-registry`)
- [x] Manually verify `just publish-cli` workflow against npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)