### PR TITLE
Add aws-docs MCP server to registry

### DIFF
--- a/registry/mcp/aws-docs.yaml
+++ b/registry/mcp/aws-docs.yaml
@@ -1,0 +1,8 @@
+name: "aws-docs"
+description: "Provides access to AWS documentation with search, content reading, and recommendations for related content."
+config:
+  aws-docs:
+    type: stdio
+    command: uvx
+    args:
+      - "awslabs.aws-documentation-mcp-server@latest"


### PR DESCRIPTION
## Summary
- Add `aws-docs` MCP definition for the AWS Documentation MCP server (`awslabs.aws-documentation-mcp-server`)
- Provides search, content reading, and recommendations for AWS documentation

## Test plan
- [x] `validate-registry` passes
- [ ] Install via `npx @provectusinc/awos-recruitment mcp aws-docs` and verify `.mcp.json` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)