### PR TITLE
Add terraform-mcp-server MCP definition

### DIFF
--- a/registry/mcp/terraform-mcp-server.yaml
+++ b/registry/mcp/terraform-mcp-server.yaml
@@ -1,0 +1,11 @@
+name: "terraform-mcp-server"
+description: "Terraform Registry integration — search and inspect providers, modules, and policies. Enables provider version lookup, module details, and policy discovery for Infrastructure as Code development."
+config:
+  terraform-mcp-server:
+    type: stdio
+    command: docker
+    args:
+      - "run"
+      - "-i"
+      - "--rm"
+      - "hashicorp/terraform-mcp-server"


### PR DESCRIPTION
## Summary
- Adds `terraform-mcp-server` MCP server definition to the registry

## Test plan
- [x] Verify YAML is valid and follows registry schema
- [ ] Confirm MCP server installs and runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)