### PR TITLE
Add shadcn MCP server to registry

### DIFF
--- a/registry/mcp/shadcn.yaml
+++ b/registry/mcp/shadcn.yaml
@@ -1,0 +1,9 @@
+name: "shadcn"
+description: "Browse, search, and install shadcn/ui components and blocks. Works with any shadcn-compatible registry."
+config:
+  shadcn:
+    type: stdio
+    command: npx
+    args:
+      - shadcn@latest
+      - mcp


### PR DESCRIPTION
## Summary

- Add official [shadcn MCP server](https://ui.shadcn.com/docs/mcp) to `registry/mcp/`
- Enables browsing, searching, and installing shadcn/ui components and blocks
- Works with any shadcn-compatible registry

## Test plan

- [ ] Install via `npx @provectusinc/awos-recruitment mcp shadcn`
- [ ] Verify `just validate-registry` passes
- [ ] Confirm MCP server starts and responds to tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)