### PR TITLE
Add fastapi-best-practices skill to registry

### DIFF
--- a/registry/skills/fastapi-best-practices/README.md
+++ b/registry/skills/fastapi-best-practices/README.md
@@ -1,0 +1,39 @@
+# FastAPI Best Practices
+
+Opinionated conventions for building production FastAPI applications — async routing, dependency injection, Pydantic integration, domain-based project structure, testing, and operational patterns.
+
+> This skill is based on [zhanymkanov/fastapi-best-practices](https://github.com/zhanymkanov/fastapi-best-practices). Big thanks to the author for the foundational work.
+
+## Install
+
+```bash
+npx @provectusinc/awos-recruitment skill fastapi-best-practices
+```
+
+## Scope
+
+Covers FastAPI-specific patterns only. General Python best practices (naming, type hints, error handling, dataclasses, project layout) are handled by the companion `modern-python-development` skill.
+
+This skill teaches:
+
+- **Async routing** — when to use `async def` vs `def`, event loop blocking, CPU-bound offloading
+- **Dependency injection** — validation via dependencies, chaining, caching, auth/pagination patterns
+- **Pydantic integration** — custom base models, split BaseSettings, response serialization gotchas
+- **Project structure** — domain-based module layout with standard file conventions
+- **Database conventions** — table naming, index naming, SQL-first approach, Alembic migrations
+- **Testing** — async test client setup from day one
+- **API documentation** — hiding docs in production, endpoint documentation
+
+## Files
+
+| File | Content |
+|---|---|
+| `SKILL.md` | Quick reference index — categories, rules, and pointers to references |
+| `references/async-patterns.md` | Async vs sync routes, threadpool caveats, CPU-bound tasks, `run_in_threadpool`, decision matrix |
+| `references/dependencies.md` | Validation via DI, chaining, caching, auth guards, pagination, DB session patterns |
+| `references/pydantic-patterns.md` | Custom base model, BaseSettings splitting, response serialization, ValueError gotcha, schema design |
+| `references/project-conventions.md` | Domain module layout, DB naming, Alembic migrations, API docs config, testing, linting |
+
+## Usage
+
+Once installed, the skill activates automatically when Claude Code detects FastAPI-related tasks — writing route handlers, reviewing async patterns, setting up dependencies, or configuring Pydantic schemas.

--- a/registry/skills/fastapi-best-practices/SKILL.md
+++ b/registry/skills/fastapi-best-practices/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: fastapi-best-practices
+description: >-
+  FastAPI best practices and conventions. Use when writing, reviewing, or refactoring
+  FastAPI applications — route handlers, Pydantic schemas, dependency injection,
+  project structure, async patterns, testing, or API documentation. Triggers on tasks
+  involving FastAPI routers, endpoints, request validation, response models, or
+  application configuration. Does not cover general Python syntax or typing — see
+  modern-python-development for that.
+version: 0.1.0
+---
+
+# FastAPI Best Practices
+
+Opinionated conventions for building production FastAPI applications. Covers project layout, async routing, Pydantic usage, dependency injection, REST design, testing, and operational concerns. General Python idioms (naming, type hints, error handling, dataclasses) are covered by the `modern-python-development` skill — this skill focuses on FastAPI-specific patterns.
+
+## Project Structure
+
+Organize code by **domain**, not by file type. Each domain package follows a standard module layout.
+
+```
+src/
+├── auth/
+│   ├── router.py        # API endpoints
+│   ├── schemas.py       # Pydantic request/response models
+│   ├── models.py        # Database models
+│   ├── service.py       # Business logic
+│   ├── dependencies.py  # Route dependencies
+│   ├── config.py        # Domain-specific env vars (BaseSettings)
+│   ├── constants.py     # Constants and error codes
+│   ├── exceptions.py    # Domain-specific exceptions
+│   └── utils.py         # Non-business helpers
+├── posts/
+│   └── ...              # Same module pattern
+├── config.py            # Global configuration
+├── models.py            # Shared DB models
+├── exceptions.py        # Global exception handlers
+├── database.py          # DB connection setup
+└── main.py              # FastAPI app initialization
+```
+
+### Import convention
+
+Use explicit module names when importing across domains:
+
+```python
+from src.auth import constants as auth_constants
+from src.notifications import service as notification_service
+```
+
+## Async Routes
+
+### Rules
+
+| Route type | When to use | How it runs |
+|---|---|---|
+| `async def` | Non-blocking I/O only (`await` calls) | Directly on the event loop |
+| `def` (sync) | Blocking I/O (sync DB drivers, file I/O) | Automatically in a threadpool |
+| CPU-intensive | Heavy computation, data processing | Offload to Celery / multiprocessing |
+
+### Critical mistake — blocking in async routes
+
+```python
+# WRONG — blocks the entire event loop
+@router.get("/bad")
+async def bad():
+    time.sleep(10)
+    return {"done": True}
+
+# CORRECT — sync route runs in threadpool
+@router.get("/good")
+def good():
+    time.sleep(10)
+    return {"done": True}
+
+# CORRECT — non-blocking async
+@router.get("/best")
+async def best():
+    await asyncio.sleep(10)
+    return {"done": True}
+```
+
+### Sync libraries in async context
+
+```python
+from fastapi.concurrency import run_in_threadpool
+
+@router.get("/")
+async def call_sync_lib():
+    result = await run_in_threadpool(sync_client.make_request, data=my_data)
+    return result
+```
+
+For detailed async patterns including threadpool caveats and CPU-bound guidance, see `references/async-patterns.md`.
+
+## Pydantic
+
+### Leverage built-in validators
+
+```python
+from pydantic import BaseModel, EmailStr, Field
+
+class UserCreate(BaseModel):
+    username: str = Field(min_length=1, max_length=128, pattern="^[A-Za-z0-9-_]+$")
+    email: EmailStr
+    age: int = Field(ge=18)
+```
+
+### Custom base model for consistent serialization
+
+```python
+from pydantic import BaseModel, ConfigDict
+
+class CustomModel(BaseModel):
+    model_config = ConfigDict(
+        json_encoders={datetime: datetime_to_gmt_str},
+        populate_by_name=True,
+    )
+```
+
+### Split BaseSettings by domain
+
+```python
+# src/auth/config.py
+from pydantic_settings import BaseSettings
+
+class AuthConfig(BaseSettings):
+    JWT_ALG: str
+    JWT_SECRET: str
+    JWT_EXP: int = 5
+
+auth_settings = AuthConfig()
+```
+
+For response serialization gotchas, ValueError behavior, and more Pydantic patterns, see `references/pydantic-patterns.md`.
+
+## Dependencies
+
+Use dependencies for **request validation**, not just DI:
+
+```python
+async def valid_post_id(post_id: UUID4) -> dict[str, Any]:
+    post = await service.get_by_id(post_id)
+    if not post:
+        raise PostNotFound()
+    return post
+
+@router.get("/posts/{post_id}")
+async def get_post(post: dict[str, Any] = Depends(valid_post_id)):
+    return post
+```
+
+### Key rules
+
+- **Chain dependencies** to compose validation logic without repetition
+- **Dependencies are cached per request** — the same dependency called multiple times executes once
+- **Prefer `async` dependencies** to avoid unnecessary threadpool overhead
+- Use consistent path variable names across routes to enable dependency reuse
+
+For dependency chaining, caching behavior, and advanced patterns, see `references/dependencies.md`.
+
+## REST Conventions
+
+- Use consistent path variable names for dependency reuse across routes
+- Rename path variables to match shared dependencies when semantically equivalent
+
+```python
+# Both use profile_id — shared valid_profile_id dependency works for both
+GET /profiles/{profile_id}
+GET /creators/{profile_id}  # creator is a profile, so reuse profile_id
+```
+
+## API Documentation
+
+### Hide docs in production
+
+```python
+SHOW_DOCS_ENVIRONMENT = ("local", "staging")
+
+app_configs = {"title": "My API"}
+if ENVIRONMENT not in SHOW_DOCS_ENVIRONMENT:
+    app_configs["openapi_url"] = None
+
+app = FastAPI(**app_configs)
+```
+
+### Document endpoints properly
+
+```python
+@router.post(
+    "/endpoints",
+    response_model=DefaultResponseModel,
+    status_code=status.HTTP_201_CREATED,
+    description="Description of the endpoint",
+    tags=["Category"],
+    responses={
+        status.HTTP_201_CREATED: {"model": CreatedResponse},
+        status.HTTP_400_BAD_REQUEST: {"model": ErrorResponse},
+    },
+)
+```
+
+## Testing
+
+Use an async test client from day one to avoid event loop conflicts:
+
+```python
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+@pytest.fixture
+async def client():
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+@pytest.mark.asyncio
+async def test_create_post(client: AsyncClient):
+    resp = await client.post("/posts")
+    assert resp.status_code == 201
+```
+
+## Quick Reference
+
+| Scenario | Solution |
+|---|---|
+| Non-blocking I/O | `async def` route with `await` |
+| Blocking I/O | `def` route (sync, runs in threadpool) |
+| Sync library in async | `run_in_threadpool()` |
+| CPU-intensive work | Celery or multiprocessing |
+| Request validation with DB | Dependencies, not Pydantic validators |
+| Shared validation logic | Chain dependencies |
+| Config per domain | Separate `BaseSettings` subclasses |
+| Complex DB queries | SQL-first with JSON aggregation |
+| Docs in production | Set `openapi_url=None` |
+
+## Reference Files
+
+For detailed guidance beyond this overview, consult:
+- **`references/async-patterns.md`** — Async vs sync routes, event loop blocking, CPU-bound tasks, `run_in_threadpool`
+- **`references/dependencies.md`** — Dependency chaining, caching, validation patterns, auth flows
+- **`references/pydantic-patterns.md`** — Custom base model, BaseSettings, response serialization, ValueError gotcha
+- **`references/project-conventions.md`** — DB naming, Alembic migrations, linting, detailed project structure

--- a/registry/skills/fastapi-best-practices/SKILL.md
+++ b/registry/skills/fastapi-best-practices/SKILL.md
@@ -12,234 +12,82 @@ version: 0.1.0
 
 # FastAPI Best Practices
 
-Opinionated conventions for building production FastAPI applications. Covers project layout, async routing, Pydantic usage, dependency injection, REST design, testing, and operational concerns. General Python idioms (naming, type hints, error handling, dataclasses) are covered by the `modern-python-development` skill — this skill focuses on FastAPI-specific patterns.
+Opinionated conventions for building production FastAPI applications. General Python idioms (naming, type hints, error handling, dataclasses) are covered by `modern-python-development` — this skill focuses on FastAPI-specific patterns.
 
-## Project Structure
+## Categories
 
-Organize code by **domain**, not by file type. Each domain package follows a standard module layout.
-
-```
-src/
-├── auth/
-│   ├── router.py        # API endpoints
-│   ├── schemas.py       # Pydantic request/response models
-│   ├── models.py        # Database models
-│   ├── service.py       # Business logic
-│   ├── dependencies.py  # Route dependencies
-│   ├── config.py        # Domain-specific env vars (BaseSettings)
-│   ├── constants.py     # Constants and error codes
-│   ├── exceptions.py    # Domain-specific exceptions
-│   └── utils.py         # Non-business helpers
-├── posts/
-│   └── ...              # Same module pattern
-├── config.py            # Global configuration
-├── models.py            # Shared DB models
-├── exceptions.py        # Global exception handlers
-├── database.py          # DB connection setup
-└── main.py              # FastAPI app initialization
-```
-
-### Import convention
-
-Use explicit module names when importing across domains:
-
-```python
-from src.auth import constants as auth_constants
-from src.notifications import service as notification_service
-```
-
-## Async Routes
-
-### Rules
-
-| Route type | When to use | How it runs |
+| Category | Impact | Reference |
 |---|---|---|
-| `async def` | Non-blocking I/O only (`await` calls) | Directly on the event loop |
-| `def` (sync) | Blocking I/O (sync DB drivers, file I/O) | Automatically in a threadpool |
-| CPU-intensive | Heavy computation, data processing | Offload to Celery / multiprocessing |
-
-### Critical mistake — blocking in async routes
-
-```python
-# WRONG — blocks the entire event loop
-@router.get("/bad")
-async def bad():
-    time.sleep(10)
-    return {"done": True}
-
-# CORRECT — sync route runs in threadpool
-@router.get("/good")
-def good():
-    time.sleep(10)
-    return {"done": True}
-
-# CORRECT — non-blocking async
-@router.get("/best")
-async def best():
-    await asyncio.sleep(10)
-    return {"done": True}
-```
-
-### Sync libraries in async context
-
-```python
-from fastapi.concurrency import run_in_threadpool
-
-@router.get("/")
-async def call_sync_lib():
-    result = await run_in_threadpool(sync_client.make_request, data=my_data)
-    return result
-```
-
-For detailed async patterns including threadpool caveats and CPU-bound guidance, see `references/async-patterns.md`.
-
-## Pydantic
-
-### Leverage built-in validators
-
-```python
-from pydantic import BaseModel, EmailStr, Field
-
-class UserCreate(BaseModel):
-    username: str = Field(min_length=1, max_length=128, pattern="^[A-Za-z0-9-_]+$")
-    email: EmailStr
-    age: int = Field(ge=18)
-```
-
-### Custom base model for consistent serialization
-
-```python
-from pydantic import BaseModel, ConfigDict
-
-class CustomModel(BaseModel):
-    model_config = ConfigDict(
-        json_encoders={datetime: datetime_to_gmt_str},
-        populate_by_name=True,
-    )
-```
-
-### Split BaseSettings by domain
-
-```python
-# src/auth/config.py
-from pydantic_settings import BaseSettings
-
-class AuthConfig(BaseSettings):
-    JWT_ALG: str
-    JWT_SECRET: str
-    JWT_EXP: int = 5
-
-auth_settings = AuthConfig()
-```
-
-For response serialization gotchas, ValueError behavior, and more Pydantic patterns, see `references/pydantic-patterns.md`.
-
-## Dependencies
-
-Use dependencies for **request validation**, not just DI:
-
-```python
-async def valid_post_id(post_id: UUID4) -> dict[str, Any]:
-    post = await service.get_by_id(post_id)
-    if not post:
-        raise PostNotFound()
-    return post
-
-@router.get("/posts/{post_id}")
-async def get_post(post: dict[str, Any] = Depends(valid_post_id)):
-    return post
-```
-
-### Key rules
-
-- **Chain dependencies** to compose validation logic without repetition
-- **Dependencies are cached per request** — the same dependency called multiple times executes once
-- **Prefer `async` dependencies** to avoid unnecessary threadpool overhead
-- Use consistent path variable names across routes to enable dependency reuse
-
-For dependency chaining, caching behavior, and advanced patterns, see `references/dependencies.md`.
-
-## REST Conventions
-
-- Use consistent path variable names for dependency reuse across routes
-- Rename path variables to match shared dependencies when semantically equivalent
-
-```python
-# Both use profile_id — shared valid_profile_id dependency works for both
-GET /profiles/{profile_id}
-GET /creators/{profile_id}  # creator is a profile, so reuse profile_id
-```
-
-## API Documentation
-
-### Hide docs in production
-
-```python
-SHOW_DOCS_ENVIRONMENT = ("local", "staging")
-
-app_configs = {"title": "My API"}
-if ENVIRONMENT not in SHOW_DOCS_ENVIRONMENT:
-    app_configs["openapi_url"] = None
-
-app = FastAPI(**app_configs)
-```
-
-### Document endpoints properly
-
-```python
-@router.post(
-    "/endpoints",
-    response_model=DefaultResponseModel,
-    status_code=status.HTTP_201_CREATED,
-    description="Description of the endpoint",
-    tags=["Category"],
-    responses={
-        status.HTTP_201_CREATED: {"model": CreatedResponse},
-        status.HTTP_400_BAD_REQUEST: {"model": ErrorResponse},
-    },
-)
-```
-
-## Testing
-
-Use an async test client from day one to avoid event loop conflicts:
-
-```python
-import pytest
-from httpx import AsyncClient, ASGITransport
-
-@pytest.fixture
-async def client():
-    async with AsyncClient(
-        transport=ASGITransport(app=app),
-        base_url="http://test",
-    ) as client:
-        yield client
-
-@pytest.mark.asyncio
-async def test_create_post(client: AsyncClient):
-    resp = await client.post("/posts")
-    assert resp.status_code == 201
-```
+| Project Structure | HIGH | `references/project-conventions.md` |
+| Async Routes | CRITICAL | `references/async-patterns.md` |
+| Pydantic Integration | HIGH | `references/pydantic-patterns.md` |
+| Dependency Injection | HIGH | `references/dependencies.md` |
+| Database & Migrations | MEDIUM | `references/project-conventions.md` |
+| Testing | MEDIUM | `references/project-conventions.md` |
+| API Documentation | LOW | `references/project-conventions.md` |
 
 ## Quick Reference
 
-| Scenario | Solution |
-|---|---|
-| Non-blocking I/O | `async def` route with `await` |
-| Blocking I/O | `def` route (sync, runs in threadpool) |
-| Sync library in async | `run_in_threadpool()` |
-| CPU-intensive work | Celery or multiprocessing |
-| Request validation with DB | Dependencies, not Pydantic validators |
-| Shared validation logic | Chain dependencies |
-| Config per domain | Separate `BaseSettings` subclasses |
-| Complex DB queries | SQL-first with JSON aggregation |
-| Docs in production | Set `openapi_url=None` |
+### Async Routes
 
-## Reference Files
+- `async def` — use ONLY with non-blocking `await` calls; blocks event loop otherwise
+- `def` (sync) — use for blocking I/O; runs in threadpool automatically
+- CPU-intensive — offload to Celery or multiprocessing, not threads
+- Sync SDK in async route — use `run_in_threadpool()` from Starlette
 
-For detailed guidance beyond this overview, consult:
-- **`references/async-patterns.md`** — Async vs sync routes, event loop blocking, CPU-bound tasks, `run_in_threadpool`
-- **`references/dependencies.md`** — Dependency chaining, caching, validation patterns, auth flows
-- **`references/pydantic-patterns.md`** — Custom base model, BaseSettings, response serialization, ValueError gotcha
-- **`references/project-conventions.md`** — DB naming, Alembic migrations, linting, detailed project structure
+See `references/async-patterns.md` for decision matrix, threadpool caveats, and examples.
+
+### Project Structure
+
+- Organize by **domain** (auth/, posts/), not by file type (routers/, models/)
+- Each domain: `router.py`, `schemas.py`, `models.py`, `service.py`, `dependencies.py`, `config.py`, `constants.py`, `exceptions.py`, `utils.py`
+- Import across domains with explicit module names: `from src.auth import constants as auth_constants`
+
+See `references/project-conventions.md` for full layout, DB naming, Alembic, and linting.
+
+### Pydantic
+
+- Use built-in validators (`Field`, `EmailStr`, `AnyUrl`) before writing custom ones
+- Create a custom base model for consistent serialization across the app
+- Split `BaseSettings` by domain — one per module, not a single global config
+- Beware: `ValueError` in validators becomes a 422 response with the full message
+- Response models are created twice — once by you, once by FastAPI for validation
+
+See `references/pydantic-patterns.md` for base model template, schema design, and ORM mode.
+
+### Dependencies
+
+- Use for **request validation** (DB lookups, auth), not just DI
+- Chain dependencies to compose validation without repetition
+- Dependencies are **cached per request** — same dependency in multiple chains runs once
+- Prefer `async` dependencies to avoid threadpool overhead on trivial operations
+- Use consistent path variable names across routes for dependency reuse
+
+See `references/dependencies.md` for chaining, auth, pagination, and DB session patterns.
+
+### Database
+
+- Table names: `lower_case_snake`, singular (`post`, `user`, `post_like`)
+- DateTime columns: `_at` suffix; date columns: `_date` suffix
+- Set explicit index naming conventions in SQLAlchemy metadata
+- Prefer SQL-first — complex joins and JSON aggregation belong in the database
+
+See `references/project-conventions.md` for index naming template, Alembic migration conventions, and SQL-first examples.
+
+### Testing
+
+- Set up an async test client (httpx + ASGITransport) from day one
+- Mixing sync/async test patterns later causes event loop conflicts
+
+See `references/project-conventions.md` for async test fixture setup.
+
+### API Documentation
+
+- Hide docs in production: set `openapi_url=None` for non-allowed environments
+- Always set `response_model`, `status_code`, `description`, `tags` on endpoints
+
+See `references/project-conventions.md` for docs configuration and endpoint documentation examples.
+
+## How to Use
+
+Each reference file contains detailed explanations, correct/incorrect code examples, and rationale. Read individual files as needed for the category you're working on.

--- a/registry/skills/fastapi-best-practices/SKILL.md
+++ b/registry/skills/fastapi-best-practices/SKILL.md
@@ -39,8 +39,27 @@ See `references/async-patterns.md` for decision matrix, threadpool caveats, and 
 
 ### Project Structure
 
-- Organize by **domain** (auth/, posts/), not by file type (routers/, models/)
-- Each domain: `router.py`, `schemas.py`, `models.py`, `service.py`, `dependencies.py`, `config.py`, `constants.py`, `exceptions.py`, `utils.py`
+Organize by **domain**, not by file type:
+
+```
+src/
+├── auth/                # Domain package
+│   ├── router.py        # Endpoints
+│   ├── schemas.py       # Pydantic models
+│   ├── models.py        # DB models
+│   ├── service.py       # Business logic
+│   ├── dependencies.py  # Route dependencies
+│   ├── config.py        # Env vars (BaseSettings)
+│   ├── constants.py     # Constants, error codes
+│   ├── exceptions.py    # Domain exceptions
+│   └── utils.py         # Helpers
+├── posts/               # Another domain
+│   └── ...
+├── config.py            # Global config
+├── database.py          # DB connection
+└── main.py              # App init
+```
+
 - Import across domains with explicit module names: `from src.auth import constants as auth_constants`
 
 See `references/project-conventions.md` for full layout, DB naming, Alembic, and linting.

--- a/registry/skills/fastapi-best-practices/references/async-patterns.md
+++ b/registry/skills/fastapi-best-practices/references/async-patterns.md
@@ -1,0 +1,98 @@
+# Async Patterns in FastAPI
+
+## How FastAPI Handles Routes
+
+FastAPI is async-first but supports both sync and async route handlers with different execution models.
+
+### Sync routes (`def`)
+
+FastAPI runs sync routes in a **threadpool**. Blocking I/O in a sync route blocks only the worker thread, not the event loop — other requests continue being processed.
+
+```python
+@router.get("/sync")
+def sync_route():
+    time.sleep(10)  # Blocks worker thread, NOT the event loop
+    return {"done": True}
+```
+
+### Async routes (`async def`)
+
+Async routes run directly on the event loop. If you perform blocking I/O here, the **entire event loop stalls** — no other requests can be handled until the blocking call finishes.
+
+```python
+# WRONG — blocks the entire event loop for 10 seconds
+@router.get("/terrible")
+async def terrible():
+    time.sleep(10)
+    return {"done": True}
+
+# CORRECT — non-blocking, event loop handles other requests while waiting
+@router.get("/perfect")
+async def perfect():
+    await asyncio.sleep(10)
+    return {"done": True}
+```
+
+## Threadpool Caveats
+
+- Threads are more expensive than coroutines — they consume more memory and have scheduling overhead.
+- The threadpool has a **limited number of workers** (default: `min(32, os.cpu_count() + 4)`). If all workers are busy with slow sync routes, new requests queue up.
+- For high-throughput scenarios, prefer async routes with async drivers (e.g., `asyncpg`, `aiohttp`, `httpx`).
+
+## CPU-Intensive Tasks
+
+Neither async routes nor threadpool offloading help with CPU-bound work:
+
+- **Awaiting CPU work** is useless — the CPU must actively compute; there's nothing to "wait" for.
+- **Threads don't help** due to the GIL — only one thread executes Python bytecode at a time.
+
+Solutions for CPU-intensive tasks:
+
+```python
+# Option 1: run_in_executor with ProcessPoolExecutor
+import asyncio
+from concurrent.futures import ProcessPoolExecutor
+
+executor = ProcessPoolExecutor(max_workers=4)
+
+@router.get("/compute")
+async def compute():
+    loop = asyncio.get_event_loop()
+    result = await loop.run_in_executor(executor, heavy_computation, data)
+    return {"result": result}
+
+# Option 2: Offload to a task queue (Celery, Dramatiq, etc.)
+@router.post("/transcode")
+async def transcode(video_id: UUID4):
+    task = celery_app.send_task("transcode_video", args=[str(video_id)])
+    return {"task_id": task.id}
+```
+
+## Using Sync Libraries in Async Routes
+
+When you must call a sync SDK from an async route, use `run_in_threadpool` from Starlette:
+
+```python
+from fastapi.concurrency import run_in_threadpool
+
+@router.get("/")
+async def call_sync_library():
+    my_data = await service.get_my_data()
+    client = SyncAPIClient()
+    result = await run_in_threadpool(client.make_request, data=my_data)
+    return result
+```
+
+This is equivalent to `asyncio.to_thread()` but integrated with Starlette's threadpool.
+
+## Decision Matrix
+
+| Scenario | Route type | Why |
+|---|---|---|
+| Async DB driver (asyncpg, motor) | `async def` | Native async — most efficient |
+| Sync DB driver (psycopg2) | `def` | Threadpool prevents event loop blocking |
+| External async HTTP (httpx) | `async def` | Native async |
+| Sync HTTP library in async route | `run_in_threadpool()` | Bridges sync→async safely |
+| File I/O (small files) | `def` | Threadpool is fine for short blocking |
+| Heavy computation | Process pool or task queue | GIL prevents thread-based parallelism |
+| Async + one sync call | `async def` + `run_in_threadpool` | Keep route async, offload sync part |

--- a/registry/skills/fastapi-best-practices/references/dependencies.md
+++ b/registry/skills/fastapi-best-practices/references/dependencies.md
@@ -1,0 +1,174 @@
+# FastAPI Dependencies
+
+## Dependencies as Validation
+
+FastAPI dependencies are not just for DI — they are the primary mechanism for request validation that requires database or external service calls.
+
+```python
+# dependencies.py
+async def valid_post_id(post_id: UUID4) -> dict[str, Any]:
+    post = await service.get_by_id(post_id)
+    if not post:
+        raise PostNotFound()
+    return post
+
+# router.py — reuse across multiple endpoints
+@router.get("/posts/{post_id}", response_model=PostResponse)
+async def get_post(post: dict[str, Any] = Depends(valid_post_id)):
+    return post
+
+@router.put("/posts/{post_id}", response_model=PostResponse)
+async def update_post(
+    update_data: PostUpdate,
+    post: dict[str, Any] = Depends(valid_post_id),
+):
+    updated = await service.update(id=post["id"], data=update_data)
+    return updated
+
+@router.get("/posts/{post_id}/reviews", response_model=list[ReviewResponse])
+async def get_post_reviews(post: dict[str, Any] = Depends(valid_post_id)):
+    return await reviews_service.get_by_post_id(post["id"])
+```
+
+Without the dependency, you'd validate `post_id` existence in every endpoint and duplicate tests.
+
+## Chaining Dependencies
+
+Dependencies can depend on other dependencies, composing validation logic:
+
+```python
+from fastapi.security import OAuth2PasswordBearer
+
+async def parse_jwt_data(
+    token: str = Depends(OAuth2PasswordBearer(tokenUrl="/auth/token")),
+) -> dict[str, Any]:
+    try:
+        payload = jwt.decode(token, "JWT_SECRET", algorithms=["HS256"])
+    except JWTError:
+        raise InvalidCredentials()
+    return {"user_id": payload["id"]}
+
+async def valid_owned_post(
+    post: dict[str, Any] = Depends(valid_post_id),
+    token_data: dict[str, Any] = Depends(parse_jwt_data),
+) -> dict[str, Any]:
+    if post["creator_id"] != token_data["user_id"]:
+        raise UserNotOwner()
+    return post
+
+async def valid_active_creator(
+    token_data: dict[str, Any] = Depends(parse_jwt_data),
+) -> dict[str, Any]:
+    user = await users_service.get_by_id(token_data["user_id"])
+    if not user["is_active"]:
+        raise UserIsBanned()
+    if not user["is_creator"]:
+        raise UserNotCreator()
+    return user
+```
+
+## Dependency Caching
+
+Dependencies are **cached per request** by default. If the same dependency appears multiple times in a route's dependency tree, it executes only once.
+
+```python
+@router.get("/users/{user_id}/posts/{post_id}", response_model=PostResponse)
+async def get_user_post(
+    worker: BackgroundTasks,
+    post: Mapping = Depends(valid_owned_post),     # calls parse_jwt_data
+    user: Mapping = Depends(valid_active_creator),  # also calls parse_jwt_data
+):
+    # parse_jwt_data runs ONCE despite being in both dependency chains
+    worker.add_task(notifications_service.send_email, user["id"])
+    return post
+```
+
+To disable caching for a specific dependency (e.g., if it should run fresh each time):
+
+```python
+@router.get("/")
+async def route(dep=Depends(my_dependency, use_cache=False)):
+    ...
+```
+
+## Prefer Async Dependencies
+
+Sync dependencies run in a threadpool, just like sync routes. For small non-I/O operations (parsing a header, checking a condition), the threadpool overhead is unnecessary.
+
+```python
+# AVOID — runs in threadpool for no reason
+def get_current_page(page: int = Query(1, ge=1)) -> int:
+    return page
+
+# PREFER — runs on the event loop, zero overhead
+async def get_current_page(page: int = Query(1, ge=1)) -> int:
+    return page
+```
+
+## REST Path Variables for Dependency Reuse
+
+Use consistent path variable names across routes so dependencies can be shared:
+
+```python
+# src/profiles/dependencies.py
+async def valid_profile_id(profile_id: UUID4) -> Mapping:
+    profile = await service.get_by_id(profile_id)
+    if not profile:
+        raise ProfileNotFound()
+    return profile
+
+# src/creators/dependencies.py
+async def valid_creator_id(profile: Mapping = Depends(valid_profile_id)) -> Mapping:
+    if not profile["is_creator"]:
+        raise ProfileNotCreator()
+    return profile
+
+# src/profiles/router.py
+@router.get("/profiles/{profile_id}", response_model=ProfileResponse)
+async def get_profile(profile: Mapping = Depends(valid_profile_id)):
+    return profile
+
+# src/creators/router.py — uses profile_id (not creator_id) to chain dependencies
+@router.get("/creators/{profile_id}", response_model=ProfileResponse)
+async def get_creator(creator: Mapping = Depends(valid_creator_id)):
+    return creator
+```
+
+## Common Dependency Patterns
+
+### Auth guard as a router dependency
+
+```python
+router = APIRouter(dependencies=[Depends(require_authenticated)])
+
+@router.get("/me")
+async def get_me(user: User = Depends(get_current_user)):
+    return user
+```
+
+### Database session dependency
+
+```python
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    async with async_session_maker() as session:
+        yield session
+
+@router.get("/items")
+async def list_items(db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Item))
+    return result.scalars().all()
+```
+
+### Pagination dependency
+
+```python
+async def pagination_params(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(20, ge=1, le=100),
+) -> dict[str, int]:
+    return {"skip": skip, "limit": limit}
+
+@router.get("/posts")
+async def list_posts(pagination: dict[str, int] = Depends(pagination_params)):
+    return await service.list(skip=pagination["skip"], limit=pagination["limit"])
+```

--- a/registry/skills/fastapi-best-practices/references/project-conventions.md
+++ b/registry/skills/fastapi-best-practices/references/project-conventions.md
@@ -1,0 +1,180 @@
+# Project Conventions
+
+## Domain-Based Module Layout
+
+Each domain package under `src/` follows a standard file layout:
+
+| File | Purpose |
+|---|---|
+| `router.py` | API endpoints — the core of each module |
+| `schemas.py` | Pydantic request/response models |
+| `models.py` | Database (ORM) models |
+| `service.py` | Business logic functions |
+| `dependencies.py` | Route-level dependencies |
+| `config.py` | Domain-specific env vars via `BaseSettings` |
+| `constants.py` | Constants and error codes |
+| `exceptions.py` | Domain-specific exceptions (e.g., `PostNotFound`) |
+| `utils.py` | Non-business helpers (response normalization, data enrichment) |
+
+Global modules live at the `src/` root level: `config.py`, `models.py`, `exceptions.py`, `database.py`, `main.py`.
+
+### Cross-domain imports
+
+Always use explicit module names to make the origin clear:
+
+```python
+from src.auth import constants as auth_constants
+from src.notifications import service as notification_service
+from src.posts.constants import ErrorCode as PostsErrorCode
+```
+
+## Database Naming Conventions
+
+### Table names
+- `lower_case_snake` format
+- Singular form: `post`, `user`, `post_like`
+- Group related tables with a prefix: `payment_account`, `payment_bill`
+- Use `_at` suffix for datetime columns: `created_at`, `updated_at`
+- Use `_date` suffix for date columns: `birth_date`, `start_date`
+
+### Column naming consistency
+- Use `profile_id` across all tables that reference profiles
+- Use concrete names where semantically appropriate: `creator_id` when only creators are valid, `course_id` instead of generic `post_id` in a course-specific table
+
+### Explicit index naming
+
+Set naming conventions in SQLAlchemy metadata to avoid auto-generated names:
+
+```python
+from sqlalchemy import MetaData
+
+POSTGRES_INDEXES_NAMING_CONVENTION = {
+    "ix": "%(column_0_label)s_idx",
+    "uq": "%(table_name)s_%(column_0_name)s_key",
+    "ck": "%(table_name)s_%(constraint_name)s_check",
+    "fk": "%(table_name)s_%(column_0_name)s_fkey",
+    "pk": "%(table_name)s_pkey",
+}
+metadata = MetaData(naming_convention=POSTGRES_INDEXES_NAMING_CONVENTION)
+```
+
+## SQL-First Approach
+
+Prefer database-level operations over Python-side processing:
+- Complex joins and filtering belong in SQL
+- Aggregate nested JSON in the database for responses with nested objects
+- The database handles data processing faster and cleaner than CPython
+
+```python
+select_query = (
+    select(
+        posts.c.id,
+        posts.c.slug,
+        posts.c.title,
+        func.json_build_object(
+            text("'id', profiles.id"),
+            text("'first_name', profiles.first_name"),
+            text("'last_name', profiles.last_name"),
+        ).label("creator"),
+    )
+    .select_from(posts.join(profiles, posts.c.owner_id == profiles.c.id))
+    .where(posts.c.owner_id == creator_id)
+    .limit(limit)
+    .offset(offset)
+    .order_by(desc(coalesce(posts.c.updated_at, posts.c.created_at)))
+)
+```
+
+## Alembic Migrations
+
+### Rules
+- Migrations must be **static and reversible** — structure should not depend on dynamic data
+- Use **descriptive file names** with slugs that explain the change
+- Always generate both upgrade and downgrade functions
+
+### File naming
+
+Configure a human-readable template in `alembic.ini`:
+
+```ini
+file_template = %%(year)d-%%(month).2d-%%(day).2d_%%(slug)s
+```
+
+This produces files like `2024-03-15_add_post_content_idx.py` instead of cryptic revision hashes.
+
+## API Documentation
+
+### Hide docs in production
+
+```python
+from src.constants import Environment
+
+SHOW_DOCS_ENVIRONMENT = ("local", "staging")
+
+app_configs = {"title": "My API"}
+if settings.ENVIRONMENT not in SHOW_DOCS_ENVIRONMENT:
+    app_configs["openapi_url"] = None
+
+app = FastAPI(**app_configs)
+```
+
+### Endpoint documentation
+
+Always set `response_model`, `status_code`, `description`, and `tags`:
+
+```python
+@router.post(
+    "/posts",
+    response_model=PostResponse,
+    status_code=status.HTTP_201_CREATED,
+    description="Create a new post",
+    tags=["Posts"],
+    summary="Create Post",
+    responses={
+        status.HTTP_201_CREATED: {
+            "model": PostResponse,
+            "description": "Post created successfully",
+        },
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {
+            "model": ValidationErrorResponse,
+            "description": "Validation failed",
+        },
+    },
+)
+async def create_post(data: PostCreate):
+    ...
+```
+
+## Testing
+
+### Async test client from day one
+
+Setting up an async test client early prevents event loop conflicts that arise when mixing sync and async test patterns later:
+
+```python
+import pytest
+from httpx import AsyncClient, ASGITransport
+from src.main import app
+
+@pytest.fixture
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+@pytest.mark.asyncio
+async def test_create_post(client: AsyncClient):
+    resp = await client.post("/posts", json={"title": "Test", "content": "Body"})
+    assert resp.status_code == 201
+```
+
+## Linting
+
+Use [ruff](https://github.com/astral-sh/ruff) for formatting and linting — it replaces black, isort, autoflake, and supports 600+ rules:
+
+```shell
+ruff check --fix src
+ruff format src
+```

--- a/registry/skills/fastapi-best-practices/references/project-conventions.md
+++ b/registry/skills/fastapi-best-practices/references/project-conventions.md
@@ -2,21 +2,83 @@
 
 ## Domain-Based Module Layout
 
-Each domain package under `src/` follows a standard file layout:
+Organize by **domain** (auth, posts, payments), not by file type (routers/, models/, services/). Each domain is a self-contained package with a standard set of modules.
 
-| File | Purpose |
+### Full project tree
+
+```
+fastapi-project/
+├── alembic/                     # Migration scripts
+├── src/
+│   ├── auth/                    # Auth domain
+│   │   ├── router.py            # API endpoints
+│   │   ├── schemas.py           # Pydantic request/response models
+│   │   ├── models.py            # Database (ORM) models
+│   │   ├── service.py           # Business logic
+│   │   ├── dependencies.py      # Route-level dependencies
+│   │   ├── config.py            # Domain env vars (BaseSettings)
+│   │   ├── constants.py         # Constants and error codes
+│   │   ├── exceptions.py        # Domain exceptions (e.g., InvalidCredentials)
+│   │   └── utils.py             # Non-business helpers
+│   ├── posts/                   # Posts domain
+│   │   ├── router.py
+│   │   ├── schemas.py
+│   │   ├── models.py
+│   │   ├── service.py
+│   │   ├── dependencies.py
+│   │   ├── constants.py
+│   │   ├── exceptions.py
+│   │   └── utils.py
+│   ├── aws/                     # External service client
+│   │   ├── client.py            # SDK wrapper
+│   │   ├── schemas.py
+│   │   ├── config.py
+│   │   ├── constants.py
+│   │   ├── exceptions.py
+│   │   └── utils.py
+│   ├── config.py                # Global configuration
+│   ├── models.py                # Shared DB models
+│   ├── exceptions.py            # Global exception handlers
+│   ├── pagination.py            # Shared modules (pagination, etc.)
+│   ├── database.py              # DB engine & session setup
+│   └── main.py                  # FastAPI app initialization
+├── tests/
+│   ├── auth/                    # Tests mirror domain structure
+│   ├── posts/
+│   └── aws/
+├── templates/                   # Jinja2 templates (if needed)
+├── .env
+├── alembic.ini
+└── pyproject.toml
+```
+
+### Domain module reference
+
+| Module | Purpose | When to create |
+|---|---|---|
+| `router.py` | API endpoints — the core of each domain | Always |
+| `schemas.py` | Pydantic request/response models | Always |
+| `models.py` | Database (ORM) models | When domain has DB tables |
+| `service.py` | Business logic functions | When logic goes beyond simple CRUD |
+| `dependencies.py` | Route-level dependencies (validation, auth) | When routes need shared validation |
+| `config.py` | Domain-specific env vars via `BaseSettings` | When domain has its own config |
+| `constants.py` | Constants and error codes | Always |
+| `exceptions.py` | Domain-specific exceptions | Always |
+| `utils.py` | Non-business helpers (normalization, enrichment) | When needed |
+| `client.py` | External service SDK wrapper | For external service integrations |
+
+### Global vs domain modules
+
+Global modules at `src/` root handle cross-cutting concerns:
+
+| Module | Purpose |
 |---|---|
-| `router.py` | API endpoints — the core of each module |
-| `schemas.py` | Pydantic request/response models |
-| `models.py` | Database (ORM) models |
-| `service.py` | Business logic functions |
-| `dependencies.py` | Route-level dependencies |
-| `config.py` | Domain-specific env vars via `BaseSettings` |
-| `constants.py` | Constants and error codes |
-| `exceptions.py` | Domain-specific exceptions (e.g., `PostNotFound`) |
-| `utils.py` | Non-business helpers (response normalization, data enrichment) |
-
-Global modules live at the `src/` root level: `config.py`, `models.py`, `exceptions.py`, `database.py`, `main.py`.
+| `main.py` | App init, middleware, router mounting |
+| `config.py` | Global settings (DB URL, Redis, CORS, environment) |
+| `database.py` | Engine, session factory, base model |
+| `models.py` | Shared models (if any) |
+| `exceptions.py` | Global exception handlers, base exception classes |
+| `pagination.py` | Shared utilities used across domains |
 
 ### Cross-domain imports
 
@@ -27,6 +89,12 @@ from src.auth import constants as auth_constants
 from src.notifications import service as notification_service
 from src.posts.constants import ErrorCode as PostsErrorCode
 ```
+
+### When to create a new domain package
+
+- The feature has its own API endpoints → new domain
+- The feature is an external service integration (AWS, Stripe) → new domain with `client.py`
+- Shared utilities used across multiple domains → keep at `src/` root level, not in a domain
 
 ## Database Naming Conventions
 

--- a/registry/skills/fastapi-best-practices/references/project-conventions.md
+++ b/registry/skills/fastapi-best-practices/references/project-conventions.md
@@ -178,3 +178,5 @@ Use [ruff](https://github.com/astral-sh/ruff) for formatting and linting — it 
 ruff check --fix src
 ruff format src
 ```
+
+**Important:** Always read linting rules from the project's configuration (`pyproject.toml`, `ruff.toml`, or `.ruff.toml`) before applying or suggesting fixes. Projects define their own rule sets, line length, ignore lists, and per-file overrides — do not assume defaults or add rules that conflict with the existing config.

--- a/registry/skills/fastapi-best-practices/references/pydantic-patterns.md
+++ b/registry/skills/fastapi-best-practices/references/pydantic-patterns.md
@@ -1,0 +1,190 @@
+# Pydantic Patterns for FastAPI
+
+## Leverage Built-in Validators
+
+Pydantic provides rich validation out of the box — use it before writing custom validators:
+
+```python
+from enum import StrEnum
+from pydantic import AnyUrl, BaseModel, EmailStr, Field
+
+
+class MusicBand(StrEnum):
+    AEROSMITH = "AEROSMITH"
+    QUEEN = "QUEEN"
+    ACDC = "AC/DC"
+
+
+class UserCreate(BaseModel):
+    first_name: str = Field(min_length=1, max_length=128)
+    username: str = Field(min_length=1, max_length=128, pattern="^[A-Za-z0-9-_]+$")
+    email: EmailStr
+    age: int = Field(ge=18, default=None)
+    favorite_band: MusicBand | None = None
+    website: AnyUrl | None = None
+```
+
+## Custom Base Model
+
+Create a project-wide base model for consistent serialization:
+
+```python
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from fastapi.encoders import jsonable_encoder
+from pydantic import BaseModel, ConfigDict
+
+
+def datetime_to_gmt_str(dt: datetime) -> str:
+    if not dt.tzinfo:
+        dt = dt.replace(tzinfo=ZoneInfo("UTC"))
+    return dt.strftime("%Y-%m-%dT%H:%M:%S%z")
+
+
+class CustomModel(BaseModel):
+    model_config = ConfigDict(
+        json_encoders={datetime: datetime_to_gmt_str},
+        populate_by_name=True,
+    )
+
+    def serializable_dict(self, **kwargs):
+        """Return a dict with only serializable fields."""
+        default_dict = self.model_dump()
+        return jsonable_encoder(default_dict)
+```
+
+Benefits:
+- Consistent datetime formatting across all responses
+- Single place to add shared serialization logic
+- All domain schemas inherit shared behavior
+
+## Split BaseSettings by Domain
+
+A single global `BaseSettings` class gets unwieldy fast. Split config by domain:
+
+```python
+# src/auth/config.py
+from datetime import timedelta
+from pydantic_settings import BaseSettings
+
+class AuthConfig(BaseSettings):
+    JWT_ALG: str
+    JWT_SECRET: str
+    JWT_EXP: int = 5  # minutes
+    REFRESH_TOKEN_KEY: str
+    REFRESH_TOKEN_EXP: timedelta = timedelta(days=30)
+    SECURE_COOKIES: bool = True
+
+auth_settings = AuthConfig()
+
+
+# src/config.py
+from pydantic import PostgresDsn, RedisDsn
+from pydantic_settings import BaseSettings
+from src.constants import Environment
+
+class Config(BaseSettings):
+    DATABASE_URL: PostgresDsn
+    REDIS_URL: RedisDsn
+    SITE_DOMAIN: str = "myapp.com"
+    ENVIRONMENT: Environment = Environment.PRODUCTION
+    SENTRY_DSN: str | None = None
+    CORS_ORIGINS: list[str]
+    CORS_ORIGINS_REGEX: str | None = None
+    CORS_HEADERS: list[str]
+    APP_VERSION: str = "1.0"
+
+settings = Config()
+```
+
+## Response Serialization Gotcha
+
+FastAPI creates your Pydantic response model **twice** — once when you return it, and once internally for validation:
+
+```python
+class ProfileResponse(BaseModel):
+    @model_validator(mode="after")
+    def debug_usage(self):
+        print("created pydantic model")  # Prints TWICE per request
+        return self
+
+@app.get("/", response_model=ProfileResponse)
+async def root():
+    return ProfileResponse()
+```
+
+The flow: your object → `jsonable_encoder` → dict → validate against `response_model` → JSON.
+
+Be aware of this when using expensive validators or side effects in response models.
+
+## ValueError Becomes ValidationError
+
+If you raise a `ValueError` inside a Pydantic validator used in a request body, FastAPI returns it as a **detailed validation error response** to the client. This can leak internal details.
+
+```python
+class ProfileCreate(BaseModel):
+    password: str
+
+    @field_validator("password", mode="after")
+    @classmethod
+    def valid_password(cls, password: str) -> str:
+        if not re.match(STRONG_PASSWORD_PATTERN, password):
+            raise ValueError(
+                "Password must contain at least "
+                "one lower character, one upper character, "
+                "digit or special symbol"
+            )
+        return password
+```
+
+The `ValueError` message is included verbatim in the 422 response. Keep validation messages user-friendly and avoid leaking implementation details.
+
+## Schema Design Patterns
+
+### Separate input and output schemas
+
+```python
+# Input — what the client sends
+class PostCreate(BaseModel):
+    title: str = Field(min_length=1, max_length=200)
+    content: str
+
+# Output — what the API returns
+class PostResponse(BaseModel):
+    id: UUID4
+    title: str
+    content: str
+    created_at: datetime
+    creator: CreatorInfo
+```
+
+### Shared base with read-only fields
+
+```python
+class PostBase(BaseModel):
+    title: str = Field(min_length=1, max_length=200)
+    content: str
+
+class PostCreate(PostBase):
+    pass
+
+class PostUpdate(BaseModel):
+    title: str | None = Field(None, min_length=1, max_length=200)
+    content: str | None = None
+
+class PostResponse(PostBase):
+    id: UUID4
+    created_at: datetime
+```
+
+### Config for ORM mode
+
+```python
+class PostResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID4
+    title: str
+    created_at: datetime
+```


### PR DESCRIPTION
### Summary

  - Adds a new fastapi-best-practices skill based on https://github.com/zhanymkanov/fastapi-best-practices
  - Covers FastAPI-specific patterns: async routing, dependency injection, Pydantic integration, domain-based project layout, DB conventions, testing, and API
  documentation
  - Deliberately avoids duplicating general Python topics (naming, type hints, error handling, dataclasses, pathlib) already covered by modern-python-development

### Test Plan

- [x] validate-registry passes
- [x] Verify skill installs correctly via `npx @provectusinc/awos-recruitment skill fastapi-best-practices`