### PR TITLE
Add docs-that-work skill

### DIFF
--- a/registry/skills/docs-that-work/README.md
+++ b/registry/skills/docs-that-work/README.md
@@ -5,7 +5,7 @@ A skill that teaches agents how to write project documentation that serves both 
 ## Install
 
 ```bash
-claude skill add --from awos-recruitment docs-that-work
+npx @provectusinc/awos-recruitment skill docs-that-work
 ```
 
 ## What This Skill Teaches

--- a/registry/skills/docs-that-work/README.md
+++ b/registry/skills/docs-that-work/README.md
@@ -1,0 +1,26 @@
+# docs-that-work
+
+A skill that teaches agents how to write project documentation that serves both humans and AI agents.
+
+## Install
+
+```bash
+claude skill add --from awos-recruitment docs-that-work
+```
+
+## What This Skill Teaches
+
+- **The discoverability rule** — never document what code already reveals
+- **CLAUDE.md discipline** — non-obvious context only, target <30 lines
+- **README.md structure** — executable setup steps, not prose
+- **Grey box documentation** — describe interfaces, not internals
+- **Document separation** — each file has one job, no duplication
+- **When docs ARE needed** — "why" decisions, cross-service contracts, environment gotchas
+
+## Files
+
+| File | Content |
+|---|---|
+| `SKILL.md` | Core guidelines and rules |
+| `references/claude-md-guide.md` | Templates for CLAUDE.md and README.md, decision tables |
+| `references/anti-patterns.md` | Bloat examples, discoverable content catalog, three-question test |

--- a/registry/skills/docs-that-work/SKILL.md
+++ b/registry/skills/docs-that-work/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: docs-that-work
+description: >-
+  Project documentation guidelines. Use when asked to "write documentation",
+  "create a CLAUDE.md", "write a README", "document this project",
+  "improve documentation", or when creating/updating CLAUDE.md or README.md files.
+---
+
+# Docs That Work
+
+Write documentation that serves both humans and AI agents. Core principle: **document only what cannot be discovered from code**. Codebase structure matters more than documentation volume — a well-organized project with 10 lines of docs beats a messy one with 200.
+
+## The Discoverability Rule
+
+Before writing any documentation line, ask: _"Could an agent find this by reading code or config files?"_
+
+If yes, don't write it. Directory trees, exports, types, linter rules, commands, dependencies, test locations, env var names — all discoverable from code and config files. See `references/anti-patterns.md` for the full catalog.
+
+Every line you add has a maintenance cost that compounds across every session. Stale docs cause worse decisions than no docs.
+
+## CLAUDE.md Rules
+
+**Purpose:** non-obvious context that AI agents cannot discover from code.
+
+**Content that belongs:**
+
+- Project purpose — 1-2 sentences on what this does and why
+- Undiscoverable conventions — naming patterns, architectural decisions, gotchas
+- Non-obvious constraints — "never import X from Y", "always run Z before W"
+
+**Content that does NOT belong:** anything that passes the discoverability rule — commands, directory trees, exports, types, config rules, dependency lists.
+
+**Structure:**
+
+- Root `CLAUDE.md` — project-wide context applicable everywhere
+- Service-level `CLAUDE.md` — that module's non-obvious constraints only, never repeat root content
+
+**Size:** target <30 lines. If you're past 50 lines, it's bloated. Cut ruthlessly.
+
+See `references/claude-md-guide.md` for templates and examples.
+
+## README.md Rules
+
+**Purpose:** human onboarding — get someone from zero to productive.
+
+**Content:** project description, prerequisites, setup, how to run, how to test, how to contribute. Keep it executable — commands that copy-paste and work beat prose.
+
+Root `README.md` = full overview + setup. Service-level = purpose + how to run independently. Don't duplicate `CLAUDE.md` content — different audiences, different purposes.
+
+## Grey Box Documentation
+
+Every module is a grey box — clear public API, hidden internals. Documentation describes the **interface** (what it does, constraints, gotchas), NOT the **implementation** (file trees, data flow, internal functions).
+
+Progressive disclosure: import from public API → read docs for context → read source only if needed.
+
+You own the interface. AI owns the implementation. Tests keep it honest. If docs describe internal wiring, they couple consumers to implementation and break on every refactor.
+
+## Document Separation
+
+Each document has exactly one job:
+
+| Document          | Job                     |
+| ----------------- | ----------------------- |
+| `README.md`       | Human onboarding        |
+| `CLAUDE.md`       | AI agent context        |
+| Architecture docs | System design decisions |
+| API docs          | Endpoint contracts      |
+
+Never duplicate between them. If the same info is in two places, delete the copy in the wrong file.
+
+## When Documentation IS Needed
+
+Some things genuinely need docs because no amount of code reading reveals them:
+
+- **"Why" decisions** — architectural rationale, trade-off reasoning
+- **Cross-service contracts** — agreements not enforced by types or schemas
+- **Environment gotchas** — WSL quirks, VPN requirements, OS-specific steps
+- **Historical context** — past decisions constraining current design
+- **Security procedures** — auth flows, key rotation, access patterns
+- **Non-obvious flags** — env vars or CLI flags with surprising behavior
+
+If you're unsure whether something needs docs, apply the three-question test from `references/anti-patterns.md`.
+
+## Deep Dives
+
+| Topic                                                  | Reference                       |
+| ------------------------------------------------------ | ------------------------------- |
+| CLAUDE.md and README templates                         | `references/claude-md-guide.md` |
+| Anti-patterns, bloat examples, the three-question test | `references/anti-patterns.md`   |

