### PR TITLE
Add terraform-conventions skill (fork of antonbabenko/terraform-skill v1.5.0)

### DIFF
--- a/registry/skills/terraform-conventions/SKILL.md
+++ b/registry/skills/terraform-conventions/SKILL.md
@@ -1,0 +1,582 @@
+---
+name: terraform-conventions
+description: Use when working with Terraform or OpenTofu - creating modules, writing tests (native test framework, Terratest), setting up CI/CD pipelines, reviewing configurations, choosing between testing approaches, debugging state issues, implementing security scanning (trivy, checkov), or making infrastructure-as-code architecture decisions. Enforces Provectus opinionated conventions (exact version pinning, etc.) on top of community best practices.
+---
+
+# Terraform Skill for Claude
+
+Comprehensive Terraform and OpenTofu guidance covering testing, modules, CI/CD, and production patterns. Based on terraform-best-practices.com and enterprise experience. Layered with Provectus opinionated conventions.
+
+## Provectus Conventions
+
+> ### Version Pinning
+>
+> **All Terraform, provider, and module versions MUST be pinned to exact versions.**
+>
+> | Component | Constraint | Example |
+> |-----------|-----------|---------|
+> | **Terraform** | Exact version | `required_version = "= 1.9.8"` |
+> | **Providers** | Exact version | `version = "= 5.82.2"` |
+> | **Modules (prod)** | Exact version | `version = "5.1.2"` |
+> | **Modules (dev)** | Exact version | `version = "5.1.2"` |
+>
+> No pessimistic (`~>`) or range constraints. Pin everything. This prevents drift between environments and ensures reproducible builds.
+
+> ### Root Module Configuration
+>
+> **Use `locals.tf` instead of `terraform.tfvars` in root modules.** Define values directly in locals — no `.tfvars` files at the root level. This keeps all configuration in version-controlled HCL and avoids hidden variable overrides.
+>
+> ```hcl
+> # locals.tf — root module
+> locals {
+>   environment = "prod"
+>   project     = "my-project"
+>   region      = "us-east-1"
+> }
+> ```
+
+> ### Required Resource Tags
+>
+> **All taggable resources MUST include these four tags:**
+>
+> | Tag | Description | Example |
+> |-----|-------------|---------|
+> | `Environment` | Deployment environment | `prod`, `staging`, `dev` |
+> | `Project` | Project or service name | `my-project` |
+> | `Owner` | Team or person responsible | `platform-team` |
+> | `ManagedBy` | How the resource is managed | `terraform` |
+>
+> ```hcl
+> locals {
+>   required_tags = {
+>     Environment = local.environment
+>     Project     = local.project
+>     Owner       = local.owner
+>     ManagedBy   = "terraform"
+>   }
+> }
+>
+> resource "aws_s3_bucket" "this" {
+>   bucket = "my-bucket"
+>
+>   tags = merge(local.required_tags, {
+>     Name = "my-bucket"
+>   })
+> }
+> ```
+
+> ### Apply Workflow
+>
+> **Always use `plan -out` and get explicit approval before applying.**
+>
+> ```bash
+> terraform plan -out=plan.tfplan    # Step 1: Generate saved plan
+> terraform show plan.tfplan         # Step 2: Review the plan
+> # Step 3: Wait for explicit approval
+> terraform apply plan.tfplan        # Step 4: Apply the saved plan
+> ```
+>
+> Never run `terraform apply` without a saved plan file. This ensures what was reviewed is exactly what gets applied.
+
+## When to Use This Skill
+
+**Activate this skill when:**
+- Creating new Terraform or OpenTofu configurations or modules
+- Setting up testing infrastructure for IaC code
+- Deciding between testing approaches (validate, plan, frameworks)
+- Structuring multi-environment deployments
+- Implementing CI/CD for infrastructure-as-code
+- Reviewing or refactoring existing Terraform/OpenTofu projects
+- Choosing between module patterns or state management approaches
+
+**Don't use this skill for:**
+- Basic Terraform/OpenTofu syntax questions (Claude knows this)
+- Provider-specific API reference (link to docs instead)
+- Cloud platform questions unrelated to Terraform/OpenTofu
+
+## Core Principles
+
+### 1. Code Structure Philosophy
+
+**Module Hierarchy:**
+
+| Type | When to Use | Scope |
+|------|-------------|-------|
+| **Resource Module** | Single logical group of connected resources | VPC + subnets, Security group + rules |
+| **Infrastructure Module** | Collection of resource modules for a purpose | Multiple resource modules in one region/account |
+| **Composition** | Complete infrastructure | Spans multiple regions/accounts |
+
+**Hierarchy:** Resource → Resource Module → Infrastructure Module → Composition
+
+**Directory Structure:**
+```
+environments/        # Environment-specific configurations
+├── prod/
+├── staging/
+└── dev/
+
+modules/            # Reusable modules
+├── networking/
+├── compute/
+└── data/
+
+examples/           # Module usage examples (also serve as tests)
+├── complete/
+└── minimal/
+```
+
+**Key principle from terraform-best-practices.com:**
+- Separate **environments** (prod, staging) from **modules** (reusable components)
+- Use **examples/** as both documentation and integration test fixtures
+- Keep modules small and focused (single responsibility)
+
+**For detailed module architecture, see:** [Code Patterns: Module Types & Hierarchy](references/code-patterns.md)
+
+### 2. Naming Conventions
+
+**Resources:**
+```hcl
+# Good: Descriptive, contextual
+resource "aws_instance" "web_server" { }
+resource "aws_s3_bucket" "application_logs" { }
+
+# Good: "this" for singleton resources (only one of that type)
+resource "aws_vpc" "this" { }
+resource "aws_security_group" "this" { }
+
+# Avoid: Generic names for non-singletons
+resource "aws_instance" "main" { }
+resource "aws_s3_bucket" "bucket" { }
+```
+
+**Singleton Resources:**
+
+Use `"this"` when your module creates only one resource of that type:
+
+DO:
+```hcl
+resource "aws_vpc" "this" {}           # Module creates one VPC
+resource "aws_security_group" "this" {}  # Module creates one SG
+```
+
+DON'T use "this" for multiple resources:
+```hcl
+resource "aws_subnet" "this" {}  # If creating multiple subnets
+```
+
+Use descriptive names when creating multiple resources of the same type.
+
+**Variables:**
+```hcl
+# Prefix with context when needed
+var.vpc_cidr_block          # Not just "cidr"
+var.database_instance_class # Not just "instance_class"
+```
+
+**Files:**
+- `main.tf` - Primary resources
+- `variables.tf` - Input variables
+- `outputs.tf` - Output values
+- `versions.tf` - Provider versions
+- `data.tf` - Data sources (optional)
+
+## Testing Strategy Framework
+
+### Decision Matrix: Which Testing Approach?
+
+| Your Situation | Recommended Approach | Tools | Cost |
+|----------------|---------------------|-------|------|
+| **Quick syntax check** | Static analysis | `terraform validate`, `fmt` | Free |
+| **Pre-commit validation** | Static + lint | `validate`, `tflint`, `trivy`, `checkov` | Free |
+| **Terraform 1.6+, simple logic** | Native test framework | Built-in `terraform test` | Free-Low |
+| **Pre-1.6, or Go expertise** | Integration testing | Terratest | Low-Med |
+| **Security/compliance focus** | Policy as code | OPA, Sentinel | Free |
+| **Cost-sensitive workflow** | Mock providers (1.7+) | Native tests + mocking | Free |
+| **Multi-cloud, complex** | Full integration | Terratest + real infra | Med-High |
+
+### Testing Pyramid for Infrastructure
+
+```
+        /\
+       /  \          End-to-End Tests (Expensive)
+      /____\         - Full environment deployment
+     /      \        - Production-like setup
+    /________\
+   /          \      Integration Tests (Moderate)
+  /____________\     - Module testing in isolation
+ /              \    - Real resources in test account
+/________________\   Static Analysis (Cheap)
+                     - validate, fmt, lint
+                     - Security scanning
+```
+
+### Native Test Best Practices (1.6+)
+
+**Before generating test code:**
+
+1. **Validate schemas with Terraform MCP:**
+   ```
+   Search provider docs → Get resource schema → Identify block types
+   ```
+
+2. **Choose correct command mode:**
+   - `command = plan` - Fast, for input validation
+   - `command = apply` - Required for computed values and set-type blocks
+
+3. **Handle set-type blocks correctly:**
+   - Cannot index with `[0]`
+   - Use `for` expressions to iterate
+   - Or use `command = apply` to materialize
+
+**Common patterns:**
+- S3 encryption rules: **set** (use for expressions)
+- Lifecycle transitions: **set** (use for expressions)
+- IAM policy statements: **set** (use for expressions)
+
+**For detailed testing guides, see:**
+- **[Testing Frameworks Guide](references/testing-frameworks.md)** - Deep dive into static analysis, native tests, and Terratest
+- **[Quick Reference](references/quick-reference.md#testing-approach-selection)** - Decision flowchart and command cheat sheet
+
+## Code Structure Standards
+
+### Resource Block Ordering
+
+**Strict ordering for consistency:**
+1. `count` or `for_each` FIRST (blank line after)
+2. Other arguments
+3. `tags` as last real argument
+4. `depends_on` after tags (if needed)
+5. `lifecycle` at the very end (if needed)
+
+```hcl
+# GOOD - Correct ordering
+resource "aws_nat_gateway" "this" {
+  count = var.create_nat_gateway ? 1 : 0
+
+  allocation_id = aws_eip.this[0].id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = {
+    Name = "${var.name}-nat"
+  }
+
+  depends_on = [aws_internet_gateway.this]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+```
+
+### Variable Block Ordering
+
+1. `description` (ALWAYS required)
+2. `type`
+3. `default`
+4. `validation`
+5. `nullable` (when setting to false)
+
+```hcl
+variable "environment" {
+  description = "Environment name for resource tagging"
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be one of: dev, staging, prod."
+  }
+
+  nullable = false
+}
+```
+
+**For complete structure guidelines, see:** [Code Patterns: Block Ordering & Structure](references/code-patterns.md#block-ordering--structure)
+
+## Count vs For_Each: When to Use Each
+
+### Quick Decision Guide
+
+| Scenario | Use | Why |
+|----------|-----|-----|
+| Boolean condition (create or don't) | `count = condition ? 1 : 0` | Simple on/off toggle |
+| Simple numeric replication | `count = 3` | Fixed number of identical resources |
+| Items may be reordered/removed | `for_each = toset(list)` | Stable resource addresses |
+| Reference by key | `for_each = map` | Named access to resources |
+| Multiple named resources | `for_each` | Better maintainability |
+
+### Common Patterns
+
+**Boolean conditions:**
+```hcl
+# GOOD - Boolean condition
+resource "aws_nat_gateway" "this" {
+  count = var.create_nat_gateway ? 1 : 0
+  # ...
+}
+```
+
+**Stable addressing with for_each:**
+```hcl
+# GOOD - Removing "us-east-1b" only affects that subnet
+resource "aws_subnet" "private" {
+  for_each = toset(var.availability_zones)
+
+  availability_zone = each.key
+  # ...
+}
+
+# BAD - Removing middle AZ recreates all subsequent subnets
+resource "aws_subnet" "private" {
+  count = length(var.availability_zones)
+
+  availability_zone = var.availability_zones[count.index]
+  # ...
+}
+```
+
+**For migration guides and detailed examples, see:** [Code Patterns: Count vs For_Each](references/code-patterns.md#count-vs-for_each-deep-dive)
+
+## Locals for Dependency Management
+
+**Use locals to ensure correct resource deletion order:**
+
+```hcl
+# Problem: Subnets might be deleted after CIDR blocks, causing errors
+# Solution: Use try() in locals to hint deletion order
+
+locals {
+  # References secondary CIDR first, falling back to VPC
+  # Forces Terraform to delete subnets before CIDR association
+  vpc_id = try(
+    aws_vpc_ipv4_cidr_block_association.this[0].vpc_id,
+    aws_vpc.this.id,
+    ""
+  )
+}
+
+resource "aws_vpc" "this" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_vpc_ipv4_cidr_block_association" "this" {
+  count = var.add_secondary_cidr ? 1 : 0
+
+  vpc_id     = aws_vpc.this.id
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_subnet" "public" {
+  vpc_id     = local.vpc_id  # Uses local, not direct reference
+  cidr_block = "10.1.0.0/24"
+}
+```
+
+**Why this matters:**
+- Prevents deletion errors when destroying infrastructure
+- Ensures correct dependency order without explicit `depends_on`
+- Particularly useful for VPC configurations with secondary CIDR blocks
+
+**For detailed examples, see:** [Code Patterns: Locals for Dependency Management](references/code-patterns.md#locals-for-dependency-management)
+
+## Module Development
+
+### Standard Module Structure
+
+```
+my-module/
+├── README.md           # Usage documentation
+├── main.tf             # Primary resources
+├── variables.tf        # Input variables with descriptions
+├── outputs.tf          # Output values
+├── versions.tf         # Provider version constraints
+├── examples/
+│   ├── minimal/        # Minimal working example
+│   └── complete/       # Full-featured example
+└── tests/              # Test files
+    └── module_test.tftest.hcl  # Or .go
+```
+
+### Best Practices Summary
+
+**Variables:**
+- Always include `description`
+- Use explicit `type` constraints
+- Provide sensible `default` values where appropriate
+- Add `validation` blocks for complex constraints
+- Use `sensitive = true` for secrets
+
+**Outputs:**
+- Always include `description`
+- Mark sensitive outputs with `sensitive = true`
+- Consider returning objects for related values
+- Document what consumers should do with each output
+
+**For detailed module patterns, see:**
+- **[Module Patterns Guide](references/module-patterns.md)** - Variable best practices, output design, DO vs DON'T patterns
+- **[Quick Reference](references/quick-reference.md#common-patterns)** - Resource naming, variable naming, file organization
+
+## CI/CD Integration
+
+### Recommended Workflow Stages
+
+1. **Validate** - Format check + syntax validation + linting
+2. **Test** - Run automated tests (native or Terratest)
+3. **Plan** - Generate and review execution plan
+4. **Apply** - Execute changes (with approvals for production)
+
+### Cost Optimization Strategy
+
+1. **Use mocking for PR validation** (free)
+2. **Run integration tests only on main branch** (controlled cost)
+3. **Implement auto-cleanup** (prevent orphaned resources)
+4. **Tag all test resources** (track spending)
+
+**For complete CI/CD templates, see:**
+- **[CI/CD Workflows Guide](references/ci-cd-workflows.md)** - GitHub Actions, GitLab CI, Atlantis integration, cost optimization
+- **[Quick Reference](references/quick-reference.md#troubleshooting-guide)** - Common CI/CD issues and solutions
+
+## Security & Compliance
+
+### Essential Security Checks
+
+```bash
+# Static security scanning
+trivy config .
+checkov -d .
+```
+
+### Common Issues to Avoid
+
+**Don't:**
+- Store secrets in variables
+- Use default VPC
+- Skip encryption
+- Open security groups to 0.0.0.0/0
+
+**Do:**
+- Use AWS Secrets Manager / Parameter Store
+- Create dedicated VPCs
+- Enable encryption at rest
+- Use least-privilege security groups
+
+**For detailed security guidance, see:**
+- **[Security & Compliance Guide](references/security-compliance.md)** - Trivy/Checkov integration, secrets management, state file security, compliance testing
+
+## Version Management
+
+> **Provectus Convention: All versions must be pinned to exact versions. No pessimistic (`~>`) or range constraints.**
+
+### Version Constraint Syntax
+
+```hcl
+version = "= 5.82.2"    # Exact (required by Provectus convention)
+version = "5.1.2"        # Exact (alternative syntax for modules)
+```
+
+### Strategy by Component
+
+| Component | Strategy | Example |
+|-----------|----------|---------|
+| **Terraform** | Pin exact version | `required_version = "= 1.9.8"` |
+| **Providers** | Pin exact version | `version = "= 5.82.2"` |
+| **Modules (prod)** | Pin exact version | `version = "5.1.2"` |
+| **Modules (dev)** | Pin exact version | `version = "5.1.2"` |
+
+### Update Workflow
+
+```bash
+# Lock versions initially
+terraform init              # Creates .terraform.lock.hcl
+
+# Update to latest within constraints
+terraform init -upgrade     # Updates providers
+
+# Review and test
+terraform plan
+```
+
+**For detailed version management, see:** [Code Patterns: Version Management](references/code-patterns.md#version-management)
+
+## Modern Terraform Features (1.0+)
+
+### Feature Availability by Version
+
+| Feature | Version | Use Case |
+|---------|---------|----------|
+| `try()` function | 0.13+ | Safe fallbacks, replaces `element(concat())` |
+| `nullable = false` | 1.1+ | Prevent null values in variables |
+| `moved` blocks | 1.1+ | Refactor without destroy/recreate |
+| `optional()` with defaults | 1.3+ | Optional object attributes |
+| Native testing | 1.6+ | Built-in test framework |
+| Mock providers | 1.7+ | Cost-free unit testing |
+| Provider functions | 1.8+ | Provider-specific data transformation |
+| Cross-variable validation | 1.9+ | Validate relationships between variables |
+| Write-only arguments | 1.11+ | Secrets never stored in state |
+
+### Quick Examples
+
+```hcl
+# try() - Safe fallbacks (0.13+)
+output "sg_id" {
+  value = try(aws_security_group.this[0].id, "")
+}
+
+# optional() - Optional attributes with defaults (1.3+)
+variable "config" {
+  type = object({
+    name    = string
+    timeout = optional(number, 300)  # Default: 300
+  })
+}
+
+# Cross-variable validation (1.9+)
+variable "environment" { type = string }
+variable "backup_days" {
+  type = number
+  validation {
+    condition     = var.environment == "prod" ? var.backup_days >= 7 : true
+    error_message = "Production requires backup_days >= 7"
+  }
+}
+```
+
+**For complete patterns and examples, see:** [Code Patterns: Modern Terraform Features](references/code-patterns.md#modern-terraform-features-10)
+
+## Version-Specific Guidance
+
+### Terraform 1.0-1.5
+- Use Terratest for testing
+- No native testing framework available
+- Focus on static analysis and plan validation
+
+### Terraform 1.6+ / OpenTofu 1.6+
+- **New:** Native `terraform test` / `tofu test` command
+- Consider migrating from external frameworks for simple tests
+- Keep Terratest only for complex integration tests
+
+### Terraform 1.7+ / OpenTofu 1.7+
+- **New:** Mock providers for unit testing
+- Reduce cost by mocking external dependencies
+- Use real integration tests for final validation
+
+### Terraform vs OpenTofu
+
+Both are fully supported by this skill. For licensing, governance, and feature comparison, see [Quick Reference: Terraform vs OpenTofu](references/quick-reference.md#terraform-vs-opentofu-comparison).
+
+## Detailed Guides
+
+This skill uses **progressive disclosure** - essential information is in this main file, detailed guides are available when needed:
+
+**Reference Files:**
+- **[Testing Frameworks](references/testing-frameworks.md)** - In-depth guide to static analysis, native tests, and Terratest
+- **[Module Patterns](references/module-patterns.md)** - Module structure, variable/output best practices, DO vs DON'T patterns
+- **[CI/CD Workflows](references/ci-cd-workflows.md)** - GitHub Actions, GitLab CI templates, cost optimization, automated cleanup
+- **[Security & Compliance](references/security-compliance.md)** - Trivy/Checkov integration, secrets management, compliance testing
+- **[Quick Reference](references/quick-reference.md)** - Command cheat sheets, decision flowcharts, troubleshooting guide
+
+**How to use:** When you need detailed information on a topic, reference the appropriate guide. Claude will load it on demand to provide comprehensive guidance.
+
+## License
+
+This skill is based on [terraform-skill](https://github.com/antonbabenko/terraform-skill) by Anton Babenko, licensed under the **Apache License 2.0**.

--- a/registry/skills/terraform-conventions/references/ci-cd-workflows.md
+++ b/registry/skills/terraform-conventions/references/ci-cd-workflows.md
@@ -1,0 +1,473 @@
+# CI/CD Workflows for Terraform
+
+> **Part of:** [terraform-skill](../SKILL.md)
+> **Purpose:** CI/CD integration patterns for Terraform/OpenTofu
+
+This document provides detailed CI/CD workflow templates and optimization strategies for infrastructure-as-code pipelines.
+
+---
+
+## Table of Contents
+
+1. [GitHub Actions Workflow](#github-actions-workflow)
+2. [GitLab CI Template](#gitlab-ci-template)
+3. [Cost Optimization](#cost-optimization)
+4. [Automated Cleanup](#automated-cleanup)
+5. [Best Practices](#best-practices)
+
+---
+
+## GitHub Actions Workflow
+
+### Complete Example
+
+```yaml
+# .github/workflows/terraform.yml
+name: Terraform
+
+on: [push, pull_request]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/setup-terraform@v2
+
+      - name: Terraform Format
+        run: terraform fmt -check -recursive
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: TFLint
+        run: |
+          curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+          tflint --init
+          tflint
+
+  test:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run Terraform Tests
+        run: terraform test
+
+      # Or for Terratest:
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: Run Terratest
+        run: |
+          cd tests
+          go test -v -timeout 30m -parallel 4
+
+  plan:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/setup-terraform@v2
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Plan
+        run: terraform plan -out=tfplan
+
+      - name: Upload Plan
+        uses: actions/upload-artifact@v3
+        with:
+          name: tfplan
+          path: tfplan
+
+  apply:
+    needs: plan
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    environment: production
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/setup-terraform@v2
+
+      - name: Download Plan
+        uses: actions/download-artifact@v3
+        with:
+          name: tfplan
+
+      - name: Terraform Apply
+        run: terraform apply tfplan
+```
+
+### With Cost Estimation (Infracost)
+
+```yaml
+  cost-estimate:
+    needs: plan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Infracost
+        uses: infracost/actions/setup@v2
+        with:
+          api-key: ${{ secrets.INFRACOST_API_KEY }}
+
+      - name: Generate Cost Estimate
+        run: |
+          infracost breakdown --path . \
+            --format json \
+            --out-file /tmp/infracost.json
+
+      - name: Post Cost Comment
+        uses: infracost/actions/comment@v1
+        with:
+          path: /tmp/infracost.json
+          behavior: update
+```
+
+---
+
+## GitLab CI Template
+
+```yaml
+# .gitlab-ci.yml
+stages:
+  - validate
+  - test
+  - plan
+  - apply
+
+variables:
+  TF_ROOT: ${CI_PROJECT_DIR}
+
+.terraform_template:
+  image: hashicorp/terraform:latest
+  before_script:
+    - cd ${TF_ROOT}
+    - terraform init
+
+validate:
+  extends: .terraform_template
+  stage: validate
+  script:
+    - terraform fmt -check -recursive
+    - terraform validate
+
+test:
+  extends: .terraform_template
+  stage: test
+  script:
+    - terraform test
+  only:
+    - merge_requests
+    - main
+
+plan:
+  extends: .terraform_template
+  stage: plan
+  script:
+    - terraform plan -out=tfplan
+  artifacts:
+    paths:
+      - ${TF_ROOT}/tfplan
+    expire_in: 1 week
+  only:
+    - merge_requests
+    - main
+
+apply:
+  extends: .terraform_template
+  stage: apply
+  script:
+    - terraform apply tfplan
+  dependencies:
+    - plan
+  only:
+    - main
+  when: manual
+  environment:
+    name: production
+```
+
+---
+
+## Cost Optimization
+
+### Strategy
+
+1. **Use mocking for PR validation** (free)
+2. **Run integration tests only on main branch** (controlled cost)
+3. **Implement auto-cleanup** (prevent orphaned resources)
+4. **Tag all test resources** (track spending)
+
+### Example: Conditional Test Execution
+
+```yaml
+# GitHub Actions
+test:
+  runs-on: ubuntu-latest
+  steps:
+    - name: Run Unit Tests (Mocked)
+      run: terraform test
+
+    - name: Run Integration Tests
+      if: github.ref == 'refs/heads/main'
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      run: |
+        cd tests
+        go test -v -timeout 30m
+```
+
+### Cost-Aware Test Tags
+
+```go
+// In Terratest
+terraformOptions := &terraform.Options{
+    TerraformDir: "../examples/complete",
+    Vars: map[string]interface{}{
+        "tags": map[string]string{
+            "Environment": "test",
+            "TTL":         "2h",
+            "CreatedBy":   "CI",
+            "JobID":       os.Getenv("GITHUB_RUN_ID"),
+        },
+    },
+}
+```
+
+---
+
+## Automated Cleanup
+
+### Cleanup Script (Bash)
+
+```bash
+#!/bin/bash
+# cleanup-test-resources.sh
+
+# Find and terminate instances older than 2 hours with test tag
+aws resourcegroupstaggingapi get-resources \
+  --tag-filters Key=Environment,Values=test \
+  --query 'ResourceTagMappingList[?Tags[?Key==`TTL` && Value<`'$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%S)'`]].ResourceARN' \
+  --output text | \
+  while read arn; do
+    instance_id=$(echo $arn | grep -oP 'instance/\K[^/]+')
+    if [ ! -z "$instance_id" ]; then
+      echo "Terminating instance: $instance_id"
+      aws ec2 terminate-instances --instance-ids $instance_id
+    fi
+  done
+```
+
+### Scheduled Cleanup (GitHub Actions)
+
+```yaml
+# .github/workflows/cleanup.yml
+name: Cleanup Test Resources
+
+on:
+  schedule:
+    - cron: '0 */2 * * *'  # Every 2 hours
+  workflow_dispatch:        # Manual trigger
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Run Cleanup Script
+        run: ./scripts/cleanup-test-resources.sh
+```
+
+---
+
+## Best Practices
+
+### 1. Separate Environments
+
+```yaml
+# Different workflows for different environments
+.github/workflows/
+  terraform-dev.yml
+  terraform-staging.yml
+  terraform-prod.yml
+```
+
+Or use reusable workflows:
+
+```yaml
+# .github/workflows/terraform-deploy.yml (reusable)
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+
+jobs:
+  deploy:
+    environment: ${{ inputs.environment }}
+    # ... deployment steps
+```
+
+### 2. Require Approvals for Production
+
+```yaml
+apply:
+  environment:
+    name: production
+    # Requires manual approval in GitHub
+  when: manual
+```
+
+### 3. Use Remote State
+
+```hcl
+# backend.tf
+terraform {
+  backend "s3" {
+    bucket         = "my-terraform-state"
+    key            = "prod/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+  }
+}
+```
+
+### 4. Implement State Locking
+
+```yaml
+# In CI, use -lock-timeout to handle concurrent runs
+- name: Terraform Apply
+  run: terraform apply -lock-timeout=10m tfplan
+```
+
+### 5. Cache Terraform Plugins
+
+```yaml
+# GitHub Actions
+- name: Cache Terraform Plugins
+  uses: actions/cache@v3
+  with:
+    path: |
+      ~/.terraform.d/plugin-cache
+    key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
+```
+
+### 6. Security Scanning in CI
+
+```yaml
+security-scan:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v3
+
+    - name: Run Trivy
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: 'config'
+        scan-ref: '.'
+
+    - name: Run Checkov
+      uses: bridgecrewio/checkov-action@master
+      with:
+        directory: .
+        framework: terraform
+```
+
+---
+
+## Atlantis Integration
+
+[Atlantis](https://www.runatlantis.io/) provides Terraform automation via pull request comments.
+
+### atlantis.yaml
+
+```yaml
+version: 3
+projects:
+  - name: production
+    dir: environments/prod
+    workspace: default
+    terraform_version: v1.6.0
+    workflow: custom
+
+workflows:
+  custom:
+    plan:
+      steps:
+        - init
+        - plan:
+            extra_args: ["-lock", "false"]
+    apply:
+      steps:
+        - apply
+```
+
+### Benefits
+
+- Plan results as PR comments
+- Apply via PR comments
+- Locking prevents concurrent changes
+- Integrates with VCS (GitHub, GitLab, Bitbucket)
+
+---
+
+## Troubleshooting
+
+### Issue: Tests fail in CI but pass locally
+
+**Cause:** Different Terraform/provider versions
+
+**Solution:**
+
+```hcl
+# versions.tf - Pin exact versions (Provectus convention)
+terraform {
+  required_version = "= 1.9.8"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 5.82.2"
+    }
+  }
+}
+```
+
+### Issue: Parallel tests conflict
+
+**Cause:** Resource naming collisions
+
+**Solution:**
+
+```go
+// Use unique identifiers
+uniqueId := random.UniqueId()
+bucketName := fmt.Sprintf("test-bucket-%s-%s",
+    os.Getenv("GITHUB_RUN_ID"),
+    uniqueId)
+```
+
+---
+
+**Back to:** [Main Skill File](../SKILL.md)

--- a/registry/skills/terraform-conventions/references/code-patterns.md
+++ b/registry/skills/terraform-conventions/references/code-patterns.md
@@ -1,0 +1,841 @@
+# Code Patterns & Structure
+
+> **Part of:** [terraform-skill](../SKILL.md)
+> **Purpose:** Comprehensive patterns for Terraform/OpenTofu code structure and modern features
+
+This document provides detailed code patterns, structure guidelines, and modern Terraform features. For high-level principles, see the [main skill file](../SKILL.md).
+
+---
+
+## Table of Contents
+
+1. [Block Ordering & Structure](#block-ordering--structure)
+2. [Count vs For_Each Deep Dive](#count-vs-for_each-deep-dive)
+3. [Modern Terraform Features (1.0+)](#modern-terraform-features-10)
+4. [Version Management](#version-management)
+5. [Refactoring Patterns](#refactoring-patterns)
+6. [Locals for Dependency Management](#locals-for-dependency-management)
+
+---
+
+## Block Ordering & Structure
+
+### Resource Block Structure
+
+**Strict argument ordering:**
+
+1. `count` or `for_each` FIRST (blank line after)
+2. Other arguments (alphabetical or logical grouping)
+3. `tags` as last real argument
+4. `depends_on` after tags (if needed)
+5. `lifecycle` at the very end (if needed)
+
+```hcl
+# GOOD - Correct ordering with required tags
+resource "aws_nat_gateway" "this" {
+  count = var.create_nat_gateway ? 1 : 0
+
+  allocation_id = aws_eip.this[0].id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = merge(local.required_tags, {
+    Name = "${var.name}-nat"
+  })
+
+  depends_on = [aws_internet_gateway.this]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# BAD - Wrong ordering, missing required tags
+resource "aws_nat_gateway" "this" {
+  allocation_id = aws_eip.this[0].id
+
+  tags = { Name = "nat" }
+
+  count = var.create_nat_gateway ? 1 : 0  # Should be first
+
+  subnet_id = aws_subnet.public[0].id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [aws_internet_gateway.this]  # Should be after tags
+}
+```
+
+### Variable Definition Structure
+
+**Variable block ordering:**
+
+1. `description` (ALWAYS required)
+2. `type`
+3. `default`
+4. `sensitive` (when setting to true)
+5. `nullable` (when setting to false)
+6. `validation`
+
+```hcl
+# GOOD - Correct ordering and structure
+variable "environment" {
+  description = "Environment name for resource tagging"
+  type        = string
+  default     = "dev"
+  nullable    = false
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be one of: dev, staging, prod."
+  }
+}
+```
+
+### Variable Type Preferences
+
+- Prefer **simple types** (`string`, `number`, `list()`, `map()`) over `object()` unless strict validation needed
+- Use `optional()` for optional object attributes (Terraform 1.3+)
+- Use `any` to disable validation at certain depths or support multiple types
+
+**Modern variable patterns (Terraform 1.3+):**
+
+```hcl
+# GOOD - Using optional() for object attributes
+variable "database_config" {
+  description = "Database configuration with optional parameters"
+  type = object({
+    name               = string
+    engine             = string
+    instance_class     = string
+    backup_retention   = optional(number, 7)      # Default: 7
+    monitoring_enabled = optional(bool, true)     # Default: true
+    tags               = optional(map(string), {}) # Default: {}
+  })
+}
+
+# Usage - only required fields needed
+database_config = {
+  name           = "mydb"
+  engine         = "mysql"
+  instance_class = "db.t3.micro"
+  # Optional fields use defaults
+}
+```
+
+**Complex type example:**
+
+```hcl
+# For lists/maps of same type
+variable "subnet_configs" {
+  description = "Map of subnet configurations"
+  type        = map(map(string))  # All values are maps of strings
+}
+
+# When types vary, use any
+variable "mixed_config" {
+  description = "Configuration with varying types"
+  type        = any
+}
+```
+
+### Output Structure
+
+**Pattern:** `{name}_{type}_{attribute}`
+
+```hcl
+# GOOD
+output "security_group_id" {  # "this_" should be omitted
+  description = "The ID of the security group"
+  value       = try(aws_security_group.this[0].id, "")
+}
+
+output "private_subnet_ids" {  # Plural for list
+  description = "List of private subnet IDs"
+  value       = aws_subnet.private[*].id
+}
+
+# BAD
+output "this_security_group_id" {  # Don't prefix with "this_"
+  value = aws_security_group.this[0].id
+}
+
+output "subnet_id" {  # Should be plural "subnet_ids"
+  value = aws_subnet.private[*].id  # Returns list
+}
+```
+
+---
+
+## Count vs For_Each Deep Dive
+
+### When to use count
+
+**Simple numeric replication:**
+```hcl
+resource "aws_subnet" "public" {
+  count = 3
+
+  cidr_block = cidrsubnet(var.vpc_cidr, 8, count.index)
+}
+```
+
+**Boolean conditions (create or don't):**
+```hcl
+# GOOD - Boolean condition
+resource "aws_nat_gateway" "this" {
+  count = var.create_nat_gateway ? 1 : 0
+}
+
+# Less preferred - length check
+resource "aws_nat_gateway" "this" {
+  count = length(var.public_subnets) > 0 ? 1 : 0
+}
+```
+
+**When order doesn't matter and items won't change**
+
+### When to use for_each
+
+**Reference resources by key:**
+```hcl
+resource "aws_subnet" "private" {
+  for_each = toset(var.availability_zones)
+
+  vpc_id            = aws_vpc.this.id
+  availability_zone = each.key
+  cidr_block        = cidrsubnet(var.vpc_cidr, 4, index(var.availability_zones, each.key))
+}
+
+# Reference by key: aws_subnet.private["us-east-1a"]
+```
+
+**Items may be added/removed from middle:**
+```hcl
+# BAD with count - removing middle item recreates all subsequent resources
+resource "aws_subnet" "private" {
+  count = length(var.availability_zones)
+
+  availability_zone = var.availability_zones[count.index]
+  # If var.availability_zones[1] removed, all resources after recreated!
+}
+
+# GOOD with for_each - removal only affects that one resource
+resource "aws_subnet" "private" {
+  for_each = toset(var.availability_zones)
+
+  availability_zone = each.key
+  # Removing one AZ only destroys that subnet
+}
+```
+
+**Creating multiple named resources:**
+```hcl
+variable "environments" {
+  default = {
+    dev = {
+      instance_type = "t3.micro"
+      instance_count = 1
+    }
+    prod = {
+      instance_type = "t3.large"
+      instance_count = 3
+    }
+  }
+}
+
+resource "aws_instance" "app" {
+  for_each = var.environments
+
+  instance_type = each.value.instance_type
+  count         = each.value.instance_count
+
+  tags = {
+    Environment = each.key  # "dev" or "prod"
+  }
+}
+```
+
+### Count to For_Each Migration
+
+**When to migrate:** When you need stable resource addressing or items might be added/removed from middle of list.
+
+**Migration steps:**
+
+1. Add `for_each` to resource
+2. Use `moved` blocks to preserve existing resources
+3. Remove `count` after verifying with `terraform plan`
+
+**Complete example:**
+
+```hcl
+# Before (using count)
+variable "availability_zones" {
+  default = ["us-east-1a", "us-east-1b", "us-east-1c"]
+}
+
+resource "aws_subnet" "private" {
+  count = length(var.availability_zones)
+
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index)
+  availability_zone = var.availability_zones[count.index]
+
+  tags = {
+    Name = "private-${var.availability_zones[count.index]}"
+  }
+}
+
+# Reference: aws_subnet.private[0].id
+
+# After (using for_each)
+resource "aws_subnet" "private" {
+  for_each = toset(var.availability_zones)
+
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, index(var.availability_zones, each.key))
+  availability_zone = each.key
+
+  tags = {
+    Name = "private-${each.key}"
+  }
+}
+
+# Reference: aws_subnet.private["us-east-1a"].id
+
+# Migration blocks (prevents resource recreation)
+moved {
+  from = aws_subnet.private[0]
+  to   = aws_subnet.private["us-east-1a"]
+}
+
+moved {
+  from = aws_subnet.private[1]
+  to   = aws_subnet.private["us-east-1b"]
+}
+
+moved {
+  from = aws_subnet.private[2]
+  to   = aws_subnet.private["us-east-1c"]
+}
+
+# Verify migration:
+# terraform plan should show "moved" operations, not destroy/create
+```
+
+**Benefits after migration:**
+- Removing "us-east-1b" only destroys that subnet (not c)
+- Adding new AZ doesn't affect existing subnets
+- Resources have stable addresses by AZ name
+
+---
+
+## Modern Terraform Features (1.0+)
+
+### try() Function (Terraform 0.13+)
+
+**Use try() instead of element(concat()):**
+
+```hcl
+# GOOD - Modern try() function
+output "security_group_id" {
+  description = "The ID of the security group"
+  value       = try(aws_security_group.this[0].id, "")
+}
+
+output "first_subnet_id" {
+  description = "ID of first subnet with multiple fallbacks"
+  value       = try(
+    aws_subnet.public[0].id,
+    aws_subnet.private[0].id,
+    ""
+  )
+}
+
+# BAD - Legacy pattern
+output "security_group_id" {
+  value = element(concat(aws_security_group.this.*.id, [""]), 0)
+}
+```
+
+### nullable = false (Terraform 1.1+)
+
+**Set nullable = false for non-null variables:**
+
+```hcl
+# GOOD (Terraform 1.1+)
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  nullable    = false  # Passing null uses default, not null
+  default     = "10.0.0.0/16"
+}
+```
+
+### optional() with Defaults (Terraform 1.3+)
+
+**Use optional() for object attributes:**
+
+```hcl
+# GOOD - Using optional() for object attributes
+variable "database_config" {
+  description = "Database configuration with optional parameters"
+  type = object({
+    name               = string
+    engine             = string
+    instance_class     = string
+    backup_retention   = optional(number, 7)      # Default: 7
+    monitoring_enabled = optional(bool, true)     # Default: true
+    tags               = optional(map(string), {}) # Default: {}
+  })
+}
+
+# Usage - only required fields needed
+database_config = {
+  name           = "mydb"
+  engine         = "mysql"
+  instance_class = "db.t3.micro"
+  # Optional fields use defaults
+}
+```
+
+### Moved Blocks (Terraform 1.1+)
+
+**Rename resources without destroy/recreate:**
+
+```hcl
+# Rename a resource
+moved {
+  from = aws_instance.web_server
+  to   = aws_instance.web
+}
+
+# Rename a module
+moved {
+  from = module.old_module_name
+  to   = module.new_module_name
+}
+
+# Move resource into for_each
+moved {
+  from = aws_subnet.private[0]
+  to   = aws_subnet.private["us-east-1a"]
+}
+```
+
+### Provider-Defined Functions (Terraform 1.8+)
+
+**Use provider-specific functions for data transformation:**
+
+```hcl
+# AWS provider function example
+data "aws_region" "current" {}
+
+locals {
+  # Provider function (Terraform 1.8+)
+  bucket_name = provider::aws::arn_build("s3", "my-bucket", data.aws_region.current.name)
+}
+
+# Check provider documentation for available functions
+# Common providers adding functions: AWS, Azure, Google Cloud
+```
+
+### Cross-Variable Validation (Terraform 1.9+)
+
+**Reference other variables in validation blocks:**
+
+```hcl
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+}
+
+variable "storage_size" {
+  description = "Storage size in GB"
+  type        = number
+
+  validation {
+    # Can reference var.instance_type in Terraform 1.9+
+    condition = !(
+      var.instance_type == "db.t3.micro" &&
+      var.storage_size > 1000
+    )
+    error_message = "Micro instances cannot have storage > 1000 GB"
+  }
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "backup_retention" {
+  description = "Backup retention period in days"
+  type        = number
+
+  validation {
+    # Production requires longer retention
+    condition = (
+      var.environment == "prod" ? var.backup_retention >= 7 : true
+    )
+    error_message = "Production environment requires backup_retention >= 7 days"
+  }
+}
+```
+
+### Write-Only Arguments (Terraform 1.11+)
+
+**Always use write-only arguments or external secret management:**
+
+```hcl
+# GOOD - External secret with write-only argument
+data "aws_secretsmanager_secret" "db_password" {
+  name = "prod-database-password"
+}
+
+data "aws_secretsmanager_secret_version" "db_password" {
+  secret_id = data.aws_secretsmanager_secret.db_password.id
+}
+
+resource "aws_db_instance" "this" {
+  engine         = "mysql"
+  instance_class = "db.t3.micro"
+  username       = "admin"
+
+  # write-only: Terraform sends to AWS then forgets it (not in state)
+  password_wo = data.aws_secretsmanager_secret_version.db_password.secret_string
+}
+
+# BAD - Secret ends up in state file
+resource "random_password" "db" {
+  length = 16
+}
+
+resource "aws_db_instance" "this" {
+  password = random_password.db.result  # Stored in state!
+}
+
+# BAD - Variable secret stored in state
+resource "aws_db_instance" "this" {
+  password = var.db_password  # Ends up in state file
+}
+```
+
+---
+
+## Version Management
+
+> **Provectus Convention: All versions must be pinned to exact versions. No pessimistic (`~>`) or range constraints.**
+
+### Version Constraint Syntax
+
+```hcl
+# Exact version (required by Provectus convention)
+version = "= 5.82.2"
+
+# For modules (quotes-only syntax also pins exactly)
+version = "5.1.2"
+```
+
+### Versioning Strategy by Component
+
+**Terraform itself:**
+```hcl
+# versions.tf
+terraform {
+  # Pin to exact version
+  required_version = "= 1.9.8"
+}
+```
+
+**Providers:**
+```hcl
+# versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 5.82.2"  # Pin exact version
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "= 3.6.3"
+    }
+  }
+}
+```
+
+**Modules:**
+```hcl
+# All environments - pin exact version
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.1.2"  # Exact version for all environments
+}
+```
+
+### Update Strategy
+
+**Security patches:**
+- Update immediately
+- Test in dev -> stage -> prod
+- Prioritize provider and Terraform core updates
+
+**Minor versions:**
+- Regular maintenance windows (monthly/quarterly)
+- Review changelog for breaking changes
+- Test thoroughly before production
+
+**Major versions:**
+- Planned upgrade cycles
+- Dedicated testing period
+- May require code changes
+- Update in phases: dev -> stage -> prod
+
+### Version Management Workflow
+
+```hcl
+# Step 1: Lock versions in versions.tf
+terraform {
+  required_version = "= 1.9.8"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 5.82.2"
+    }
+  }
+}
+
+# Step 2: Generate lock file (commit this)
+terraform init
+# Creates .terraform.lock.hcl with exact versions used
+
+# Step 3: When updating, change the exact version in versions.tf first
+# Then run terraform init -upgrade
+
+# Step 4: Review and test changes before committing
+terraform plan
+```
+
+### Example versions.tf Template
+
+```hcl
+terraform {
+  # Terraform version - pinned exactly
+  required_version = "= 1.9.8"
+
+  # Provider versions - pinned exactly
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 5.82.2"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "= 3.6.3"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.3"
+    }
+  }
+
+  # Backend configuration (optional here, often in backend.tf)
+  backend "s3" {
+    bucket = "my-terraform-state"
+    key    = "infrastructure/terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+```
+
+---
+
+## Refactoring Patterns
+
+### Terraform Version Upgrades
+
+#### 0.12/0.13 -> 1.x Migration Checklist
+
+**Replace legacy patterns with modern equivalents:**
+
+- [ ] Replace `element(concat(...))` with `try()`
+- [ ] Add `nullable = false` to variables that shouldn't accept null
+- [ ] Use `optional()` in object types for optional attributes
+- [ ] Add `validation` blocks to variables with constraints
+- [ ] Migrate secrets to write-only arguments (Terraform 1.11+)
+- [ ] Use `moved` blocks for resource refactoring (Terraform 1.1+)
+- [ ] Consider cross-variable validation (Terraform 1.9+)
+
+**Example migration:**
+
+```hcl
+# Before (0.12 style)
+output "security_group_id" {
+  value = element(concat(aws_security_group.this.*.id, [""]), 0)
+}
+
+variable "config" {
+  type = object({
+    name = string
+    size = number
+  })
+}
+
+# After (1.x style)
+output "security_group_id" {
+  description = "The ID of the security group"
+  value       = try(aws_security_group.this[0].id, "")
+}
+
+variable "config" {
+  description = "Configuration settings"
+  type = object({
+    name = string
+    size = optional(number, 100)  # Optional with default
+  })
+  nullable = false  # Don't accept null
+}
+```
+
+### Secrets Remediation
+
+**Pattern:** Move secrets out of Terraform state into external secret management.
+
+#### Before - Secrets in State
+
+```hcl
+# BAD - Secret generated and stored in state
+resource "random_password" "db" {
+  length  = 16
+  special = true
+}
+
+resource "aws_db_instance" "this" {
+  engine   = "mysql"
+  username = "admin"
+  password = random_password.db.result  # In state!
+}
+
+# OR
+
+# BAD - Secret passed via variable and stored in state
+variable "db_password" {
+  description = "Database password"
+  type        = string
+  sensitive   = true  # Marked sensitive but still in state!
+}
+
+resource "aws_db_instance" "this" {
+  password = var.db_password  # In state!
+}
+```
+
+#### After - External Secret Management
+
+**Option 1: Write-only arguments (Terraform 1.11+)**
+
+```hcl
+# GOOD - Fetch from AWS Secrets Manager
+data "aws_secretsmanager_secret" "db_password" {
+  name = "prod-database-password"
+}
+
+data "aws_secretsmanager_secret_version" "db_password" {
+  secret_id = data.aws_secretsmanager_secret.db_password.id
+}
+
+resource "aws_db_instance" "this" {
+  engine   = "mysql"
+  username = "admin"
+
+  # write-only: Sent to AWS, not stored in state
+  password_wo = data.aws_secretsmanager_secret_version.db_password.secret_string
+}
+```
+
+**Option 2: Separate secret creation (if Terraform 1.11+ not available)**
+
+```hcl
+# GOOD - Reference pre-existing secret
+# Secret created outside Terraform (manually or separate process)
+
+data "aws_secretsmanager_secret" "db_password" {
+  name = "prod-database-password"
+}
+
+data "aws_secretsmanager_secret_version" "db_password" {
+  secret_id = data.aws_secretsmanager_secret.db_password.id
+}
+
+# Note: Without write-only, you may need to handle secret rotation
+# outside Terraform or accept that the secret value appears in state
+# during initial creation but not after rotation
+```
+
+**Migration steps:**
+
+1. Create secret in AWS Secrets Manager (outside Terraform)
+2. Update Terraform to use data sources
+3. Use write-only argument (if Terraform 1.11+)
+4. Remove `random_password` resource or variable
+5. Run `terraform apply` to update
+6. Verify secret not in state: `terraform show` should not display password
+
+---
+
+## Locals for Dependency Management
+
+**Use locals to hint explicit resource deletion order:**
+
+```hcl
+# GOOD - Forces correct deletion order
+# Ensures subnets deleted before secondary CIDR blocks
+
+locals {
+  # References secondary CIDR first, falling back to VPC
+  # This forces Terraform to delete subnets before CIDR association
+  vpc_id = try(
+    aws_vpc_ipv4_cidr_block_association.this[0].vpc_id,
+    aws_vpc.this.id,
+    ""
+  )
+}
+
+resource "aws_vpc" "this" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_vpc_ipv4_cidr_block_association" "this" {
+  count = var.add_secondary_cidr ? 1 : 0
+
+  vpc_id     = aws_vpc.this.id
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_subnet" "public" {
+  # Uses local instead of direct reference
+  # Creates implicit dependency on CIDR association
+  vpc_id     = local.vpc_id
+  cidr_block = "10.1.0.0/24"
+}
+
+# Without local: Terraform might try to delete CIDR before subnets -> ERROR
+# With local: Subnets deleted first, then CIDR association, then VPC
+```
+
+**Why this matters:**
+- Prevents deletion errors when destroying infrastructure
+- Ensures correct dependency order without explicit `depends_on`
+- Particularly useful for complex VPC configurations with secondary CIDR blocks
+
+**Common use cases:**
+- VPC with secondary CIDR blocks
+- Resources that depend on optional configurations
+- Complex deletion order requirements
+
+---
+
+**Back to:** [Main Skill File](../SKILL.md)

--- a/registry/skills/terraform-conventions/references/module-patterns.md
+++ b/registry/skills/terraform-conventions/references/module-patterns.md
@@ -1,0 +1,1126 @@
+# Module Development Patterns
+
+> **Part of:** [terraform-skill](../SKILL.md)
+> **Purpose:** Best practices for Terraform/OpenTofu module development
+
+This document provides detailed guidance on creating reusable, maintainable Terraform modules. For high-level principles, see the [main skill file](../SKILL.md#core-principles).
+
+---
+
+## Table of Contents
+
+1. [Module Hierarchy](#module-hierarchy)
+2. [Architecture Principles](#architecture-principles)
+3. [Module Structure](#module-structure)
+4. [Variable Best Practices](#variable-best-practices)
+5. [Output Best Practices](#output-best-practices)
+6. [Common Patterns](#common-patterns)
+7. [Anti-patterns to Avoid](#anti-patterns-to-avoid)
+8. [Testing Philosophy & Patterns](#testing-philosophy--patterns)
+
+---
+
+## Module Hierarchy
+
+### Module Type Classification
+
+Terraform modules can be organized into three distinct types, each serving a specific purpose:
+
+| Type | When to Use | Scope | Example |
+|------|-------------|-------|---------|
+| **Resource Module** | Single logical group of connected resources | Tightly coupled resources that always work together | VPC + subnets, Security group + rules, IAM role + policies |
+| **Infrastructure Module** | Collection of resource modules for a purpose | Multiple resource modules in one region/account | Complete networking stack, Application infrastructure |
+| **Composition** | Complete infrastructure | Spans multiple regions/accounts, orchestrates infrastructure modules | Multi-region deployment, Production environment |
+
+**Hierarchy:** Resource → Resource Module → Infrastructure Module → Composition
+
+### Resource Module
+
+**Characteristics:**
+- Smallest building block
+- Single logical group of resources
+- Highly reusable across projects
+- Minimal external dependencies
+- Clear, focused purpose
+
+**Examples:**
+```
+modules/
+├── vpc/                    # Resource module
+│   ├── main.tf            # VPC + subnets + route tables
+│   ├── variables.tf
+│   └── outputs.tf
+├── security-group/         # Resource module
+│   ├── main.tf            # Security group + rules
+│   ├── variables.tf
+│   └── outputs.tf
+└── rds/                    # Resource module
+    ├── main.tf            # RDS instance + subnet group
+    ├── variables.tf
+    └── outputs.tf
+```
+
+### Infrastructure Module
+
+**Characteristics:**
+- Combines multiple resource modules
+- Purpose-specific (e.g., "web application infrastructure")
+- May span multiple services
+- Region or account-specific
+- Moderate reusability
+
+**Examples:**
+```
+modules/
+└── web-application/        # Infrastructure module
+    ├── main.tf            # Orchestrates multiple resource modules
+    ├── variables.tf
+    ├── outputs.tf
+    └── README.md
+
+# main.tf contents:
+module "vpc" {
+  source = "../vpc"
+}
+
+module "alb" {
+  source = "../alb"
+  vpc_id = module.vpc.vpc_id
+}
+
+module "ecs" {
+  source = "../ecs"
+  vpc_id = module.vpc.vpc_id
+  subnets = module.vpc.private_subnet_ids
+}
+```
+
+### Composition
+
+**Characteristics:**
+- Highest level of abstraction
+- Complete environment or application
+- Combines infrastructure modules
+- Environment-specific (dev, staging, prod)
+- Not reusable (environment-specific values)
+
+**Examples:**
+```
+environments/
+├── prod/                   # Composition
+│   ├── main.tf            # Complete production environment
+│   ├── backend.tf         # Remote state configuration
+│   ├── terraform.tfvars   # Production-specific values
+│   └── variables.tf
+├── staging/                # Composition
+│   ├── main.tf
+│   ├── backend.tf
+│   ├── terraform.tfvars
+│   └── variables.tf
+└── dev/                    # Composition
+    ├── main.tf
+    ├── backend.tf
+    ├── terraform.tfvars
+    └── variables.tf
+```
+
+### Decision Tree: Which Module Type?
+
+```
+Question 1: Is this environment-specific configuration?
+├─ YES → Composition (environments/prod/, environments/staging/)
+└─ NO  → Continue
+
+Question 2: Does it combine multiple infrastructure concerns?
+├─ YES → Infrastructure Module (modules/web-application/)
+└─ NO  → Continue
+
+Question 3: Is it a focused group of related resources?
+└─ YES → Resource Module (modules/vpc/, modules/rds/)
+```
+
+### File Organization Standards
+
+**Required files in all modules:**
+```
+main.tf        # Resource definitions, module calls, data sources
+variables.tf   # Input variable declarations
+outputs.tf     # Output value declarations
+versions.tf    # Provider and Terraform version constraints
+README.md      # Usage documentation
+```
+
+**Conditional files:**
+```
+terraform.tfvars  # ONLY at composition level (NEVER in modules)
+locals.tf         # For complex local value calculations
+data.tf           # Optional: Data sources (if main.tf gets large)
+backend.tf        # ONLY at composition level (remote state config)
+```
+
+**Why separate files?**
+- **Consistency:** Same structure across all modules
+- **Discoverability:** Know where to find specific types of configuration
+- **Maintainability:** Easier to navigate and modify
+- **Terraform Registry:** Required structure for publishing
+
+---
+
+## Architecture Principles
+
+### 1. Smaller Scopes = Better Performance + Reduced Blast Radius
+
+**Benefits:**
+- Faster `terraform plan` and `terraform apply` operations
+- Isolated failures don't affect unrelated infrastructure
+- Easier to reason about changes
+- Parallel development by multiple teams
+
+**Example:**
+
+```hcl
+# ❌ BAD - One massive composition with everything
+environments/prod/
+  main.tf  # 2000 lines, manages VPC, EC2, RDS, S3, IAM, everything
+  # Takes 10+ minutes to plan
+  # One mistake affects entire infrastructure
+
+# ✅ GOOD - Separated by concern
+environments/prod/
+  networking/     # VPC, subnets, route tables
+  compute/        # EC2, ASG, ALB
+  data/           # RDS, ElastiCache
+  storage/        # S3, EFS
+  iam/            # IAM roles, policies
+```
+
+### 2. Always Use Remote State
+
+**Why:**
+- **Prevents race conditions** with multiple developers
+- **Provides disaster recovery** (state versioning)
+- **Enables team collaboration** (shared access)
+- **Supports state locking** (prevents concurrent modifications)
+
+**Never:**
+```hcl
+# ❌ BAD - Local state (default)
+# State stored in local terraform.tfstate file
+# Lost if computer crashes
+# Can't share with team
+```
+
+**Always:**
+```hcl
+# ✅ GOOD - Remote state
+terraform {
+  backend "s3" {
+    bucket         = "my-terraform-state"
+    key            = "prod/networking/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-locks"  # State locking
+    encrypt        = true                # Encryption at rest
+  }
+}
+```
+
+### 3. Use terraform_remote_state as Glue
+
+**Pattern:** Connect compositions via remote state data sources
+
+**Why:**
+- Loose coupling between infrastructure components
+- Teams can work independently
+- Changes to one stack don't require rebuilding others
+- Outputs from one stack become inputs to another
+
+**Example:**
+
+```hcl
+# environments/prod/networking/outputs.tf
+output "vpc_id" {
+  description = "ID of the production VPC"
+  value       = aws_vpc.this.id
+}
+
+output "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  value       = aws_subnet.private[*].id
+}
+
+# environments/prod/compute/main.tf
+data "terraform_remote_state" "networking" {
+  backend = "s3"
+  config = {
+    bucket = "my-terraform-state"
+    key    = "prod/networking/terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+
+module "ec2" {
+  source = "../../modules/ec2"
+
+  vpc_id     = data.terraform_remote_state.networking.outputs.vpc_id
+  subnet_ids = data.terraform_remote_state.networking.outputs.private_subnet_ids
+}
+```
+
+**Best practices:**
+- Use remote state for cross-team dependencies
+- Document which outputs are consumed by other stacks
+- Version outputs (don't break downstream consumers)
+- Consider using data sources instead for provider-managed resources
+
+### 4. Keep Resource Modules Simple
+
+**Principles:**
+- Don't hardcode values
+- Use variables for all configurable parameters
+- Use data sources for external dependencies
+- Focus on single responsibility
+
+**Example:**
+
+```hcl
+# ❌ BAD - Hardcoded values in resource module
+resource "aws_instance" "web" {
+  ami           = "ami-0c55b159cbfafe1f0"  # Hardcoded
+  instance_type = "t3.large"               # Hardcoded
+  subnet_id     = "subnet-12345678"        # Hardcoded
+
+  tags = {
+    Environment = "production"             # Hardcoded
+  }
+}
+
+# ✅ GOOD - Parameterized resource module
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"]  # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+}
+
+resource "aws_instance" "web" {
+  ami           = var.ami_id != "" ? var.ami_id : data.aws_ami.ubuntu.id
+  instance_type = var.instance_type
+  subnet_id     = var.subnet_id
+
+  tags = var.tags
+}
+```
+
+### 5. Composition Layer: Environment-Specific Values Only
+
+**Pattern:** Compositions provide concrete values, modules provide abstractions
+
+```hcl
+# ✅ GOOD - Composition with environment-specific values
+# environments/prod/main.tf
+
+module "vpc" {
+  source = "../../modules/vpc"
+
+  cidr_block           = "10.0.0.0/16"
+  availability_zones   = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  enable_nat_gateway   = true
+  single_nat_gateway   = false  # HA for production
+
+  tags = {
+    Environment = "production"
+    ManagedBy   = "Terraform"
+    CostCenter  = "engineering"
+  }
+}
+
+module "rds" {
+  source = "../../modules/rds"
+
+  instance_class       = "db.r5.xlarge"  # Production sizing
+  allocated_storage    = 500             # Production sizing
+  multi_az             = true            # HA for production
+  backup_retention     = 30              # Long retention for prod
+
+  vpc_id               = module.vpc.vpc_id
+  subnet_ids           = module.vpc.private_subnet_ids
+
+  tags = {
+    Environment = "production"
+  }
+}
+```
+
+---
+
+## Module Structure
+
+### Standard Layout
+
+```
+my-module/
+├── README.md                # Usage documentation
+├── LICENSE                  # MIT or Apache 2.0 (for public modules)
+├── .pre-commit-config.yaml  # Pre-commit hooks configuration
+├── main.tf                  # Primary resources
+├── variables.tf             # Input variables with descriptions
+├── outputs.tf               # Output values
+├── versions.tf              # Provider version constraints
+├── examples/
+│   ├── simple/              # Minimal working example
+│   └── complete/            # Full-featured example
+└── tests/                   # Test files
+    └── module_test.tftest.hcl  # Or .go
+```
+
+### Why This Structure?
+
+- **README.md** - First thing users see, should explain module purpose
+- **LICENSE** - Legal terms for public modules (MIT or Apache 2.0)
+- **.pre-commit-config.yaml** - Automated validation before commits
+- **main.tf** - Primary resources, keep focused
+- **variables.tf** - All inputs in one place with descriptions
+- **outputs.tf** - All outputs documented
+- **versions.tf** - Lock provider versions for stability
+- **examples/** - Serve as both documentation and test fixtures
+- **tests/** - Automated testing
+
+### License Files
+
+For public modules, always include a LICENSE file:
+- **MIT License** - Simple, permissive (common for public modules)
+- **Apache 2.0** - Permissive with patent grant protection
+
+**Important:** Do NOT store LICENSE templates in this skill. Generate them during module creation using user preference.
+
+**When to include:**
+- ✅ Public modules (GitHub, Terraform Registry)
+- ✅ Open-source projects
+- ❌ Private internal modules (optional)
+- ❌ Environment-specific configurations
+
+### Terraform vs OpenTofu Preference
+
+**Before generating any module or configuration:**
+
+1. **Ask the user:** "Will this be for Terraform or OpenTofu? (Both are supported equally)"
+
+2. **Use the preference throughout:**
+   - Command examples: `terraform` vs `tofu`
+   - README documentation
+   - CI/CD workflow templates
+   - Version constraints
+   - Binary references
+
+3. **Document the choice:**
+   ```markdown
+   ## Requirements
+
+   | Name | Version |
+   |------|---------|
+   | [terraform/tofu] | >= 1.7.0 |
+   | aws | >= 6.0 |
+   ```
+
+4. **Example command variations:**
+   ```bash
+   # Terraform
+   terraform init
+   terraform test
+   terraform plan
+
+   # OpenTofu
+   tofu init
+   tofu test
+   tofu plan
+   ```
+
+**Note:** The choice is primarily about commands and documentation. The HCL code itself is identical.
+
+**Default behavior:**
+- If user doesn't specify: Ask explicitly
+- If project already exists: Detect from existing files (`.terraform/` or `.tofu/`)
+- If still unclear: Default to showing both options in documentation
+
+---
+
+## Variable Best Practices
+
+### Complete Example
+
+```hcl
+variable "instance_type" {
+  description = "EC2 instance type for the application server"
+  type        = string
+  default     = "t3.micro"
+
+  validation {
+    condition     = contains(["t3.micro", "t3.small", "t3.medium"], var.instance_type)
+    error_message = "Instance type must be t3.micro, t3.small, or t3.medium."
+  }
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "enable_monitoring" {
+  description = "Enable CloudWatch detailed monitoring"
+  type        = bool
+  default     = true
+}
+```
+
+### Key Principles
+
+- ✅ **Always include `description`** - Helps users understand the variable
+- ✅ **Use explicit `type` constraints** - Catches errors early
+- ✅ **Provide sensible `default` values** - Where appropriate
+- ✅ **Add `validation` blocks** - For complex constraints
+- ✅ **Use `sensitive = true`** - For secrets (Terraform 0.14+)
+
+### Variable Naming
+
+```hcl
+# ✅ Good: Context-specific
+var.vpc_cidr_block          # Not just "cidr"
+var.database_instance_class # Not just "instance_class"
+var.application_port        # Not just "port"
+
+# ❌ Bad: Generic names
+var.name
+var.type
+var.value
+```
+
+---
+
+## Output Best Practices
+
+### Complete Example
+
+```hcl
+output "instance_id" {
+  description = "ID of the created EC2 instance"
+  value       = aws_instance.this.id
+}
+
+output "instance_arn" {
+  description = "ARN of the created EC2 instance"
+  value       = aws_instance.this.arn
+}
+
+output "private_ip" {
+  description = "Private IP address of the instance"
+  value       = aws_instance.this.private_ip
+  sensitive   = false  # Explicitly document sensitivity
+}
+
+output "connection_info" {
+  description = "Connection information for the instance"
+  value = {
+    id         = aws_instance.this.id
+    private_ip = aws_instance.this.private_ip
+    public_dns = aws_instance.this.public_dns
+  }
+}
+```
+
+### Key Principles
+
+- ✅ **Always include `description`** - Explain what the output is for
+- ✅ **Mark sensitive outputs** - Use `sensitive = true`
+- ✅ **Return objects for related values** - Groups logically related data
+- ✅ **Document intended use** - What should consumers do with this?
+
+---
+
+## Common Patterns
+
+### ✅ DO: Use `for_each` for Resources
+
+```hcl
+# Good: Maintain stable resource addresses
+resource "aws_instance" "server" {
+  for_each = toset(["web", "api", "worker"])
+
+  instance_type = "t3.micro"
+  tags = {
+    Name = each.key
+  }
+}
+```
+
+**Why?** When you remove an item from the middle, `for_each` doesn't reshuffle other resources.
+
+### ❌ DON'T: Use `count` When Order Matters
+
+```hcl
+# Bad: Removing middle item reshuffles all subsequent resources
+resource "aws_instance" "server" {
+  count = length(var.server_names)
+
+  tags = {
+    Name = var.server_names[count.index]
+  }
+}
+```
+
+**Problem:** If you remove `var.server_names[1]`, Terraform will destroy and recreate all instances after it.
+
+### ✅ DO: Separate Root Module from Reusable Modules
+
+```
+# Root module (environment-specific)
+prod/
+  main.tf          # Calls modules with prod-specific values
+  variables.tf     # Environment-specific variables
+
+# Reusable module
+modules/webapp/
+  main.tf          # Generic, parameterized resources
+  variables.tf     # Configurable inputs
+```
+
+**Why?** Root modules are environment-specific, reusable modules are generic.
+
+### ✅ DO: Use Locals for Computed Values
+
+```hcl
+locals {
+  common_tags = merge(
+    var.tags,
+    {
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    }
+  )
+
+  instance_name = "${var.project}-${var.environment}-instance"
+}
+
+resource "aws_instance" "app" {
+  tags = local.common_tags
+  # ...
+}
+```
+
+### ✅ DO: Version Your Modules
+
+```hcl
+# In consuming code
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.1.2"  # Pin exact version
+
+  # module inputs...
+}
+```
+
+**Why?** Prevents unexpected breaking changes.
+
+---
+
+## Anti-patterns to Avoid
+
+### ❌ DON'T: Hard-code Environment-Specific Values
+
+```hcl
+# Bad: Module is locked to production
+resource "aws_instance" "app" {
+  instance_type = "m5.large"  # Should be variable
+  tags = {
+    Environment = "production" # Should be variable
+  }
+}
+```
+
+**Fix:** Make everything configurable:
+
+```hcl
+resource "aws_instance" "app" {
+  instance_type = var.instance_type
+  tags          = var.tags
+}
+```
+
+### ❌ DON'T: Create God Modules
+
+```hcl
+# Bad: One module does everything
+module "everything" {
+  source = "./modules/app-infrastructure"
+
+  # Creates VPC, EC2, RDS, S3, IAM, CloudWatch, etc.
+}
+```
+
+**Problem:** Hard to test, hard to reuse, hard to maintain.
+
+**Fix:** Break into focused modules:
+
+```hcl
+module "networking" {
+  source = "./modules/vpc"
+}
+
+module "compute" {
+  source = "./modules/ec2"
+  vpc_id = module.networking.vpc_id
+}
+
+module "database" {
+  source = "./modules/rds"
+  vpc_id = module.networking.vpc_id
+}
+```
+
+### ❌ DON'T: Use `count` or `for_each` in Root Modules for Different Environments
+
+```hcl
+# Bad: All environments in one root module
+resource "aws_instance" "app" {
+  for_each = toset(["dev", "staging", "prod"])
+
+  instance_type = each.key == "prod" ? "m5.large" : "t3.micro"
+}
+```
+
+**Problem:** Can't have separate state files, blast radius is huge.
+
+**Fix:** Use separate root modules:
+
+```
+environments/
+  dev/
+    main.tf
+  staging/
+    main.tf
+  prod/
+    main.tf
+```
+
+### ❌ DON'T: Use `terraform_remote_state` Everywhere
+
+```hcl
+# Overused: Creates tight coupling
+data "terraform_remote_state" "vpc" {
+  # ...
+}
+
+data "terraform_remote_state" "database" {
+  # ...
+}
+
+data "terraform_remote_state" "security" {
+  # ...
+}
+```
+
+**Problem:** Changes to one state file break others.
+
+**Fix:** Use module outputs when possible, reserve remote state for truly separate teams.
+
+---
+
+## Module Naming Conventions
+
+### Public Modules
+
+Follow the Terraform Registry convention:
+
+```
+terraform-<PROVIDER>-<NAME>
+
+Examples:
+terraform-aws-vpc
+terraform-aws-eks
+terraform-google-network
+```
+
+### Private Modules
+
+Use organization-specific prefixes:
+
+```
+<ORG>-terraform-<PROVIDER>-<NAME>
+
+Examples:
+acme-terraform-aws-vpc
+acme-terraform-aws-rds
+```
+
+---
+
+## Testing Your Modules
+
+For testing guidance, see [testing-frameworks.md](testing-frameworks.md).
+
+Quick checklist:
+
+- [ ] Ask: Terraform or OpenTofu?
+- [ ] Ask: Public or private module?
+- [ ] Include `examples/` directory
+- [ ] Write tests (native or Terratest)
+- [ ] Document inputs and outputs in README.md
+- [ ] Version your module
+- [ ] Create `.gitignore` (from template below)
+- [ ] Create `.pre-commit-config.yaml` (from template above)
+- [ ] Create `LICENSE` file (MIT or Apache 2.0 for public modules)
+- [ ] Add attribution footer to README.md (see template below)
+
+### Pre-commit Hooks
+
+When creating new modules, always include pre-commit hooks for automated validation and documentation generation:
+
+**Standard .pre-commit-config.yaml template:**
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.92.0  # Use latest version from releases
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_tflint
+      - id: terraform_docs
+```
+
+**Installation:**
+
+```bash
+# Install pre-commit
+pip install pre-commit
+
+# Install hooks
+pre-commit install
+
+# Run manually
+pre-commit run -a
+```
+
+**Best practices:**
+- Include `.pre-commit-config.yaml` in all new modules
+- Pin to specific pre-commit-terraform version
+- Update version regularly
+
+**For module generation:**
+When generating new modules, also create:
+- `.pre-commit-config.yaml` (from template above)
+- `LICENSE` file (MIT or Apache 2.0, based on user preference)
+- `.gitignore` (from template below)
+- `README.md` with attribution footer (see template below)
+
+#### README.md Attribution Template
+
+When generating module README.md files, include this attribution footer:
+
+```markdown
+## Attribution
+
+This module was created following best practices from [terraform-skill](https://github.com/antonbabenko/terraform-skill) by Anton Babenko.
+
+Additional resources:
+- [terraform-best-practices.com](https://terraform-best-practices.com)
+- [Compliance.tf](https://compliance.tf)
+```
+
+**When to include attribution:**
+- ✅ All new modules created with terraform-skill guidance
+- ✅ Public modules (GitHub, Terraform Registry)
+- ✅ Private modules shared within organizations
+- ⚠️ Optional for one-off environment configurations
+
+**Rationale:** This is a derivative work as defined in the Apache 2.0 License Section 1. Attribution supports the open-source ecosystem and helps others discover these best practices.
+
+**README Structure with Attribution:**
+```markdown
+# Module Name
+
+## Description
+[Module purpose]
+
+## Usage
+[Usage examples]
+
+## Inputs
+[Input variables]
+
+## Outputs
+[Output values]
+
+## Requirements
+[Terraform/OpenTofu versions, providers]
+
+## Attribution
+[Attribution footer from template above]
+```
+
+#### .gitignore Template
+
+**Standard .gitignore for Terraform/OpenTofu projects:**
+
+```gitignore
+# .gitignore - Terraform/OpenTofu projects
+# Based on terraform-skill best practices
+
+# Local .terraform directories
+**/.terraform/*
+
+.terraform.lock.hcl
+
+# .tfstate files - NEVER commit state files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files (may contain sensitive data)
+*.tfvars
+*.tfvars.json
+
+# Ignore override files (local development)
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# CLI configuration files
+.terraformrc
+terraform.rc
+
+# Environment variables and secrets
+.env
+.env.*
+secrets/
+*.secret
+*.pem
+*.key
+
+# IDE and editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Terraform plan output files
+*.tfplan
+*.tfplan.json
+```
+
+---
+
+## Testing Philosophy & Patterns
+
+### What to Test in Terraform Modules
+
+**Core testing areas:**
+- **Input validation** - Variables accept valid values and reject invalid ones
+- **Resource creation** - Resources are created as expected with correct attributes
+- **Output correctness** - Outputs return expected values and types
+- **Idempotency** - Applying twice doesn't recreate resources
+- **Destroy completeness** - All resources are cleaned up properly
+
+**When to write tests:**
+- During development for reusable modules
+- Before publishing modules to registry
+- After significant refactoring
+- For modules with complex logic or conditionals
+
+### Testing Layers
+
+**1. Syntax validation:**
+```bash
+terraform fmt -check -recursive
+```
+
+**2. Configuration validity:**
+```bash
+terraform validate
+```
+
+**3. Plan preview:**
+```bash
+terraform plan
+# Review: Are expected resources being created?
+# Verify: Count and types of resources match expectations
+```
+
+**4. Integration testing:**
+```bash
+# Apply and verify
+terraform apply -auto-approve
+
+# Verify resources exist (use AWS CLI, etc.)
+aws ec2 describe-vpcs --vpc-ids $(terraform output -raw vpc_id)
+
+# Test idempotency - should show no changes
+terraform plan
+# Expected: "No changes. Your infrastructure matches the configuration."
+
+# Clean up
+terraform destroy -auto-approve
+```
+
+### Input Validation Testing
+
+Test that variables reject invalid values:
+
+```hcl
+# In variables.tf
+variable "environment" {
+  description = "Environment name"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be one of: dev, staging, prod."
+  }
+}
+
+# Test: terraform plan with invalid value should fail
+# terraform plan -var="environment=invalid"
+# Expected: Error message about validation failure
+```
+
+### Output Verification Testing
+
+After apply, verify outputs contain expected values:
+
+```bash
+# Verify output is not empty
+VPC_ID=$(terraform output -raw vpc_id)
+[ -z "$VPC_ID" ] && echo "ERROR: VPC ID is empty" || echo "OK: VPC ID is $VPC_ID"
+
+# Verify output format
+SUBNET_IDS=$(terraform output -json subnet_ids)
+echo $SUBNET_IDS | jq 'length'  # Should match expected subnet count
+```
+
+### Idempotency Testing
+
+**Critical test** - ensures Terraform doesn't recreate resources unnecessarily:
+
+```bash
+# Apply configuration
+terraform apply -auto-approve
+
+# Immediately run plan - should show no changes
+terraform plan -detailed-exitcode
+# Exit code 0 = no changes (idempotent) ✓
+# Exit code 2 = changes detected (not idempotent) ✗
+```
+
+**Why idempotency matters:**
+- Proves configuration is stable
+- No resource churn on repeated applies
+- Safe to run in CI/CD pipelines
+- Indicates proper use of computed values
+
+### Destroy Testing
+
+Verify all resources are properly cleaned up:
+
+```bash
+# Before destroy - count resources
+BEFORE_COUNT=$(terraform state list | wc -l)
+
+# Destroy
+terraform destroy -auto-approve
+
+# After destroy - verify state is empty
+AFTER_COUNT=$(terraform state list | wc -l)
+[ "$AFTER_COUNT" -eq 0 ] && echo "OK: All resources destroyed" || echo "ERROR: Resources remain"
+```
+
+### Testing Anti-patterns
+
+**❌ Don't:**
+- Skip idempotency testing (most important test)
+- Test only happy paths (test validation failures too)
+- Forget to clean up test resources
+- Run expensive integration tests on every commit
+- Test Terraform syntax (terraform validate does this)
+
+**✅ Do:**
+- Test that validation blocks reject invalid input
+- Verify outputs have expected types and formats
+- Test conditional resource creation (count/for_each)
+- Document expected resource counts in tests
+- Use mocking for unit tests (Terraform 1.7+)
+- Run integration tests only on main branch or scheduled
+
+### Testing Strategy by Module Type
+
+**Resource modules:**
+- Focus on input validation
+- Test resource creation with minimal config
+- Verify outputs are correct
+- Test idempotency
+
+**Infrastructure modules:**
+- Test module composition works
+- Verify cross-module dependencies
+- Test with different configurations
+- Integration tests in test account
+
+**Compositions:**
+- Smoke tests (can it plan?)
+- Test with production-like values
+- Verify remote state connectivity
+- Manual QA in lower environments first
+
+### Cost Control for Testing
+
+**Strategies:**
+
+1. **Use mocking for unit tests** (Terraform 1.7+)
+   ```hcl
+   mock_provider "aws" {
+     mock_data "aws_ami" {
+       defaults = {
+         id = "ami-12345678"
+       }
+     }
+   }
+   ```
+
+2. **Tag test resources for tracking**
+   ```hcl
+   tags = {
+     Environment = "test"
+     TTL         = "2h"
+     ManagedBy   = "terraform-test"
+   }
+   ```
+
+3. **Run integration tests only on main branch**
+   ```yaml
+   if: github.ref == 'refs/heads/main'
+   ```
+
+4. **Use smaller instance types**
+   ```hcl
+   instance_type = var.environment == "test" ? "t3.micro" : var.instance_type
+   ```
+
+5. **Implement auto-cleanup**
+   - Use AWS Lambda to delete resources with expired TTL tags
+   - Run destroy in CI/CD after tests complete
+   - Use terraform-compliance to enforce TTL tags
+
+**For testing framework details, see:** [Testing Frameworks Guide](testing-frameworks.md)
+
+---
+
+**Back to:** [Main Skill File](../SKILL.md)

--- a/registry/skills/terraform-conventions/references/quick-reference.md
+++ b/registry/skills/terraform-conventions/references/quick-reference.md
@@ -1,0 +1,601 @@
+# Quick Reference
+
+> **Part of:** [terraform-skill](../SKILL.md)
+> **Purpose:** Command cheat sheets and decision flowcharts
+
+This document provides quick lookup tables, command references, and decision flowcharts for rapid consultation during development.
+
+---
+
+## Table of Contents
+
+1. [Command Cheat Sheet](#command-cheat-sheet)
+2. [Decision Flowchart](#decision-flowchart)
+3. [Version-Specific Guidance](#version-specific-guidance)
+4. [Troubleshooting Guide](#troubleshooting-guide)
+5. [Migration Paths](#migration-paths)
+
+---
+
+## Command Cheat Sheet
+
+### Static Analysis
+
+Works with both `terraform` and `tofu` commands:
+
+```bash
+# Format and validate
+terraform fmt -recursive -check    # or: tofu fmt -recursive -check
+terraform validate                 # or: tofu validate
+
+# Linting
+tflint --init && tflint
+
+# Security scanning
+checkov -d .
+```
+
+### Native Tests (1.6+)
+
+```bash
+# Run all tests
+terraform test                     # or: tofu test
+
+# Run tests in specific directory
+terraform test -test-directory=tests/unit/
+
+# Verbose output
+terraform test -verbose
+```
+
+### Plan Validation
+
+```bash
+# Generate and review plan
+terraform plan -out tfplan         # or: tofu plan -out tfplan
+
+# Convert plan to pretty JSON
+terraform show -json tfplan | jq -r '.' > tfplan.json
+
+# Check for specific changes
+terraform show tfplan | grep "will be created"
+```
+
+---
+
+## Decision Flowchart
+
+### Testing Approach Selection
+
+```
+Need to test Terraform/OpenTofu code?
+│
+├─ Just syntax/format?
+│  └─ terraform/tofu validate + fmt
+│
+├─ Static security scan?
+│  └─ trivy + checkov
+│
+├─ Terraform/OpenTofu 1.6+?
+│  ├─ Simple logic test?
+│  │  └─ Native terraform/tofu test
+│  │
+│  └─ Complex integration?
+│     └─ Terratest
+│
+└─ Pre-1.6?
+   ├─ Go team?
+   │  └─ Terratest
+   │
+   └─ Neither?
+      └─ Plan to upgrade Terraform/OpenTofu
+```
+
+### Module Development Workflow
+
+```
+1. Plan
+   ├─ Define inputs (variables.tf)
+   ├─ Define outputs (outputs.tf)
+   └─ Document purpose (README.md)
+
+2. Implement
+   ├─ Create resources (main.tf)
+   ├─ Pin versions (versions.tf)
+   └─ Add examples (examples/simple, examples/complete)
+
+3. Test
+   ├─ Static analysis (validate, fmt, lint)
+   ├─ Unit tests (native or Terratest)
+   └─ Integration tests (examples/)
+
+4. Document
+   ├─ Update README with usage
+   ├─ Document inputs/outputs
+   └─ Add CHANGELOG
+
+5. Publish
+   ├─ Tag version (git tag v1.0.0)
+   ├─ Push to registry
+   └─ Announce changes
+```
+
+---
+
+## Version-Specific Guidance
+
+### Terraform 1.0-1.5
+
+- No native testing framework
+- Use Terratest
+- Focus on static analysis
+- terraform plan validation
+
+### Terraform 1.6+ / OpenTofu 1.6+
+
+- NEW: Native `terraform test` / `tofu test`
+- Consider migrating simple tests from Terratest
+- Keep Terratest for complex integration
+- All Terraform 1.0+ features available
+
+### Terraform 1.7+ / OpenTofu 1.7+
+
+- NEW: Mock providers for unit testing
+- Reduce costs with mocking
+- Use real integration tests for final validation
+- Faster test iteration
+
+### Terraform vs OpenTofu Comparison
+
+Both Terraform and OpenTofu are fully supported by this skill. The choice depends on your requirements:
+
+**Quick Decision Matrix:**
+
+| Factor | Terraform | OpenTofu |
+|--------|-----------|----------|
+| **Licensing** | Business Source License (BSL) 1.1 | Mozilla Public License 2.0 (MPL 2.0) |
+| **Governance** | HashiCorp (single vendor) | Linux Foundation (community-driven) |
+| **Latest Version** | 1.14+ | 1.11+ |
+| **Native Testing** | 1.6+ | 1.6+ |
+| **Mock Providers** | 1.7+ | 1.7+ |
+| **Feature Parity** | Reference implementation | Compatible fork with some additions |
+| **Enterprise Support** | HCP Terraform, Terraform Cloud | Multiple vendors |
+| **Migration Path** | N/A | Drop-in replacement for Terraform <=1.5 |
+
+**When to choose Terraform:**
+- Using HashiCorp Terraform Cloud or HCP Terraform
+- Enterprise support contract with HashiCorp
+- Need absolute latest features first
+
+**When to choose OpenTofu:**
+- Prefer open-source governance model
+- Want to avoid vendor lock-in concerns
+- Building on community-driven development
+- BSL 1.1 license doesn't fit your use case
+
+**For this skill:**
+- Commands are shown for both: `terraform` and `tofu`
+- Most patterns work identically, though differences exist (see release notes)
+- Version-specific features noted (1.6+, 1.7+, etc.)
+- **Note:** Since OpenTofu 1.6, the platforms have diverged with unique features
+
+**When creating modules, Claude will ask your preference** to generate appropriate commands and documentation.
+
+---
+
+## Troubleshooting Guide
+
+### Issue: Tests fail in CI but pass locally
+
+**Symptoms:**
+- Tests pass on your machine
+- Same tests fail in GitHub Actions/GitLab CI
+
+**Common Causes:**
+1. Different Terraform/provider versions
+2. Different environment variables
+3. Different AWS credentials/permissions
+
+**Solution:**
+
+```hcl
+# versions.tf - Pin versions exactly (Provectus convention)
+terraform {
+  required_version = "= 1.9.8"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 5.82.2"  # Pin exact version
+    }
+  }
+}
+```
+
+### Issue: Parallel tests conflict
+
+**Symptoms:**
+- Tests fail when run in parallel
+- Error: "ResourceAlreadyExistsException"
+
+**Cause:** Resource naming collisions
+
+**Solution:**
+
+```go
+// Use unique identifiers
+import "github.com/gruntwork-io/terratest/modules/random"
+
+uniqueId := random.UniqueId()
+bucketName := fmt.Sprintf("test-bucket-%s", uniqueId)
+```
+
+### Issue: High test costs
+
+**Symptoms:**
+- AWS bill increasing from tests
+- Many orphaned resources in test account
+
+**Solutions:**
+
+1. **Use mocking for unit tests** (Terraform 1.7+)
+   ```hcl
+   mock_provider "aws" { ... }
+   ```
+
+2. **Implement resource TTL tags**
+   ```go
+   Vars: map[string]interface{}{
+       "tags": map[string]string{
+           "Environment": "test",
+           "TTL":         "2h",
+       },
+   }
+   ```
+
+3. **Run integration tests only on main branch**
+   ```yaml
+   if: github.ref == 'refs/heads/main'
+   ```
+
+4. **Use smaller instance types**
+   ```hcl
+   instance_type = "t3.micro"  # Not "m5.large"
+   ```
+
+5. **Share test resources when safe**
+   - VPCs, security groups (rarely change)
+   - Don't share: instances, databases (change often)
+
+---
+
+## Migration Paths
+
+### From Manual Testing -> Automated
+
+**Phase 1:** Static analysis
+```bash
+terraform validate
+terraform fmt -check
+```
+
+**Phase 2:** Plan review
+```bash
+terraform plan -out=tfplan
+# Manual review
+```
+
+**Phase 3:** Automated tests
+- Native tests (1.6+)
+- OR Terratest
+
+**Phase 4:** CI/CD integration
+- GitHub Actions / GitLab CI
+- Automated apply on main branch
+
+### From Terratest -> Native Tests (1.6+)
+
+**Strategy:** Gradual migration
+
+1. **Keep Terratest for:**
+   - Complex integration tests
+   - Multi-step workflows
+   - Cross-provider tests
+
+2. **Migrate to native tests:**
+   - Simple unit tests
+   - Logic validation
+   - Mock-friendly tests
+
+3. **During transition:**
+   - Maintain both frameworks
+   - Gradually increase native test coverage
+   - Remove Terratest tests once replaced
+
+**Example:** Mixed approach
+
+```
+tests/
+├── unit/                    # Native tests
+│   └── validation.tftest.hcl
+└── integration/             # Terratest
+    └── complete_test.go
+```
+
+### From Terraform -> OpenTofu
+
+**Good news:** OpenTofu is a drop-in replacement!
+
+1. **No code changes needed**
+   - All Terraform syntax works
+   - Same provider ecosystem
+   - Compatible state files
+
+2. **Update CI/CD:**
+   ```bash
+   # Replace
+   terraform init
+   terraform plan
+   terraform apply
+
+   # With
+   tofu init
+   tofu plan
+   tofu apply
+   ```
+
+3. **Update documentation:**
+   - README mentions OpenTofu compatibility
+   - CI/CD workflows use `tofu` command
+
+---
+
+## Pre-Commit Checklist
+
+### Formatting & Validation
+
+Run these commands before every commit:
+
+```bash
+# Format all Terraform files
+terraform fmt -recursive
+
+# Validate configuration
+terraform validate
+```
+
+### Naming Convention Review
+
+- [ ] All identifiers use `_` not `-`
+- [ ] No resource names repeat resource type (no `aws_vpc.main_vpc`)
+- [ ] Single-instance resources named `this` or descriptive name
+- [ ] Variables have plural names for lists/maps (`subnet_ids` not `subnet_id`)
+- [ ] All variables have descriptions
+- [ ] All outputs have descriptions
+- [ ] Output names follow `{name}_{type}_{attribute}` pattern
+- [ ] No double negatives in variable names
+
+### Code Structure Review
+
+- [ ] `count`/`for_each` at top of resource blocks (blank line after)
+- [ ] `tags` as last real argument in resources
+- [ ] `depends_on` after tags (if used)
+- [ ] `lifecycle` at end of resource (if used)
+- [ ] Variables ordered: description -> type -> default -> sensitive -> nullable -> validation
+- [ ] Only `#` comments used (no `//` or `/* */`)
+
+### Modern Features Check
+
+- [ ] Using `try()` not `element(concat())`
+- [ ] Secrets use write-only arguments or external data sources (not in state)
+- [ ] `nullable = false` set on non-null variables
+- [ ] `optional()` used in object types where applicable (Terraform 1.3+)
+- [ ] Variable validation blocks added where constraints needed
+- [ ] Consider cross-variable validation for related variables (Terraform 1.9+)
+
+### Architecture Review
+
+- [ ] Root modules use `locals.tf` instead of `terraform.tfvars` (Provectus convention)
+- [ ] Remote state configured (never local state)
+- [ ] Resource modules don't hardcode values (use variables/data sources)
+- [ ] `terraform_remote_state` used for cross-composition dependencies
+- [ ] File structure follows standard: main.tf, variables.tf, outputs.tf, versions.tf
+- [ ] All taggable resources include required tags: `Environment`, `Project`, `Owner`, `ManagedBy`
+- [ ] Tags defined via `local.required_tags` and merged per-resource
+
+### Documentation Check
+
+Required documentation for all modules:
+
+- [ ] **README.md exists** with absolute links (Terraform Registry compatibility)
+- [ ] **All variables documented** in README with descriptions and types
+- [ ] **All outputs documented** in README with descriptions
+- [ ] **Usage examples provided** showing how to use the module
+- [ ] **Version requirements specified** (Terraform version, provider versions)
+
+---
+
+## Version Management Quick Reference
+
+> **Provectus Convention: All versions must be pinned to exact versions.**
+
+### Constraint Syntax
+
+| Syntax | Meaning | Provectus Policy |
+|--------|---------|-----------------|
+| `"= 5.82.2"` | Exact version | **Required** |
+| `"5.1.2"` | Exact version (modules) | **Required** |
+
+### Strategy by Component
+
+| Component | Recommendation | Example |
+|-----------|----------------|---------|
+| **Terraform** | Pin exact version | `required_version = "= 1.9.8"` |
+| **Providers** | Pin exact version | `version = "= 5.82.2"` |
+| **Modules (prod)** | Pin exact version | `version = "5.1.2"` |
+| **Modules (dev)** | Pin exact version | `version = "5.1.2"` |
+
+### Update Workflow
+
+```bash
+# Step 1: Lock versions initially
+terraform init              # Creates .terraform.lock.hcl
+
+# Step 2: When updating, change the exact version in versions.tf first
+# Then run terraform init -upgrade
+
+# Step 3: Review changes
+terraform plan
+
+# Step 4: Commit lock file
+git add .terraform.lock.hcl
+git commit -m "Update provider versions"
+```
+
+### Update Strategy
+
+**Security patches:**
+- Update immediately
+- Test: dev -> stage -> prod
+- Prioritize Terraform core and provider updates
+
+**Minor versions:**
+- Regular maintenance (monthly/quarterly)
+- Review changelog for breaking changes
+- Test thoroughly before production
+
+**Major versions:**
+- Planned upgrade cycles
+- Dedicated testing period
+- May require code changes
+- Phased rollout: dev -> stage -> prod
+
+---
+
+## Refactoring Quick Reference
+
+### Common Refactoring Patterns
+
+#### Pattern 1: Count to For_Each Migration
+
+**When:** Need stable resource addressing or items might be reordered
+
+```bash
+# Step 1: Add for_each, keep count commented
+# Step 2: Add moved blocks for each resource
+# Step 3: Run terraform plan (should show "moved" not "destroy/create")
+# Step 4: Apply changes
+# Step 5: Remove commented count
+```
+
+**Key principle:** Use `moved` blocks to preserve existing resources
+
+#### Pattern 2: Legacy to Modern Terraform
+
+**0.12/0.13 -> 1.x checklist:**
+
+- [ ] Replace `element(concat(...))` -> `try()`
+- [ ] Add `nullable = false` where appropriate
+- [ ] Use `optional()` in object types (1.3+)
+- [ ] Add `validation` blocks
+- [ ] Migrate secrets to write-only arguments (1.11+)
+- [ ] Use `moved` blocks for refactoring (1.1+)
+- [ ] Add cross-variable validation (1.9+)
+
+#### Pattern 3: Secrets Remediation
+
+**Goal:** Move secrets out of Terraform state
+
+```bash
+# Step 1: Create secret in AWS Secrets Manager (outside Terraform)
+aws secretsmanager create-secret --name prod-db-password --secret-string "..."
+
+# Step 2: Update Terraform to use data sources
+# Step 3: Use write-only argument (Terraform 1.11+)
+# Step 4: Remove random_password resource or variable
+# Step 5: Apply and verify secret not in state
+terraform show | grep -i password  # Should not appear
+```
+
+### Refactoring Decision Tree
+
+```
+What are you refactoring?
+
+├─ Resource addressing (count[0] -> for_each["key"])
+│  └─ Use: moved blocks + for_each conversion
+│
+├─ Secrets in state
+│  └─ Use: AWS Secrets Manager + write-only arguments (1.11+)
+│
+├─ Legacy Terraform syntax (0.12/0.13)
+│  └─ Use: Modern feature checklist above
+│
+└─ Module structure (rename, reorganize)
+   └─ Use: moved blocks to preserve resources
+```
+
+### Migration Best Practices
+
+**Before refactoring:**
+1. Backup state file
+2. Test in development first
+3. Review terraform plan carefully
+4. Document what changed and why
+
+**During refactoring:**
+1. One change at a time
+2. Verify each step with terraform plan
+3. Use moved blocks, not destroy/recreate
+4. Keep git history clean with logical commits
+
+**After refactoring:**
+1. Verify idempotency (plan shows no changes)
+2. Test in staging before production
+3. Update documentation
+4. Communicate changes to team
+
+**For detailed refactoring patterns, see:** [Code Patterns: Refactoring Patterns](code-patterns.md#refactoring-patterns)
+
+---
+
+## Common Patterns
+
+### Resource Naming
+
+```hcl
+# Good: Descriptive, contextual
+resource "aws_instance" "web_server" { }
+resource "aws_s3_bucket" "application_logs" { }
+
+# Bad: Generic
+resource "aws_instance" "main" { }
+resource "aws_s3_bucket" "bucket" { }
+```
+
+### Variable Naming
+
+```hcl
+# Good: Context-specific
+var.vpc_cidr_block
+var.database_instance_class
+
+# Bad: Generic
+var.cidr
+var.instance_class
+```
+
+### File Organization
+
+```
+Standard module structure:
+├── main.tf          # Primary resources
+├── variables.tf     # Input variables
+├── outputs.tf       # Output values
+├── versions.tf      # Provider versions
+└── README.md        # Documentation
+```
+
+---
+
+**Back to:** [Main Skill File](../SKILL.md)

--- a/registry/skills/terraform-conventions/references/security-compliance.md
+++ b/registry/skills/terraform-conventions/references/security-compliance.md
@@ -1,0 +1,470 @@
+# Security & Compliance
+
+> **Part of:** [terraform-skill](../SKILL.md)
+> **Purpose:** Security best practices and compliance patterns for Terraform/OpenTofu
+
+This document provides security hardening guidance and compliance automation strategies for infrastructure-as-code.
+
+---
+
+## Table of Contents
+
+1. [Security Scanning Tools](#security-scanning-tools)
+2. [Common Security Issues](#common-security-issues)
+3. [Compliance Testing](#compliance-testing)
+4. [Secrets Management](#secrets-management)
+5. [State File Security](#state-file-security)
+
+---
+
+## Security Scanning Tools
+
+### Essential Security Checks
+
+```bash
+# Static security scanning
+trivy config .
+checkov -d .
+
+# Compliance testing
+terraform-compliance -f compliance/ -p tfplan.json
+```
+
+### Trivy Integration
+
+**Install:**
+
+```bash
+# macOS
+brew install trivy
+
+# Linux
+curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+
+# In CI
+- uses: aquasecurity/trivy-action@master
+  with:
+    scan-type: 'config'
+    scan-ref: '.'
+```
+
+**Note:** Trivy is the successor to tfsec, maintained by Aqua Security.
+
+**Example Output:**
+
+```
+Result #1 HIGH Security group rule allows egress to multiple public internet addresses
+────────────────────────────────────────────────────────────────────────────────
+  security.tf:15-20
+
+   12 | resource "aws_security_group_rule" "egress" {
+   13 |   type              = "egress"
+   14 |   from_port         = 0
+   15 |   to_port           = 0
+   16 |   protocol          = "-1"
+   17 |   cidr_blocks       = ["0.0.0.0/0"]
+   18 |   security_group_id = aws_security_group.this.id
+   19 | }
+```
+
+### Checkov Integration
+
+```bash
+# Run Checkov
+checkov -d . --framework terraform
+
+# Skip specific checks
+checkov -d . --skip-check CKV_AWS_23
+
+# Generate JSON report
+checkov -d . -o json > checkov-report.json
+```
+
+---
+
+## Common Security Issues
+
+### ❌ DON'T: Store Secrets in Variables
+
+```hcl
+# BAD: Secret in plaintext
+variable "database_password" {
+  type    = string
+  default = "SuperSecret123!"  # ❌ Never do this
+}
+```
+
+### ✅ DO: Use Secrets Manager
+
+```hcl
+# Good: Reference secrets from AWS Secrets Manager
+data "aws_secretsmanager_secret_version" "db_password" {
+  secret_id = "prod/database/password"
+}
+
+resource "aws_db_instance" "this" {
+  password = data.aws_secretsmanager_secret_version.db_password.secret_string
+}
+```
+
+### ❌ DON'T: Use Default VPC
+
+```hcl
+# BAD: Default VPC has public subnets
+resource "aws_instance" "app" {
+  ami           = "ami-12345"
+  subnet_id     = "subnet-default"  # ❌ Avoid default resources
+}
+```
+
+### ✅ DO: Create Dedicated VPCs
+
+```hcl
+# Good: Custom VPC with private subnets
+resource "aws_vpc" "this" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+}
+
+resource "aws_subnet" "private" {
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+}
+```
+
+### ❌ DON'T: Skip Encryption
+
+```hcl
+# BAD: Unencrypted S3 bucket
+resource "aws_s3_bucket" "data" {
+  bucket = "my-data-bucket"
+  # ❌ No encryption configured
+}
+```
+
+### ✅ DO: Enable Encryption at Rest
+
+```hcl
+# Good: Enable encryption
+resource "aws_s3_bucket" "data" {
+  bucket = "my-data-bucket"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+```
+
+### ❌ DON'T: Open Security Groups to Internet
+
+```hcl
+# BAD: Security group open to internet
+resource "aws_security_group_rule" "allow_all" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]  # ❌ Never do this
+  security_group_id = aws_security_group.this.id
+}
+```
+
+### ✅ DO: Use Least-Privilege Security Groups
+
+```hcl
+# Good: Restrict to specific ports and sources
+resource "aws_security_group_rule" "app_https" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["10.0.0.0/16"]  # ✅ Internal only
+  security_group_id = aws_security_group.this.id
+}
+```
+
+---
+
+## Compliance Testing
+
+### terraform-compliance
+
+**Install:**
+
+```bash
+pip install terraform-compliance
+```
+
+**Example Compliance Test:**
+
+```gherkin
+# compliance/aws-encryption.feature
+Feature: AWS Resources must be encrypted
+
+  Scenario: S3 buckets must have encryption
+    Given I have aws_s3_bucket defined
+    When it has aws_s3_bucket_server_side_encryption_configuration
+    Then it must contain rule
+    And it must contain apply_server_side_encryption_by_default
+
+  Scenario: RDS instances must be encrypted
+    Given I have aws_db_instance defined
+    Then it must contain storage_encrypted
+    And its value must be true
+```
+
+**Run Tests:**
+
+```bash
+# Generate plan in JSON
+terraform plan -out=tfplan
+terraform show -json tfplan > tfplan.json
+
+# Run compliance tests
+terraform-compliance -f compliance/ -p tfplan.json
+```
+
+### Open Policy Agent (OPA)
+
+```rego
+# policy/s3_encryption.rego
+package terraform.s3
+
+deny[msg] {
+  resource := input.resource_changes[_]
+  resource.type == "aws_s3_bucket"
+  not resource.change.after.server_side_encryption_configuration
+
+  msg := sprintf("S3 bucket '%s' must have encryption enabled", [resource.address])
+}
+```
+
+---
+
+## Secrets Management
+
+### AWS Secrets Manager Pattern
+
+```hcl
+# Create secret
+resource "aws_secretsmanager_secret" "db_password" {
+  name        = "prod/database/password"
+  description = "RDS master password"
+
+  recovery_window_in_days = 30
+}
+
+resource "aws_secretsmanager_secret_version" "db_password" {
+  secret_id     = aws_secretsmanager_secret.db_password.id
+  secret_string = random_password.db_password.result
+}
+
+# Generate secure password
+resource "random_password" "db_password" {
+  length  = 32
+  special = true
+}
+
+# Use secret in RDS
+data "aws_secretsmanager_secret_version" "db_password" {
+  secret_id = aws_secretsmanager_secret.db_password.id
+}
+
+resource "aws_db_instance" "this" {
+  password = data.aws_secretsmanager_secret_version.db_password.secret_string
+  # ...
+}
+```
+
+### Environment Variables
+
+```bash
+# Never commit these
+export TF_VAR_database_password="secret123"
+export AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE"
+export AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+```
+
+**In .gitignore:**
+
+```
+*.tfvars
+.env
+secrets/
+```
+
+---
+
+## State File Security
+
+### Encrypt State at Rest
+
+```hcl
+# backend.tf
+terraform {
+  backend "s3" {
+    bucket         = "my-terraform-state"
+    key            = "prod/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true  # ✅ Always enable encryption
+  }
+}
+```
+
+### Secure State Bucket
+
+```hcl
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = "my-terraform-state"
+}
+
+# Enable versioning (protect against accidental deletion)
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# Enable encryption
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# Block public access
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+```
+
+### Restrict State Access
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:role/TerraformRole"
+      },
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::my-terraform-state",
+        "arn:aws:s3:::my-terraform-state/*"
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## IAM Best Practices
+
+### ✅ DO: Use Least Privilege
+
+```hcl
+# Good: Specific permissions only
+resource "aws_iam_policy" "app_policy" {
+  name = "app-policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject"
+        ]
+        Resource = "arn:aws:s3:::my-app-bucket/*"
+      }
+    ]
+  })
+}
+```
+
+### ❌ DON'T: Use Wildcard Permissions
+
+```hcl
+# BAD: Overly broad permissions
+resource "aws_iam_policy" "bad_policy" {
+  policy = jsonencode({
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "*"  # ❌ Never use wildcard
+        Resource = "*"
+      }
+    ]
+  })
+}
+```
+
+---
+
+## Compliance Checklists
+
+### SOC 2 Compliance
+
+- [ ] Encryption at rest for all data stores
+- [ ] Encryption in transit (TLS/SSL)
+- [ ] IAM policies follow least privilege
+- [ ] Logging enabled for all resources
+- [ ] MFA required for privileged access
+- [ ] Regular security scanning in CI/CD
+
+### HIPAA Compliance
+
+- [ ] PHI encrypted at rest and in transit
+- [ ] Access logs enabled
+- [ ] Dedicated VPC with private subnets
+- [ ] Regular backup and retention policies
+- [ ] Audit trail for all infrastructure changes
+
+### PCI-DSS Compliance
+
+- [ ] Network segmentation (separate VPCs)
+- [ ] No default passwords
+- [ ] Strong encryption algorithms
+- [ ] Regular security scanning
+- [ ] Access control and monitoring
+
+---
+
+## Resources
+
+- [Trivy Documentation](https://aquasecurity.github.io/trivy/)
+- [Checkov Documentation](https://www.checkov.io/)
+- [terraform-compliance](https://terraform-compliance.com/)
+- [Open Policy Agent](https://www.openpolicyagent.org/)
+- [AWS Security Best Practices](https://aws.amazon.com/security/best-practices/)
+
+---
+
+**Back to:** [Main Skill File](../SKILL.md)

--- a/registry/skills/terraform-conventions/references/testing-frameworks.md
+++ b/registry/skills/terraform-conventions/references/testing-frameworks.md
@@ -1,0 +1,563 @@
+# Testing Frameworks - Detailed Guide
+
+> **Part of:** [terraform-skill](../SKILL.md)
+> **Purpose:** Detailed guides for Terraform/OpenTofu testing frameworks
+
+This document provides in-depth guidance on testing frameworks for Infrastructure as Code. For the decision matrix and high-level overview, see the [main skill file](../SKILL.md#testing-strategy-framework).
+
+---
+
+## Table of Contents
+
+1. [Static Analysis](#static-analysis)
+2. [Plan Testing](#plan-testing)
+3. [Native Terraform Tests](#native-terraform-tests)
+4. [Terratest (Go-based)](#terratest-go-based)
+
+---
+
+## Static Analysis
+
+**Always do this first.** Zero cost, catches 40%+ of issues before deployment.
+
+### Pre-commit Hooks
+
+```yaml
+# In .pre-commit-config.yaml
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  hooks:
+    - id: terraform_fmt
+    - id: terraform_validate
+    - id: terraform_tflint
+```
+
+### What Each Tool Checks
+
+- **`terraform fmt`** - Code formatting consistency
+- **`terraform validate`** - Syntax and internal consistency
+- **`TFLint`** - Best practices, provider-specific rules
+- **`trivy` / `checkov`** - Security vulnerabilities
+
+### When to Use
+
+Every commit, always. Zero cost, catches 40%+ of issues.
+
+---
+
+## Plan Testing
+
+### What terraform plan Validates
+
+- Verify expected resources will be created/modified/destroyed
+- Catch provider authentication issues
+- Validate variable combinations
+- Review before applying
+
+### In CI/CD
+
+```bash
+terraform init
+terraform plan -out=tfplan
+
+# Optionally: Convert plan to JSON and validate with tools
+terraform show -json tfplan | jq '.'
+```
+
+### Limitations
+
+- Doesn't deploy real infrastructure
+- Can't catch runtime issues (IAM permissions, network connectivity)
+- Won't find resource-specific bugs
+
+---
+
+## Native Terraform Tests
+
+**Available:** Terraform 1.6+, OpenTofu 1.6+
+
+### When to Use
+
+- Team primarily works in HCL (no Go/Ruby experience needed)
+- Testing logical operations and module behavior
+- Want to avoid external testing dependencies
+
+### Basic Structure
+
+```hcl
+# tests/s3_bucket.tftest.hcl
+run "create_bucket" {
+  command = apply
+
+  assert {
+    condition     = aws_s3_bucket.main.bucket != ""
+    error_message = "S3 bucket name must be set"
+  }
+}
+
+run "verify_encryption" {
+  command = plan
+
+  assert {
+    condition     = aws_s3_bucket_server_side_encryption_configuration.main.rule[0].apply_server_side_encryption_by_default[0].sse_algorithm == "AES256"
+    error_message = "Bucket must use AES256 encryption"
+  }
+}
+```
+
+### Critical: Validate Resource Schemas First
+
+**Always use Terraform MCP to validate resource schemas before writing tests:**
+
+```bash
+# Example workflow in Claude Code:
+# 1. Search for provider documentation
+mcp__terraform__search_providers({
+  provider_name: "aws",
+  provider_namespace: "hashicorp",
+  service_slug: "s3_bucket_server_side_encryption_configuration",
+  provider_document_type: "resources"
+})
+
+# 2. Get detailed schema
+mcp__terraform__get_provider_details({
+  provider_doc_id: "12345"  # from search results
+})
+```
+
+**Why This Matters:**
+- Some blocks are **sets** (unordered, no indexing with `[0]`)
+- Some blocks are **lists** (ordered, indexable)
+- Some attributes are **computed** (only known after apply)
+
+**Common Schema Patterns:**
+
+| AWS Resource | Block Type | Indexing |
+|--------------|------------|----------|
+| `rule` in `aws_s3_bucket_server_side_encryption_configuration` | **set** | ❌ Cannot use `[0]` |
+| `transition` in `aws_s3_bucket_lifecycle_configuration` | **set** | ❌ Cannot use `[0]` |
+| `noncurrent_version_expiration` in lifecycle | **list** | ✅ Can use `[0]` |
+
+### Working with Set-Type Blocks
+
+**Problem:** Cannot index sets with `[0]`
+```hcl
+# ❌ WRONG: This will fail
+condition = aws_s3_bucket_server_side_encryption_configuration.this.rule[0].bucket_key_enabled == true
+# Error: Cannot index a set value
+```
+
+**Solution 1:** Use `command = apply` to materialize the set
+```hcl
+run "test_encryption" {
+  command = apply  # Creates real/mocked resources
+
+  assert {
+    # Now the set is materialized and can be checked
+    condition     = length([for rule in aws_s3_bucket_server_side_encryption_configuration.this.rule :
+                             rule.bucket_key_enabled if rule.bucket_key_enabled == true]) > 0
+    error_message = "Bucket key should be enabled"
+  }
+}
+```
+
+**Solution 2:** Check at resource level (avoid accessing nested blocks)
+```hcl
+run "test_encryption_exists" {
+  command = plan
+
+  assert {
+    # Check that the resource exists without accessing set members
+    condition     = aws_s3_bucket_server_side_encryption_configuration.this != null
+    error_message = "Encryption configuration should be created"
+  }
+}
+```
+
+**Solution 3:** Use for expressions (works in apply mode)
+```hcl
+run "test_encryption_algorithm" {
+  command = apply
+
+  assert {
+    condition     = alltrue([
+      for rule in aws_s3_bucket_server_side_encryption_configuration.this.rule :
+      alltrue([
+        for config in rule.apply_server_side_encryption_by_default :
+        config.sse_algorithm == "AES256"
+      ])
+    ])
+    error_message = "Encryption should use AES256"
+  }
+}
+```
+
+### command = plan vs command = apply
+
+**Critical decision:** When to use each command mode
+
+#### Use `command = plan`
+
+**When:**
+- Checking input validation
+- Verifying resource will be created
+- Testing variable defaults
+- Checking resource attributes that are **input-derived** (not computed)
+
+**Example:**
+```hcl
+run "test_input_validation" {
+  command = plan  # Fast, no resource creation
+
+  variables {
+    bucket = "test-bucket"
+  }
+
+  assert {
+    # bucket name is an input, known at plan time
+    condition     = aws_s3_bucket.this.bucket == "test-bucket"
+    error_message = "Bucket name should match input"
+  }
+}
+```
+
+#### Use `command = apply`
+
+**When:**
+- Checking computed attributes (IDs, ARNs, generated names)
+- Accessing set-type blocks
+- Verifying actual resource behavior
+- Testing with real/mocked provider responses
+
+**Example:**
+```hcl
+run "test_computed_values" {
+  command = apply  # Executes and gets computed values
+
+  variables {
+    bucket_prefix = "test-"  # AWS generates full name
+  }
+
+  assert {
+    # bucket name is computed from prefix, only known after apply
+    condition     = length(aws_s3_bucket.this.bucket) > 0
+    error_message = "Bucket should have generated name"
+  }
+}
+```
+
+#### Common Pitfall: Checking Computed Values in Plan Mode
+
+**Problem:**
+```hcl
+run "test_bucket_prefix" {
+  command = plan  # ❌ WRONG MODE
+
+  variables {
+    bucket_prefix = "test-prefix-"
+  }
+
+  assert {
+    # bucket is computed from prefix, unknown at plan time!
+    condition     = aws_s3_bucket.this.bucket == null
+    error_message = "Bucket name should be null when using bucket_prefix"
+  }
+}
+# Error: Condition expression could not be evaluated at this time
+```
+
+**Solution:**
+```hcl
+run "test_bucket_prefix" {
+  command = apply  # ✅ CORRECT MODE or check differently
+
+  variables {
+    bucket_prefix = "test-prefix-"
+  }
+
+  assert {
+    # Now bucket has been generated by provider
+    condition     = startswith(aws_s3_bucket.this.bucket, "test-prefix-")
+    error_message = "Bucket name should start with prefix"
+  }
+}
+```
+
+**Quick Decision Guide:**
+```
+Checking input values? → command = plan
+Checking computed values? → command = apply
+Accessing set-type blocks? → command = apply
+Need fast feedback? → command = plan (with mocks)
+Testing real behavior? → command = apply (without mocks)
+```
+
+### With Mocking (1.7+)
+
+```hcl
+mock_provider "aws" {
+  mock_resource "aws_instance" {
+    defaults = {
+      id  = "i-mock123"
+      arn = "arn:aws:ec2:us-east-1:123456789:instance/i-mock123"
+    }
+  }
+}
+```
+
+### Pros
+
+- Native HCL syntax (familiar to Terraform users)
+- No external dependencies
+- Fast execution with mocks
+- Good for unit testing module logic
+
+### Cons
+
+- Newer feature (less mature than Terratest)
+- Limited ecosystem/examples
+- Mocking doesn't catch real-world AWS behavior
+
+---
+
+### Complete Test Examples (Following Best Practices)
+
+#### Example 1: S3 Bucket Tests
+
+```hcl
+# tests/unit/s3_bucket.tftest.hcl
+
+mock_provider "aws" {}  # Zero cost with mocks
+
+# Test 1: Input validation (fast, plan mode)
+run "validate_bucket_name" {
+  command = plan
+
+  variables {
+    bucket = "my-test-bucket"
+  }
+
+  assert {
+    condition     = aws_s3_bucket.this.bucket == "my-test-bucket"
+    error_message = "Bucket name should match input"
+  }
+}
+
+# Test 2: Encryption defaults (apply mode for set access)
+run "verify_default_encryption" {
+  command = apply
+
+  variables {
+    bucket = "encrypted-bucket"
+  }
+
+  assert {
+    # Using for expression to check set-type block
+    condition = alltrue([
+      for rule in aws_s3_bucket_server_side_encryption_configuration.this.rule :
+      alltrue([
+        for config in rule.apply_server_side_encryption_by_default :
+        config.sse_algorithm == "AES256"
+      ])
+    ])
+    error_message = "Default encryption should be AES256"
+  }
+
+  assert {
+    # Check bucket key at rule level
+    condition = alltrue([
+      for rule in aws_s3_bucket_server_side_encryption_configuration.this.rule :
+      rule.bucket_key_enabled == true
+    ])
+    error_message = "Bucket key should be enabled"
+  }
+}
+
+# Test 3: Computed values (apply mode required)
+run "verify_generated_name" {
+  command = apply
+
+  variables {
+    bucket_prefix = "test-"
+  }
+
+  assert {
+    condition     = startswith(aws_s3_bucket.this.bucket, "test-")
+    error_message = "Generated bucket name should have prefix"
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket.this.bucket) > 5
+    error_message = "Bucket name should be generated"
+  }
+}
+```
+
+#### Example 2: Lifecycle Rules
+
+```hcl
+# tests/unit/lifecycle.tftest.hcl
+
+mock_provider "aws" {}
+
+run "verify_lifecycle_transitions" {
+  command = apply  # Required for set-type transition blocks
+
+  variables {
+    bucket = "lifecycle-bucket"
+    lifecycle_rules = [{
+      id      = "archive"
+      enabled = true
+      transition = [
+        { days = 90, storage_class = "GLACIER" },
+        { days = 180, storage_class = "DEEP_ARCHIVE" }
+      ]
+    }]
+  }
+
+  assert {
+    # Check that both transitions exist using for expression
+    condition = length([
+      for rule in aws_s3_bucket_lifecycle_configuration.this[0].rule :
+      rule.id if rule.id == "archive"
+    ]) == 1
+    error_message = "Lifecycle rule should exist"
+  }
+
+  assert {
+    # Verify transition count using length
+    condition = alltrue([
+      for rule in aws_s3_bucket_lifecycle_configuration.this[0].rule :
+      length(rule.transition) == 2
+    ])
+    error_message = "Should have 2 transitions"
+  }
+}
+```
+
+---
+
+## Terratest (Go-based)
+
+**Recommended for:** Teams with Go experience, robust integration testing
+
+### When to Use
+
+- Team has Go experience
+- Need robust integration testing
+- Testing multiple providers/complex infrastructure
+- Want battle-tested framework with large community
+
+### Basic Structure
+
+```go
+package test
+
+import (
+    "testing"
+    "github.com/gruntwork-io/terratest/modules/terraform"
+    "github.com/stretchr/testify/assert"
+)
+
+func TestS3Module(t *testing.T) {
+    t.Parallel() // ALWAYS include for parallel execution
+
+    terraformOptions := &terraform.Options{
+        TerraformDir: "../examples/complete",
+        Vars: map[string]interface{}{
+            "bucket_name": "test-bucket-" + uniqueId(),
+        },
+    }
+
+    // Clean up resources after test
+    defer terraform.Destroy(t, terraformOptions)
+
+    // Run terraform init and apply
+    terraform.InitAndApply(t, terraformOptions)
+
+    // Get outputs and verify
+    bucketName := terraform.Output(t, terraformOptions, "bucket_name")
+    assert.NotEmpty(t, bucketName)
+}
+```
+
+### Cost Management
+
+```go
+// Use tags for automated cleanup
+Vars: map[string]interface{}{
+    "tags": map[string]string{
+        "Environment": "test",
+        "TTL":         "2h", // Auto-delete after 2 hours
+    },
+}
+```
+
+### Critical Patterns
+
+1. **Always use `t.Parallel()`** - Enables parallel test execution
+2. **Always use `defer terraform.Destroy()`** - Ensures cleanup
+3. **Use unique identifiers** - Avoid resource conflicts
+4. **Tag resources** - Enable cost tracking and automated cleanup
+5. **Use separate AWS accounts** - Isolate test infrastructure
+
+### Real-world Costs
+
+- Small module (S3, IAM): $0-5 per run
+- Medium module (VPC, EC2): $5-20 per run
+- Large module (RDS, ECS cluster): $20-100 per run
+
+### Optimization with Test Stages
+
+```go
+// Test stages for faster iteration
+stage := test_structure.RunTestStage
+
+stage(t, "setup", func() {
+    terraform.InitAndApply(t, opts)
+})
+
+stage(t, "validate", func() {
+    // Assertions here
+})
+
+stage(t, "teardown", func() {
+    terraform.Destroy(t, opts)
+})
+
+// Skip stages during development:
+// export SKIP_setup=true
+// export SKIP_teardown=true
+```
+
+---
+
+## Best Practices Summary
+
+### For All Frameworks
+
+1. **Start with static analysis** - Always free, always fast
+2. **Use unique identifiers** - Prevent resource conflicts
+3. **Tag test resources** - Enable tracking and cleanup
+4. **Separate test accounts** - Isolate test infrastructure
+5. **Implement TTL** - Automatic resource cleanup
+
+### Framework Selection
+
+```
+Quick syntax check? → terraform validate + fmt
+Security scan? → trivy + checkov
+Terraform 1.6+, simple logic? → Native tests
+Pre-1.6, or complex integration? → Terratest
+```
+
+### Cost Optimization
+
+1. Use mocking for unit tests
+2. Implement resource TTL tags
+3. Run integration tests only on main branch
+4. Use smaller instance types in tests
+5. Share test resources when safe
+
+---
+
+**Back to:** [Main Skill File](../SKILL.md)


### PR DESCRIPTION
## Summary
- Adds `terraform-conventions` skill to the registry (Provectus fork of antonbabenko/terraform-skill v1.5.0)
- Includes reference docs for CI/CD workflows, code patterns, module patterns, security/compliance, and testing frameworks

## Test plan
- [ ] Verify skill structure follows registry conventions
- [ ] Confirm SKILL.md and reference files are complete and well-formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)