### PR TITLE
Add a skill to manage PR lifecycle

### DIFF
--- a/.claude/skills/pr-lifecycle/SKILL.md
+++ b/.claude/skills/pr-lifecycle/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: pr-lifecycle
+description: >
+  Full PR lifecycle: create PRs, monitor review feedback, fix issues, push updates.
+  Handles CodeRabbit AI "Prompt for AI Agents" blocks, human reviewer comments,
+  and CI check failures. Use when user says "pr review", "create pr", "fix pr",
+  "check pr feedback", "address review comments", "pr-lifecycle", or wants to
+  manage the PR review cycle.
+allowed-tools: Bash, Read, Grep, Glob, Agent, Edit, Write
+---
+
+# PR Lifecycle — Create, Fix, Cycle
+
+You manage the full pull request lifecycle: creating PRs, collecting review feedback, fixing issues, and pushing updates. All GitHub operations use the `gh` CLI.
+
+## Arguments
+
+Parse from user message. Three modes:
+
+- **Create**: `/pr-lifecycle create` — create a PR from the current branch
+- **Fix**: `/pr-lifecycle fix` or `/pr-lifecycle` (default) — fetch all feedback, evaluate, fix valid items, commit & push
+- **Cycle**: `/pr-lifecycle cycle` — create PR if needed, then fix in a loop until clean
+
+Optional flags:
+- `--base <branch>` — override base branch (default: `develop`)
+- `<PR number>` — target a specific PR (otherwise auto-detect from current branch)
+
+If no mode is recognized, default to **Fix**.
+
+## Setup
+
+Before any mode, resolve these values:
+
+1. **Repo**: `gh repo view --json nameWithOwner -q .nameWithOwner` → `{owner}/{repo}`
+2. **Current branch**: `git branch --show-current`
+3. **Base branch**: from `--base` flag or default `develop`
+4. **PR number** (if needed): from args or `gh pr view --json number -q .number`
+
+---
+
+## Mode: Create
+
+Create a PR from the current branch against the base branch.
+
+### Steps
+
+1. **Verify branch differs from base**
+   ```bash
+   git log {base}..HEAD --oneline
+   ```
+   If empty, stop: "No commits ahead of `{base}`. Nothing to create a PR for."
+
+2. **Gather commit info**
+   Collect commit subjects from `git log {base}..HEAD --oneline` for the PR description.
+
+3. **Generate PR title**
+   Derive a concise PR title from the branch name and commit subjects. Keep it under 70 characters.
+
+4. **Build PR body**
+   Check if the repo has a PR template (e.g. `.github/pull_request_template.md`). If found, fill it in using context from the commits. If no template exists, generate a concise body summarizing what changed and why.
+
+5. **Create the PR**
+   ```bash
+   gh pr create --base {base} --title "{title}" --body "{body}"
+   ```
+
+6. **Report** the PR URL to the user.
+
+---
+
+## Mode: Fix (default)
+
+Fetch all feedback, evaluate each item, fix valid issues, commit, and push. This is the default mode.
+
+### Step 1: Gather Feedback
+
+1. **Resolve PR number** (from args or auto-detect)
+
+2. **Check CI status**
+   ```bash
+   gh pr checks {pr_number}
+   ```
+
+3. **Fetch review comments** (inline code comments)
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --paginate
+   ```
+
+4. **Fetch general comments** (conversation-level)
+   ```bash
+   gh api repos/{owner}/{repo}/issues/{pr_number}/comments --paginate
+   ```
+
+5. **Fetch review verdicts**
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews --paginate
+   ```
+
+6. **Parse CodeRabbit comments**
+   Filter comments by user login `coderabbitai[bot]`. Extract actionable items per [resources/coderabbit-parsing.md](resources/coderabbit-parsing.md).
+
+7. **Classify all feedback** per [resources/feedback-types.md](resources/feedback-types.md).
+
+8. **Present summary table**
+   ```text
+   | # | Source | Type | File:Line | Status | Summary |
+   |---|--------|------|-----------|--------|---------|
+   | 1 | coderabbit | ai-prompt | app/db.py:15 | pending | Add error handling |
+   | 2 | @reviewer | human-comment | app/main.py:42 | pending | Use comprehension |
+   | 3 | CI | ci-failure | — | failed | ruff check failed |
+   ```
+   Group by status: failed CI first, then pending items, then resolved.
+
+If no actionable feedback exists, report "No pending feedback" and stop.
+
+### Step 2: Evaluate and Fix
+
+Process items in priority order (see [resources/feedback-types.md](resources/feedback-types.md)):
+
+**CI failures** (Critical — process first):
+- Identify the failed workflow run: `gh run list --branch {branch} -L 5 --json databaseId,status,conclusion`
+- Read failed logs: `gh run view {run_id} --log-failed`
+- Diagnose the failure from log output
+- Fix the code
+
+**CodeRabbit AI prompts** (High):
+- Extract "Prompt for AI Agents" content from the comment (see [resources/coderabbit-parsing.md](resources/coderabbit-parsing.md))
+- Read the referenced code and evaluate whether the feedback is valid
+- If the issue is real, use the extracted content as guidance for the fix
+- If the feedback is incorrect, a false positive, or conflicts with project intent, skip it
+
+**Suggestion blocks** (High — both CodeRabbit and human):
+- Extract the suggestion content from ` ```suggestion ` blocks
+- Review the suggestion against the current code and project context
+- Apply only if the suggestion is correct and improves the code
+- Skip or adapt if the suggestion would break functionality or misunderstands intent
+
+**Human comments** (High):
+- Read the comment and the referenced code
+- Evaluate what change is requested and whether it makes sense
+- Apply the appropriate code modification if the feedback is valid
+
+**General comments** (Medium):
+- Assess whether a code change is needed
+- If yes and the feedback is valid, apply the fix
+- If purely conversational (praise, acknowledgment) or not applicable, skip
+
+### Step 3: Cleanup, Commit, Push
+
+1. **Post-fix cleanup**
+   Run the project's configured linter and formatter (check the project's package manager and tooling config files to determine the correct commands).
+
+2. **Commit and push**
+   - Stage only changed files by name (never `git add -A` or `git add .`)
+   - Commit with descriptive message:
+     ```text
+     Address PR review feedback
+
+     - Fix: {description of fix 1}
+     - Fix: {description of fix 2}
+     - Skip: {description of skipped item} — {reason}
+     ```
+   - Push to the current branch:
+     ```bash
+     git push
+     ```
+
+3. **Reply to addressed comments**
+   For each addressed review comment thread, post a reply:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
+     -f body="Fixed in $(git rev-parse --short HEAD)."
+   ```
+   For general issue comments, reply:
+   ```bash
+   gh api repos/{owner}/{repo}/issues/{pr_number}/comments \
+     -f body="Addressed in $(git rev-parse --short HEAD)."
+   ```
+
+4. **Report** what was fixed, what was skipped (with reasoning), and remind the user to re-invoke for the next review round.
+
+---
+
+## Mode: Cycle
+
+Fully automated end-to-end loop: create PR if needed, wait for reviews, fix, push, repeat. No user interaction required after invocation.
+
+### Steps
+
+1. **Check for existing PR** on current branch
+   ```bash
+   gh pr view --json number 2>/dev/null
+   ```
+   If no PR exists → run **Create** mode first.
+
+2. **Wait for CodeRabbit review**
+   After PR creation or a push, CodeRabbit takes 1-3 minutes to post its review.
+   Launch a background poll using Bash with `run_in_background: true`:
+   ```bash
+   OWNER_REPO="{owner}/{repo}"
+   PR={pr_number}
+   SINCE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+   for i in $(seq 1 20); do
+     sleep 30
+     # Check for new review comments since our last push
+     COUNT=$(gh api "repos/${OWNER_REPO}/pulls/${PR}/comments?since=${SINCE}" -q 'length')
+     ISSUE_COUNT=$(gh api "repos/${OWNER_REPO}/issues/${PR}/comments?since=${SINCE}" -q '[.[] | select(.user.login == "coderabbitai[bot]")] | length')
+     if [ "$COUNT" -gt 0 ] || [ "$ISSUE_COUNT" -gt 0 ]; then
+       echo "NEW_FEEDBACK_DETECTED"
+       exit 0
+     fi
+     # Also check if CodeRabbit check has completed with no inline comments
+     CR_STATUS=$(gh pr checks ${PR} 2>&1 | grep -i "CodeRabbit" | awk '{print $2}')
+     if [ "$CR_STATUS" = "pass" ]; then
+       echo "CODERABBIT_COMPLETE_NO_NEW_COMMENTS"
+       exit 0
+     fi
+   done
+   echo "POLL_TIMEOUT"
+   exit 1
+   ```
+   This polls every 30 seconds for up to 10 minutes.
+   - Do NOT sleep or poll manually — use `run_in_background` and you will be automatically notified when the task completes.
+   - While waiting, do nothing. You will be notified.
+
+3. **Process poll result**
+   When the background task completes:
+   - `NEW_FEEDBACK_DETECTED` → proceed to Fix mode
+   - `CODERABBIT_COMPLETE_NO_NEW_COMMENTS` → report "No new feedback from CodeRabbit" and stop
+   - `POLL_TIMEOUT` → report "Timed out waiting for review" and stop
+
+4. **Fix loop**
+   a. Run **Fix** mode (gather feedback, evaluate, fix valid items, push)
+   b. After push → go back to step 2 (wait for new review on the updated code)
+   c. Repeat until no new actionable feedback appears
+
+5. **Report** the final state: PR URL, all feedback addressed, CI status.
+
+### Loop guard
+- Maximum 5 fix iterations to prevent infinite loops
+- Poll timeout: 10 minutes per wait cycle
+- If feedback persists after 5 fix rounds, report remaining items and stop
+
+---
+
+## Constraints
+
+- **Never force-push** — always use regular `git push`
+- **Never dismiss reviews** without fixing the underlying issue
+- **Always run the project's linter and formatter** before committing
+- **Default base branch**: `develop` (override with `--base`)
+- **Evaluate before fixing** — never blindly apply feedback. Read the referenced code, assess whether the feedback is valid, and skip items that are false positives or conflict with project intent. Report skipped items with reasoning.
+- **Fully automated**: evaluate, fix valid feedback, commit and push without stopping for confirmation
+- **Stage specific files** — never use `git add -A` or `git add .`
+- **Auto-detect repo** from `gh repo view`
+- **Respect PR template** if the repo has one; otherwise generate a concise PR body