--- a/registry/skills/docs-that-work/references/anti-patterns.md
+++ b/registry/skills/docs-that-work/references/anti-patterns.md
@@ -1,0 +1,97 @@
+# Documentation Anti-Patterns
+
+How to recognize and avoid documentation bloat.
+
+## Bloated CLAUDE.md: Before & After
+
+### Before (bloated)
+
+```markdown
+# MyApp — A Next.js e-commerce application.
+
+## Directory Structure
+- `src/components/` — React components
+- `src/components/ui/` — Shared UI primitives
+- `src/lib/` — Utility functions
+- `src/hooks/` — Custom React hooks
+- `src/types/` — TypeScript type definitions
+
+## Exports
+- `Button`, `Input`, `Modal` from `components/ui`
+- `useAuth`, `useCart` from `hooks/`
+
+## Types
+- `User` — { id, name, email, role }
+- `Product` — { id, title, price, stock }
+
+## Dependencies
+- next 14.1, react 18, tailwindcss 3.4, prisma 5.8
+
+## Linting
+- ESLint with next/core-web-vitals
+- Prettier with single quotes, no semicolons
+
+## Commands
+- `npm run dev` / `npm run build` / `npm test` / `npm run lint`
+```
+
+### After (correct)
+
+```markdown
+# Purpose
+
+E-commerce storefront. Handles product browsing, cart, and checkout. Payments delegate to the billing service via internal API.
+
+# Conventions
+
+- All pages use the `AppLayout` wrapper — never render a page without it
+- Cart state lives in Zustand store, NOT React context — previous migration was partial, don't reintroduce context
+- Prices are stored as integers (cents) everywhere — never use floats for money
+- `npm run dev` requires `docker compose up db` first
+```
+
+Everything removed was discoverable. Everything kept requires human knowledge.
+
+## Catalog of Discoverable Content
+
+| Pattern | Why It's Discoverable | What an Agent Does Instead |
+|---|---|---|
+| Directory trees | `glob` or `ls` | Scans the filesystem |
+| Exports / public API | Read `index.ts` or `__init__.py` | Reads entry point files |
+| Type definitions | Read source files | Reads the type/interface definitions |
+| Linter rules | Read `.eslintrc`, `ruff.toml`, etc. | Reads config files |
+| Test file locations | `glob` for `*.test.*` or `tests/` | Searches for test patterns |
+| Dependencies | Read `package.json`, `pyproject.toml` | Reads manifest files |
+| Env var names | Read `.env.example` or `.env.template` | Reads env template |
+| Script commands | Read `package.json` scripts or `justfile` | Reads task runner config |
+| CI pipeline steps | Read `.github/workflows/` | Reads CI config |
+
+If it's in a file an agent can read, it doesn't need documentation.
+
+## The Three-Question Test
+
+Before adding any line to documentation, ask:
+
+1. **Could an agent find this by reading a config file?**
+2. **Could an agent find this by reading source code?**
+3. **Could an agent find this by running a standard command?**
+
+If any answer is **yes**, don't write it.
+
+### Examples
+
+- "All tests are in `__tests__/`" → `glob` finds them. **Don't write it.**
+- "Prices are cents (integers), never floats" → no config or code pattern reveals this convention. **Write it.**
+- "We use ESLint with airbnb config" → it's in `.eslintrc`. **Don't write it.**
+
+## Common Mistakes
+
+When asked to "document the project," agents typically:
+
+1. **Dump the init output** — list every file, directory, and config from the project root
+2. **Mirror the filesystem** — reproduce the directory tree as a markdown list
+3. **Copy type definitions** — paste interfaces and types into docs
+4. **Write a novel** — produce 200+ line CLAUDE.md files that no agent will fully process
+5. **Duplicate across files** — put the same commands in README, CLAUDE.md, and CONTRIBUTING.md
+
+Recognize these patterns. When you catch yourself doing any of them, stop and apply the three-question test to every line.

