### PR TITLE
Add github-mcp-server MCP definition

### DIFF
--- a/registry/mcp/github-mcp-server.yaml
+++ b/registry/mcp/github-mcp-server.yaml
@@ -1,0 +1,15 @@
+name: "github-mcp-server"
+description: "Official GitHub MCP server — manage repositories, issues, pull requests, CI/CD workflows (Actions), code search, and security alerts."
+config:
+  github-mcp-server:
+    type: stdio
+    command: docker
+    args:
+      - "run"
+      - "-i"
+      - "--rm"
+      - "-e"
+      - "GITHUB_PERSONAL_ACCESS_TOKEN"
+      - "ghcr.io/github/github-mcp-server"
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PERSONAL_ACCESS_TOKEN}"


### PR DESCRIPTION
## Summary
- Adds `github-mcp-server` MCP server definition to the registry

## Test plan
- [x] Verify YAML is valid and follows registry schema
- [ ] Confirm MCP server installs and runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)