### PR TITLE
Add aws-knowledge-mcp-server MCP definition

### DIFF
--- a/registry/mcp/aws-knowledge-mcp-server.yaml
+++ b/registry/mcp/aws-knowledge-mcp-server.yaml
@@ -1,0 +1,10 @@
+name: "aws-knowledge-mcp-server"
+description: "Comprehensive AWS knowledge base — documentation, API references, blogs, Well-Architected guidance, architectural patterns, and regional service availability. Superset of aws-documentation-mcp-server."
+config:
+  aws-knowledge-mcp-server:
+    type: stdio
+    command: uvx
+    args:
+      - "fastmcp"
+      - "run"
+      - "https://knowledge-mcp.global.api.aws"


### PR DESCRIPTION
## Summary
- Adds `aws-knowledge-mcp-server` MCP server definition to the registry

## Test plan
- [x] Verify YAML is valid and follows registry schema
- [ ] Confirm MCP server installs and runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)