### PR TITLE
Add aws-api-mcp-server MCP definition

### DIFF
--- a/registry/mcp/aws-api-mcp-server.yaml
+++ b/registry/mcp/aws-api-mcp-server.yaml
@@ -1,0 +1,10 @@
+name: "aws-api-mcp-server"
+description: "Execute AWS API calls safely through Claude — supports all AWS services via CLI command generation with built-in safety checks and auditing."
+config:
+  aws-api-mcp-server:
+    type: stdio
+    command: uvx
+    args:
+      - "awslabs.aws-api-mcp-server@latest"
+    env:
+      FASTMCP_LOG_LEVEL: "ERROR"


### PR DESCRIPTION
## Summary
- Adds `aws-api-mcp-server` MCP server definition to the registry

## Test plan
- [x] Verify YAML is valid and follows registry schema
- [ ] Confirm MCP server installs and runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)