--- a/registry/skills/docs-that-work/references/claude-md-guide.md
+++ b/registry/skills/docs-that-work/references/claude-md-guide.md
@@ -1,0 +1,116 @@
+# CLAUDE.md & README Templates
+
+Concrete templates and decision guides for project documentation.
+
+## Root CLAUDE.md Template
+
+```markdown
+# Purpose
+
+[1-2 sentences: what this project does and why it exists]
+
+# Conventions
+
+- [Convention that cannot be discovered from config files]
+- [Gotcha that has bitten people before]
+- [Non-obvious constraint on how modules interact]
+```
+
+### Example: Backend API Service
+
+```markdown
+# Purpose
+
+Order processing API for the warehouse system. Receives orders from the storefront, validates inventory, and dispatches to fulfillment.
+
+# Conventions
+
+- All API responses wrap payload in `{"data": ...}` envelope — no bare objects
+- Never import from `internal/` packages outside their parent module
+- Migration files are manually numbered (not auto-generated) — check latest before creating
+- `just dev` requires local Postgres running first (`just db-up`)
+```
+
+Commands like `just dev`, `just test`, `just lint` are discoverable from the justfile — only the non-obvious prerequisite gotcha is documented.
+
+## Service-Level CLAUDE.md Template
+
+```markdown
+# Purpose
+
+[1 sentence: what this service/module does within the larger system]
+
+# Non-Obvious Context
+
+- [Constraint specific to this module]
+- [Gotcha that only applies here]
+```
+
+### Example: Payment Module
+
+```markdown
+# Purpose
+
+Handles payment processing via Stripe — wraps the Stripe SDK and enforces idempotency.
+
+# Non-Obvious Context
+
+- All Stripe calls must include an idempotency key — the helper in `utils.py` generates one from order ID
+- Webhook signature verification uses a different API key than charge creation (see env vars)
+```
+
+Rule: never repeat root-level content. If it applies project-wide, it goes in root `CLAUDE.md`.
+
+## README.md Template
+
+Structure: title, description, prerequisites, setup, run, test, contribute. Every section should contain commands that copy-paste and work.
+
+```markdown
+# Warehouse API
+
+Order processing API for the warehouse fulfillment system.
+
+## Prerequisites
+
+- Python >= 3.12
+- Docker (for local Postgres)
+
+## Setup
+
+\`\`\`bash
+just install
+just db-up
+\`\`\`
+
+## Run / Test
+
+\`\`\`bash
+just dev # start dev server
+just test # run pytest
+\`\`\`
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md).
+```
+
+## Root vs Service-Level Decision
+
+| If the content...                        | Put it in...                                   |
+| ---------------------------------------- | ---------------------------------------------- |
+| Applies to >1 service or the whole repo  | Root `CLAUDE.md`                               |
+| Is specific to one service/module        | Service-level `CLAUDE.md`                      |
+| Contradicts or narrows a root convention | Service-level `CLAUDE.md` (with explicit note) |
+
+When unsure, put it in root. Easier to push down later than to discover missing context scattered across services.
+
+## What Belongs Where
+
+| Content Type | CLAUDE.md | README | Architecture Doc | Neither (Discoverable) |
+|---|---|---|---|---|
+| Project purpose | 1-2 sentences | Full description | - | - |
+| Setup / run / test commands | - | Yes | - | Discoverable from task runner |
+| Non-obvious gotchas | Yes | - | - | - |
+| Naming conventions | Only if not in linter | - | - | If in linter config |
+| Architecture / API contracts | - | - | Yes | - |
+| Dir trees, types, deps, env names | - | - | - | Always discoverable |


### PR DESCRIPTION
## Summary

- Adds `docs-that-work` skill teaching agents to write lean documentation for both humans and AI agents
- Core principle: document only what cannot be discovered from code
- Includes CLAUDE.md and README templates, anti-pattern catalog, and three-question test for evaluating documentation lines

## Files

| File | Lines | Content |
|---|---|---|
| `SKILL.md` | 89 | Core guidelines — discoverability rule, CLAUDE.md rules, README rules, grey box docs, document separation |
| `references/claude-md-guide.md` | 116 | Templates, root-vs-service decision table, what-belongs-where matrix |
| `references/anti-patterns.md` | 97 | Before/after bloat example, discoverable content catalog, three-question test |
| `README.md` | 26 | Install command, skill overview, file table |

## Test plan

- [x] `just validate-registry` passes (all 6 entries valid)
- [x] Total lines: 328 (under 400 target)
- [x] No directory trees, export lists, or type definitions in own docs
- [x] Anti-patterns "After" example practices what it preaches (no commands section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)