--- a/.claude/skills/pr-lifecycle/resources/coderabbit-parsing.md
+++ b/.claude/skills/pr-lifecycle/resources/coderabbit-parsing.md
@@ -1,0 +1,113 @@
+# CodeRabbit Comment Parsing
+
+How to identify, parse, and extract actionable content from CodeRabbit review comments.
+
+## Identifying CodeRabbit Comments
+
+Filter by user login: `coderabbitai[bot]`
+
+CodeRabbit posts two types of comments:
+1. **General comment** (issue-level) — the walkthrough summary posted once per review
+2. **Inline review comments** — file-specific feedback on individual lines
+
+## General Comment Structure (Walkthrough)
+
+The walkthrough comment is posted as an issue comment. It contains:
+
+- **Walkthrough**: High-level summary of all changes — not actionable, skip
+- **Changes**: Table of files and their change summaries — not actionable, skip
+- **Sequence Diagram** (optional): Visual flow — not actionable, skip
+- **Assessment against linked issues** (optional): How changes map to issue requirements — informational, skip
+
+**These general walkthrough comments are never actionable.** Do not attempt to "fix" anything from them.
+
+## Inline Review Comment Structure
+
+Inline comments are posted as pull request review comments on specific files/lines. These are the actionable items.
+
+Each inline comment may contain:
+
+### 1. Prompt for AI Agents (Primary — highest value)
+
+Look for an HTML `<details>` block with this pattern:
+
+```
+<details>
+<summary>Prompt for AI Agents</summary>
+
+{actionable instructions here}
+
+</details>
+```
+
+The content between `</summary>` and `</details>` contains precise, machine-readable instructions. **Use this as the primary fix instruction** — it is specifically written for AI agents and contains exact file paths, line numbers, and what to change.
+
+### 2. Suggestion Blocks
+
+Look for fenced code blocks with the `suggestion` language tag:
+
+````
+```suggestion
+{replacement code}
+```
+````
+
+These are exact code replacements. Apply them to the file and line range specified in the comment's `path` and `line`/`original_line` fields.
+
+### 3. Plain Text Feedback
+
+The comment body outside of the above blocks contains human-readable explanation. Use this for context but prefer the "Prompt for AI Agents" block when available.
+
+## Extraction Algorithm
+
+For each CodeRabbit inline comment:
+
+1. **Check for "Prompt for AI Agents"**:
+   - Search for `Prompt for AI Agents` in the body
+   - If found, extract content between `</summary>` and `</details>`
+   - Classify as `ai-prompt` type
+   - Use extracted content as fix instructions
+
+2. **Check for suggestion blocks**:
+   - Search for `` ```suggestion `` in the body
+   - If found, extract the code between the fences
+   - Classify as `ai-suggestion` type
+   - Apply as direct code replacement at the specified file:line
+
+3. **Plain feedback**:
+   - If neither of the above, treat as a general comment
+   - Classify based on content (bug report, style suggestion, question, etc.)
+   - Analyze the comment text + referenced code to determine the fix
+
+## Filtering Non-Actionable Content
+
+Skip these CodeRabbit outputs entirely:
+- The walkthrough summary comment (general issue comment with "Walkthrough" heading)
+- Lines that are purely praise ("Great job", "LGTM", "Looks good")
+- Status update comments ("Finished review", "Review complete")
+- Comments that are replies/acknowledgments to human responses
+
+## Example: Extracting from a Real Comment
+
+Given a comment body like:
+```text
+There's a potential `None` reference on line 42. The `user` variable
+could be `None` if the query returns no results.
+
+<details>
+<summary>Prompt for AI Agents</summary>
+
+In `app/services/user_service.py` at line 42, add a None check for the
+`user` variable before accessing its attributes. Replace:
+  result = user.name
+With:
+  result = user.name if user else "Unknown"
+
+</details>
+```
+
+Extract:
+- **Type**: `ai-prompt`
+- **File**: `app/services/user_service.py`
+- **Line**: 42
+- **Instructions**: The full content from the Prompt for AI Agents block

--- a/.claude/skills/pr-lifecycle/resources/feedback-types.md
+++ b/.claude/skills/pr-lifecycle/resources/feedback-types.md
@@ -1,0 +1,90 @@
+# Feedback Classification & Handling Rules
+
+How to classify PR feedback items and determine handling priority.
+
+## Classification Matrix
+
+| Type | Source | Priority | Identifier | Handling |
+|------|--------|----------|------------|----------|
+| `ci-failure` | CI checks | Critical | `gh pr checks` shows failure | Read logs, diagnose, fix code |
+| `ai-prompt` | CodeRabbit | High | Comment contains `Prompt for AI Agents` | Use extracted prompt as fix instructions |
+| `ai-suggestion` | CodeRabbit | High | Comment contains `` ```suggestion `` block | Apply exact code replacement |
+| `human-suggestion` | Reviewer | High | Comment contains `` ```suggestion `` block | Apply exact code replacement |
+| `human-comment` | Reviewer | High | Inline review comment on specific code | Analyze comment + code, apply fix |
+| `human-general` | Reviewer | Medium | General PR comment (not inline) | Assess if code change needed |
+
+## Priority Order for Fix Mode
+
+Process feedback in this order:
+
+1. **CI failures** — fix these first since broken CI blocks everything
+2. **CodeRabbit AI prompts** — precise instructions, quick to apply
+3. **Suggestion blocks** (CodeRabbit or human) — exact replacements, apply directly
+4. **Human inline comments** — require analysis but are on specific code
+5. **Human general comments** — may or may not require code changes
+
+## Handling Rules by Type
+
+### `ci-failure` (Critical)
+
+1. Get the failed run ID from `gh run list`
+2. Read logs: `gh run view {run_id} --log-failed`
+3. Common failure categories:
+   - **Lint/format**: Run the project's linter and formatter to fix style issues
+   - **Tests**: Read test output, fix failing test or underlying code
+   - **Build/deploy**: Check build config files for syntax errors or misconfigurations
+4. Fix the root cause, not just the symptom
+
+### `ai-prompt` (High)
+
+1. Extract the "Prompt for AI Agents" content (see [coderabbit-parsing.md](coderabbit-parsing.md))
+2. Read the referenced code and understand the current implementation
+3. Evaluate whether the feedback identifies a real issue — the prompt is high-signal guidance but not infallible
+4. If valid: apply the fix, using the prompt as guidance
+5. If invalid (false positive, conflicts with project intent, or already handled): skip and note why
+
+### `ai-suggestion` / `human-suggestion` (High)
+
+1. Extract code from the `` ```suggestion `` block
+2. Identify the target file and line range from the comment metadata
+3. Read the current code at that location
+4. Evaluate whether the suggestion is correct and improves the code
+5. If valid: apply the replacement
+6. If the suggestion would break functionality, misunderstands intent, or is unnecessary: skip or adapt
+
+### `human-comment` (High)
+
+1. Read the full comment text
+2. Read the referenced code (file + line from the comment metadata)
+3. Understand what the reviewer is asking for:
+   - **Style change**: Refactor as requested (rename, restructure, simplify)
+   - **Bug report**: Fix the identified issue
+   - **Missing handling**: Add the requested error handling, edge case, etc.
+   - **Question**: If purely a question with no implied change, skip (reply only)
+4. Apply the appropriate code modification
+
+### `human-general` (Medium)
+
+1. Read the comment in the context of the overall PR
+2. Determine if it implies a code change:
+   - **Yes**: Identify what needs to change and apply
+   - **No**: Skip (it's conversational — praise, acknowledgment, discussion)
+3. Comments like "Can you also add..." or "What about..." typically need action
+4. Comments like "LGTM", "Looks good", "Thanks" do not need action
+
+## Skipping Rules
+
+Do NOT attempt to fix:
+- Resolved review threads (already addressed)
+- Bot status comments ("Review complete", "CI passed")
+- Purely conversational comments (praise, acknowledgments)
+- Comments that are your own replies from previous fix rounds
+- CodeRabbit walkthrough summary (the general issue comment with file tables)
+
+## Status Tracking
+
+When presenting feedback in the summary table, use these statuses:
+- `pending` — actionable item not yet addressed
+- `fixed` — addressed in the current or a previous fix round
+- `skipped` — non-actionable (conversational, resolved, or bot status)
+- `failed` — CI check is failing

--- a/.claude/skills/pr-lifecycle/resources/gh-commands.md
+++ b/.claude/skills/pr-lifecycle/resources/gh-commands.md
@@ -1,0 +1,155 @@
+# gh CLI Commands Reference
+
+Exact commands for each PR lifecycle operation. All commands assume `gh` is authenticated and the current directory is within the repo.
+
+## Repo & Branch Info
+
+```bash
+# Get owner/repo
+gh repo view --json nameWithOwner -q .nameWithOwner
+
+# Current branch
+git branch --show-current
+
+# Commits ahead of base
+git log {base}..HEAD --oneline
+```
+
+## PR Detection & Creation
+
+```bash
+# Check if PR exists for current branch
+gh pr view --json number -q .number 2>/dev/null
+
+# Create PR
+gh pr create --base {base} --title "{title}" --body "{body}"
+
+# View PR details
+gh pr view {pr_number} --json number,title,state,url,headRefName,baseRefName
+```
+
+## CI Checks
+
+```bash
+# List check status for a PR
+gh pr checks {pr_number}
+
+# List recent workflow runs on the branch
+gh run list --branch {branch} -L 5 --json databaseId,status,conclusion,name
+
+# Read failed run logs
+gh run view {run_id} --log-failed
+```
+
+## Review Comments (Inline Code Comments)
+
+```bash
+# Fetch all inline review comments (paginated)
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --paginate
+
+# Reply to a review comment thread
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
+  -f body="{message}"
+```
+
+Response fields of interest:
+- `id` — comment ID (for replies)
+- `user.login` — author (check for `coderabbitai[bot]`)
+- `body` — comment text
+- `path` — file path
+- `line` / `original_line` — line number
+- `diff_hunk` — surrounding diff context
+- `in_reply_to_id` — parent comment ID (if this is a reply)
+
+## General PR Comments (Issue-Level)
+
+```bash
+# Fetch all general comments (paginated)
+gh api repos/{owner}/{repo}/issues/{pr_number}/comments --paginate
+
+# Post a general comment
+gh api repos/{owner}/{repo}/issues/{pr_number}/comments \
+  -f body="{message}"
+```
+
+Response fields of interest:
+- `id` — comment ID
+- `user.login` — author
+- `body` — comment text
+
+## Reviews (Approve/Request Changes Verdicts)
+
+```bash
+# Fetch all reviews
+gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews --paginate
+```
+
+Response fields of interest:
+- `user.login` — reviewer
+- `state` — `APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`, `DISMISSED`
+- `body` — review summary text
+
+## Resolving Review Threads (GraphQL)
+
+```bash
+# Resolve a review thread by thread ID
+gh api graphql -f query='
+  mutation {
+    resolveReviewThread(input: {threadId: "{thread_id}"}) {
+      thread { isResolved }
+    }
+  }
+'
+```
+
+To get thread IDs, query via GraphQL:
+```bash
+gh api graphql -f query='
+  query {
+    repository(owner: "{owner}", name: "{repo}") {
+      pullRequest(number: {pr_number}) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            comments(first: 1) {
+              nodes { body author { login } }
+            }
+          }
+        }
+      }
+    }
+  }
+'
+```
+
+## Polling for New Feedback (Cycle Mode)
+
+After creating a PR or pushing fixes, poll for new CodeRabbit review comments.
+
+```bash
+# Get current UTC timestamp (use as "since" filter)
+SINCE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Check for new inline review comments since timestamp
+gh api "repos/{owner}/{repo}/pulls/{pr_number}/comments?since=${SINCE}" -q 'length'
+
+# Check for new general comments from CodeRabbit since timestamp
+gh api "repos/{owner}/{repo}/issues/{pr_number}/comments?since=${SINCE}" \
+  -q '[.[] | select(.user.login == "coderabbitai[bot]")] | length'
+
+# Check CodeRabbit check status
+gh pr checks {pr_number} 2>&1 | grep -i "CodeRabbit" | awk '{print $2}'
+```
+
+## Useful Filters
+
+```bash
+# Filter review comments to only unresolved (not part of a resolved thread)
+# There is no direct REST filter — use GraphQL reviewThreads above
+
+# Filter comments by author
+# Post-process JSON: jq '.[] | select(.user.login == "coderabbitai[bot]")'
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --paginate \
+  -q '.[] | select(.user.login == "coderabbitai[bot]")'
+```


### PR DESCRIPTION
Adds a skill that allows Claude Code to open PRs with the correct description, continuously monitor the PR for feedback (including CodeRabbit) and CI failures, evaluating them and fixing when appropriate