### PR TITLE
Add CI workflow for registry validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,19 @@
+name: Validate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Validate registry
+        run: cd server && uv run python -m awos_recruitment_mcp.validate
+
+      - name: Run tests
+        run: cd server && uv run pytest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.12"
 
       - name: Validate registry
         run: cd server && uv run python -m awos_recruitment_mcp.validate

--- a/registry/skills/react-feature-sliced-design/SKILL.md
+++ b/registry/skills/react-feature-sliced-design/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: react-fsd
+name: react-feature-sliced-design
 description: This skill should be used when the user asks to "create a page", "add an entity", "build a widget", "create a feature", "scaffold FSD structure", "refactor to FSD", "where should I put this code", "what layer does X go in", "organize my React code", "FSD compliant", "fix layer violation", "explain FSD", "why is this in this layer", "review my FSD structure", or when writing, reviewing, or refactoring React/TypeScript code to ensure Feature-Sliced Design architecture compliance. Also triggers when the user places code in the wrong layer, imports across layers incorrectly, or breaks FSD conventions — the agent should proactively explain the violation and teach the correct approach.
 version: 3.0.0
 ---

--- a/server/tests/test_registry.py
+++ b/server/tests/test_registry.py
@@ -321,12 +321,17 @@ def test_real_registry_loads_all_capabilities() -> None:
 
     caps = load_registry(real_registry)
 
-    assert len(caps) >= 1, "Registry should not be empty"
+    assert len(caps) >= 1, "Registry should contain at least one capability"
 
     skill_caps = [c for c in caps if c.type == "skill"]
     tool_caps = [c for c in caps if c.type == "tool"]
     agent_caps = [c for c in caps if c.type == "agent"]
 
-    assert len(skill_caps) >= 1, f"Expected at least 1 skill, got {len(skill_caps)}"
-    assert len(tool_caps) >= 1, f"Expected at least 1 tool, got {len(tool_caps)}"
-    assert len(agent_caps) >= 1, f"Expected at least 1 agent, got {len(agent_caps)}"
+    assert len(skill_caps) >= 1, "Registry should contain at least one skill"
+    assert len(tool_caps) >= 1, "Registry should contain at least one tool"
+    assert len(agent_caps) >= 1, "Registry should contain at least one agent"
+
+    for cap in caps:
+        assert cap.name, "Every capability must have a name"
+        assert cap.description, "Every capability must have a description"
+        assert cap.type in ("skill", "tool", "agent"), f"Unknown type: {cap.type}"

--- a/server/tests/test_search_tool.py
+++ b/server/tests/test_search_tool.py
@@ -4,15 +4,19 @@ These are integration tests that exercise the full stack: the MCP client
 connects to the in-process server, the lifespan handler loads the real
 registry and builds a ChromaDB index, and the tool performs semantic search
 against that index.
-
-The real registry contains 4 capabilities:
-  - Skills: modern-python-development, typescript-development
-  - Tools:  context7, playwright
 """
 
 import json
+from pathlib import Path
 
 import pytest
+
+from awos_recruitment_mcp.registry import load_registry
+
+_REGISTRY_PATH = Path(__file__).resolve().parent.parent.parent / "registry"
+_ALL_CAPS = load_registry(_REGISTRY_PATH)
+_SKILL_NAMES = {c.name for c in _ALL_CAPS if c.type == "skill"}
+_TOOL_NAMES = {c.name for c in _ALL_CAPS if c.type == "tool"}
 
 
 # ---------------------------------------------------------------------------
@@ -183,11 +187,9 @@ async def test_search_type_filter_skill(mcp_client):
     parsed = _parse_result(result)
     assert isinstance(parsed, list), f"Expected a list, got: {type(parsed)}"
 
-    # The registry has 2 skills: modern-python-development, typescript-development.
-    # All returned results must be skills (names we know are skills).
-    skill_names = {"modern-python-development", "typescript-development"}
+    # All returned results must be skills.
     for item in parsed:
-        assert item["name"] in skill_names, (
+        assert item["name"] in _SKILL_NAMES, (
             f"Expected only skill names, but got: {item['name']}"
         )
 
@@ -202,10 +204,9 @@ async def test_search_type_filter_tool(mcp_client):
     parsed = _parse_result(result)
     assert isinstance(parsed, list), f"Expected a list, got: {type(parsed)}"
 
-    # The registry has 2 tools: context7, playwright.
-    tool_names = {"context7", "playwright"}
+    # All returned results must be tools.
     for item in parsed:
-        assert item["name"] in tool_names, (
+        assert item["name"] in _TOOL_NAMES, (
             f"Expected only tool names, but got: {item['name']}"
         )
 
@@ -265,8 +266,8 @@ async def test_search_unrelated_query_returns_few_or_no_results(mcp_client):
     parsed = _parse_result(result)
     assert isinstance(parsed, list), f"Expected a list, got: {type(parsed)}"
 
-    # With a threshold of 20 and only 4 capabilities in the registry about
-    # programming topics, an unrelated query should yield very few or no results.
+    # With a threshold of 20 and a registry focused on programming topics,
+    # an unrelated query should yield very few or no results.
     assert len(parsed) <= 1, (
         f"Expected 0 or 1 results for an unrelated query, got {len(parsed)}: "
         f"{[item['name'] for item in parsed]}"


### PR DESCRIPTION
## Summary

- Adds GitHub Actions workflow that runs on PRs to `main`
- Validates all registry entries against their schemas
- Runs the server test suite

## Test plan

- [x] Verify workflow triggers on PR creation
- [x] Confirm validation and tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)