### PR TITLE
Add google-app-development skill to registry

### DIFF
--- a/registry/skills/google-app-development/SKILL.md
+++ b/registry/skills/google-app-development/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: google-app-development
+description: "This skill should be used when the user asks to \"build an Android app\", \"create a Composable\", \"set up an Android project\", \"review Android code\", \"refactor Android\", \"add a screen\", \"create a Wear OS app\", \"build for Android TV\", \"build for Android Auto\", \"build for Android Automotive\", \"adapt for Meta Quest\", \"build for Fire TV\", \"build for Fire Tablet\", or when generating any Kotlin code targeting Google/Android platforms (including AOSP-based devices). Provides modern Jetpack Compose-first best practices covering UI patterns, app lifecycle, navigation, and platform-specific guidance. Use together with `kotlin-development` for language fundamentals. Always generates Kotlin unless the project explicitly requires Java."
+version: 0.1.0
+---
+
+# Google App Development (Jetpack Compose / Kotlin)
+
+Modern best practices for building apps across Google platforms. Targets Jetpack Compose as the primary UI framework with Kotlin. Covers Android (phone), tablet, foldables, Wear OS, Google TV / Android TV, Android Auto, Android Automotive OS, and AOSP-based platforms (Meta Quest, Amazon Fire TV, Amazon Fire Tablets).
+
+For Kotlin language fundamentals (null safety, coroutines, data modeling, error handling, idiomatic patterns), see the `kotlin-development` skill. This skill focuses on platform and framework patterns.
+
+## Important Rules
+
+- **Always generate Kotlin.** Only write Java when the project explicitly requires it (legacy codebase, Java-only API). See `references/java-interop.md` for bridging patterns.
+- **Compose-first.** Use View-based UI only when Compose lacks the capability or the project has an existing View-based codebase. See `references/view-interop.md` for interop patterns.
+- **Check the project context.** Before applying patterns, check the `minSdk`, Compose BOM version, and existing architecture. Adapt recommendations accordingly.
+
+## Reference Files
+
+- **`references/compose-patterns.md`** — Composables, state hoisting, recomposition, `remember`, `LazyColumn`, navigation, theming, Material 3, side effects
+- **`references/concurrency.md`** — Coroutines in Android context: `viewModelScope`, `lifecycleScope`, `repeatOnLifecycle`, WorkManager, foreground services
+- **`references/android-lifecycle.md`** — Activity/Fragment lifecycle, `ViewModel`, saved state, process death, configuration changes
+- **`references/view-interop.md`** — `AndroidView`, `ComposeView`, embedding Compose in Views and Views in Compose, migration strategies
+- **`references/project-structure.md`** — Gradle setup, multi-module architecture, build variants, version catalogs, convention plugins
+- **`references/tablet-patterns.md`** — Adaptive layouts, `WindowSizeClass`, multi-window, foldable devices, large screen guidelines
+- **`references/wear-os-patterns.md`** — Compose for Wear OS, Tiles, complications, Health Services, watch face
+- **`references/tv-patterns.md`** — Compose for TV, focus management, Leanback, D-pad navigation, Google TV / Android TV
+- **`references/android-auto-patterns.md`** — Car App Library, templates, phone projection, media apps, messaging apps
+- **`references/android-automotive-patterns.md`** — Android Automotive OS (AAOS), embedded car system, car hardware APIs, system UI
+- **`references/java-interop.md`** — Calling Java from Kotlin, nullability annotations, SAM conversions, incremental migration
+- **`references/meta-quest-patterns.md`** — Adapting Android APK for Meta Quest, spatial UI, entitlement check, VR input, passthrough
+- **`references/fire-tv-patterns.md`** — Amazon Fire TV, Appstore, Amazon IAP, Alexa integration, missing Google Play Services
+- **`references/fire-tablet-patterns.md`** — Amazon Fire Tablets, device capabilities, Show Mode, Kids Edition, Special Offers
+
+## Code Style
+
+For Kotlin language style (naming, null safety, type annotations), follow the `kotlin-development` skill. Below are Android/Compose-specific conventions.
+
+- **Composable naming** — `PascalCase` for UI-emitting composables, `camelCase` for composables that return values.
+- **Modifier parameter** — always the first optional parameter, default to `Modifier`.
+- **Preview functions** — prefix with `Preview`, annotate with `@Preview`.
+- **Define a custom app theme and apply it at the root.** Every app must have a custom `AppTheme` composable that wraps `MaterialTheme` with app-specific colors, typography, and shapes. Apply it once at the top level (`setContent { AppTheme { ... } }`). All UI code must reference theme tokens — never raw values.
+
+```kotlin
+// 1. Define custom theme (once, in ui/theme/)
+@Composable
+fun AppTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit,
+) {
+    val colorScheme = if (darkTheme) AppDarkColorScheme else AppLightColorScheme
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = AppTypography,
+        shapes = AppShapes,
+        content = content,
+    )
+}
+
+// 2. Apply at root (once)
+setContent { AppTheme { AppNavGraph() } }
+
+// 3. Use theme tokens everywhere — never raw values
+Text(
+    text = "Hello",
+    style = MaterialTheme.typography.bodyMedium,             // not fontSize = 14.sp
+    color = MaterialTheme.colorScheme.onSurface,             // not Color(0xFF1C1B1F)
+)
+Card(shape = MaterialTheme.shapes.medium) { ... }           // not RoundedCornerShape(8.dp)
+```
+
+For values not covered by Material tokens (spacing, elevation, icon sizes), define app-level design tokens:
+
+```kotlin
+object AppSpacing {
+    val small = 8.dp
+    val medium = 16.dp
+    val large = 24.dp
+}
+```
+
+**No magic numbers in UI code.** If a numeric value appears in UI, it must be either a Material theme token or an app-defined design constant. For theming details see `references/compose-patterns.md`.
+
+## Naming Conventions (Android-Specific)
+
+| Element | Convention | Example |
+|---|---|---|
+| Composable (UI) | `PascalCase` | `UserProfileScreen`, `SettingsCard` |
+| Composable (value) | `camelCase` | `rememberScrollState()` |
+| ViewModel | Suffix `ViewModel` | `SettingsViewModel` |
+| Screen composable | Suffix `Screen` | `HomeScreen`, `ProfileScreen` |
+| UI State | Suffix `UiState` | `HomeUiState`, `ProfileUiState` |
+| Activity | Suffix `Activity` | `MainActivity` |
+| Fragment (legacy) | Suffix `Fragment` | `HomeFragment` |
+| Repository | Suffix `Repository` | `UserRepository` |
+| Use case | Verb phrase | `GetUserUseCase`, `SyncDataUseCase` |
+| Module | Feature name, kebab-case | `:feature:auth`, `:core:network` |
+
+## Jetpack Compose Essentials
+
+```kotlin
+// UI State
+data class HomeUiState(
+    val items: List<Item> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
+// ViewModel
+class HomeViewModel(
+    private val repository: ItemRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(HomeUiState())
+    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            repository.getItems()
+                .onSuccess { items -> _uiState.update { it.copy(items = items, isLoading = false) } }
+                .onFailure { e -> _uiState.update { it.copy(error = e.message, isLoading = false) } }
+        }
+    }
+}
+
+// Composable
+@Composable
+fun HomeScreen(
+    viewModel: HomeViewModel = viewModel(),
+    onItemClick: (Item) -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when {
+        uiState.isLoading -> LoadingIndicator()
+        uiState.error != null -> ErrorMessage(uiState.error!!)
+        else -> ItemList(items = uiState.items, onItemClick = onItemClick)
+    }
+}
+```
+
+Rules:
+- Use `StateFlow` + `collectAsStateWithLifecycle()` for state in ViewModels.
+- State hoisting — composables receive state and emit events, they don't own state.
+- Use `remember` for composable-local state, `rememberSaveable` for state surviving config changes.
+- Keep composables small. Extract when a composable exceeds ~40 lines.
+
+For navigation, theming, side effects, lists, animations see `references/compose-patterns.md`.
+
+## Android Concurrency
+
+For coroutines language fundamentals (Flow, structured concurrency, cancellation), see the `kotlin-development` skill. Below are Android-specific patterns.
+
+```kotlin
+// ViewModel scope — cancelled when ViewModel is cleared
+class UserViewModel(private val repo: UserRepository) : ViewModel() {
+    val users = repo.observeUsers()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+}
+
+// Lifecycle-aware collection in Compose
+@Composable
+fun UserScreen(viewModel: UserViewModel = viewModel()) {
+    val users by viewModel.users.collectAsStateWithLifecycle()
+    UserList(users)
+}
+
+// Lifecycle-aware collection in Activity/Fragment (legacy)
+lifecycleScope.launch {
+    repeatOnLifecycle(Lifecycle.State.STARTED) {
+        viewModel.users.collect { updateUI(it) }
+    }
+}
+```
+
+Rules:
+- **`viewModelScope`** for ViewModel operations — auto-cancelled on clear.
+- **`collectAsStateWithLifecycle()`** in Compose — lifecycle-aware, stops collection when not visible.
+- **`repeatOnLifecycle`** in Activities/Fragments — restarts collection on lifecycle transitions.
+- **`WhileSubscribed(5000)`** for `stateIn` — keeps upstream active 5s after last subscriber (survives rotation).
+- **WorkManager** for deferrable background work. **Foreground services** for user-visible ongoing tasks.
+
+For WorkManager, foreground services, and advanced patterns see `references/concurrency.md`.
+
+## Architecture
+
+**Recommended: MVI (Model-View-Intent)** for new projects. MVI enforces unidirectional data flow with a single immutable state and explicit user intents, which maps naturally to Compose. If the project already uses MVVM, MVP, or MVC — adapt to the existing architecture instead of forcing a rewrite.
+
+### MVI Pattern
+
+```kotlin
+// 1. State — single immutable data class per screen
+data class HomeUiState(
+    val items: List<Item> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
+// 2. Intent — sealed interface of all user actions
+sealed interface HomeIntent {
+    data object LoadItems : HomeIntent
+    data class DeleteItem(val id: String) : HomeIntent
+    data object RetryLoad : HomeIntent
+}
+
+// 3. ViewModel — reduces intents into state
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+    private val repository: ItemRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(HomeUiState())
+    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+
+    fun onIntent(intent: HomeIntent) {
+        when (intent) {
+            is HomeIntent.LoadItems -> loadItems()
+            is HomeIntent.DeleteItem -> deleteItem(intent.id)
+            is HomeIntent.RetryLoad -> loadItems()
+        }
+    }
+
+    private fun loadItems() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            repository.getItems()
+                .onSuccess { items -> _uiState.update { it.copy(items = items, isLoading = false) } }
+                .onFailure { e -> _uiState.update { it.copy(error = e.message, isLoading = false) } }
+        }
+    }
+
+    private fun deleteItem(id: String) {
+        viewModelScope.launch {
+            repository.delete(id)
+            _uiState.update { it.copy(items = it.items.filter { item -> item.id != id }) }
+        }
+    }
+}
+
+// 4. View — renders state, emits intents
+@Composable
+fun HomeScreen(viewModel: HomeViewModel = hiltViewModel()) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) { viewModel.onIntent(HomeIntent.LoadItems) }
+
+    when {
+        uiState.isLoading -> LoadingIndicator()
+        uiState.error != null -> ErrorScreen(
+            message = uiState.error!!,
+            onRetry = { viewModel.onIntent(HomeIntent.RetryLoad) },
+        )
+        else -> ItemList(
+            items = uiState.items,
+            onDelete = { id -> viewModel.onIntent(HomeIntent.DeleteItem(id)) },
+        )
+    }
+}
+```
+
+### Project Structure
+
+```
+app/
+├── MainActivity.kt
+├── navigation/
+│   └── AppNavGraph.kt
+├── feature/
+│   ├── home/
+│   │   ├── HomeScreen.kt
+│   │   ├── HomeViewModel.kt
+│   │   ├── HomeUiState.kt
+│   │   └── HomeIntent.kt
+│   ├── profile/
+│   └── settings/
+├── core/
+│   ├── data/
+│   │   ├── repository/
+│   │   └── model/
+│   ├── network/
+│   └── database/
+└── ui/
+    ├── theme/
+    └── components/
+```
+
+### Rules
+
+- Organize by feature, not by technical layer.
+- **Unidirectional Data Flow (UDF)** — intents flow up, state flows down.
+- **Single state per screen** — one `UiState` data class, one `StateFlow`.
+- **Explicit intents** — all user actions are modeled as sealed interface members. No ad-hoc methods on ViewModel.
+- **Repository pattern** — single source of truth for data. Repositories expose Flows.
+- **Use case classes** (optional) — encapsulate complex business logic. Skip for simple CRUD.
+- One screen composable per file. ViewModel per screen.
+- **Adapt to existing architecture.** If the project uses MVVM/MVP/MVC, follow the established pattern. Propose MVI for new screens or new projects.
+
+For multi-module architecture, Gradle setup, and build variants see `references/project-structure.md`.
+
+## Dependency Injection
+
+```kotlin
+// Hilt (recommended)
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+    private val repository: ItemRepository,
+) : ViewModel() { ... }
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+    @Binds
+    abstract fun bindItemRepository(impl: DefaultItemRepository): ItemRepository
+}
+
+// Manual DI (for small projects or libraries)
+class AppContainer {
+    private val api: ApiService by lazy { RetrofitApiService() }
+    val repository: ItemRepository by lazy { DefaultItemRepository(api) }
+}
+```
+
+Rules:
+- **Hilt** for apps — standard Android DI, integrates with ViewModel, WorkManager, Navigation.
+- **Manual DI or Koin** for libraries or KMP shared modules.
+- Inject interfaces, not implementations.
+- Use `@Singleton` sparingly — scope to the narrowest lifecycle.
+
+## Testable Design
+
+- **Inject dependencies** via constructor. ViewModels receive repositories, not context.
+- **Repository interfaces** — swap real implementations with fakes in tests.
+- **UI state as data class** — easy to assert in unit tests.
+- **Compose testing** — `createComposeRule()`, semantic matchers, `onNodeWithText`.
+
+```kotlin
+class HomeViewModelTest {
+    private val fakeRepository = FakeItemRepository()
+    private val viewModel = HomeViewModel(fakeRepository)
+
+    @Test
+    fun `load items updates state`() = runTest {
+        fakeRepository.emit(listOf(Item("1", "Test")))
+        viewModel.load()
+        assertEquals(listOf(Item("1", "Test")), viewModel.uiState.value.items)
+    }
+}
+```
+
+Test naming: `fun 'description of behavior'()` with backtick syntax, or `test_method_condition_expected()`.
+
+## Platform-Specific Guidance
+
+The core skill covers Android phone by default. For other platforms, consult the corresponding reference:
+
+| Platform | Reference | Key Topics |
+|---|---|---|
+| Tablet / Foldable | `references/tablet-patterns.md` | `WindowSizeClass`, adaptive layouts, multi-window, foldable postures |
+| Wear OS | `references/wear-os-patterns.md` | Compose for Wear, Tiles, complications, Health Services |
+| Google TV / Android TV | `references/tv-patterns.md` | Compose for TV, focus/D-pad navigation, Leanback |
+| Android Auto | `references/android-auto-patterns.md` | Car App Library, templates, phone projection |
+| Android Automotive | `references/android-automotive-patterns.md` | AAOS, embedded system, car hardware APIs |
+| Meta Quest | `references/meta-quest-patterns.md` | Adapting APK for VR, spatial UI, entitlement, passthrough |
+| Amazon Fire TV | `references/fire-tv-patterns.md` | Appstore, Amazon IAP, Alexa, missing GMS |
+| Amazon Fire Tablets | `references/fire-tablet-patterns.md` | Device lineup, Show Mode, Kids Edition |
+
+## Quick Reference: Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Collecting Flow without lifecycle awareness | Use `collectAsStateWithLifecycle()` in Compose |
+| Business logic in composables | Move to ViewModel, expose as StateFlow |
+| `mutableStateOf` in ViewModel | Use `MutableStateFlow` + `asStateFlow()` |
+| Passing `Context` to ViewModel | Use `AndroidViewModel` only if truly needed, prefer abstractions |
+| `LaunchedEffect(Unit)` for one-time loads | Consider loading in ViewModel `init` block |
+| Hardcoded strings in composables | Use `stringResource(R.string.xxx)` |
+| Not handling process death | Use `SavedStateHandle` in ViewModel, `rememberSaveable` in Compose |
+| God ViewModel (500+ lines) | Split by screen, extract use cases |
+| Not using `Modifier` parameter | Always accept `modifier: Modifier = Modifier` as first optional param |
+| `remember` for complex objects | Use `remember` with proper keys, or move to ViewModel |
+| Ignoring configuration changes | Test with rotation, dark mode, font scale |
+| Using `GlobalScope` | Use `viewModelScope` or structured concurrency |
+| View-based navigation in Compose app | Use Compose Navigation (`NavHost`) |
+| `LiveData` in new code | Use `StateFlow` + `collectAsStateWithLifecycle()` |
+| Magic numbers in UI (`padding(16.dp)`, `fontSize = 14.sp`) | Define design tokens (`AppSpacing.medium`) or use `MaterialTheme` tokens |

--- a/registry/skills/google-app-development/references/android-auto-patterns.md
+++ b/registry/skills/google-app-development/references/android-auto-patterns.md
@@ -1,0 +1,842 @@
+# Android Auto Patterns Reference
+
+> Target: Car App Library 1.4+
+
+>[toc]
+
+
+## Car App Library Architecture
+
+### Core Components
+---
+
+The Car App Library (`androidx.car.app`) provides a host-agnostic framework for building Android Auto apps. The architecture follows a service-session-screen model.
+
+#### CarAppService
+
+`CarAppService` is the entry point. It is a bound `Service` that the car host connects to. Declare it in `AndroidManifest.xml` with the appropriate intent filter.
+
+```xml
+<service
+    android:name=".MyCarAppService"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="androidx.car.app.CarAppService" />
+        <category android:name="androidx.car.app.category.NAVIGATION" /> <!-- or POI, IOT, etc. -->
+    </intent-filter>
+</service>
+```
+
+```kotlin
+class MyCarAppService : CarAppService() {
+    override fun createHostValidator(): HostValidator {
+        return HostValidator.ALLOW_ALL_HOSTS_VALIDATOR // use specific hosts in production
+    }
+
+    override fun onCreateSession(): Session {
+        return MySession()
+    }
+}
+```
+
+#### Session
+
+A `Session` represents a single connection to the car host. It owns the `Screen` back stack and receives lifecycle callbacks. Each connection creates a new `Session` instance.
+
+```kotlin
+class MySession : Session() {
+    override fun onCreateScreen(intent: Intent): Screen {
+        return MainScreen(carContext)
+    }
+}
+```
+
+#### Screen
+
+A `Screen` is the basic UI unit. Each screen returns a single `Template` from `onGetTemplate()`. Screens are pushed/popped via `ScreenManager`.
+
+```kotlin
+class MainScreen(carContext: CarContext) : Screen(carContext) {
+    override fun onGetTemplate(): Template {
+        return ListTemplate.Builder()
+            .setTitle("Main Menu")
+            .setSingleList(buildItemList())
+            .build()
+    }
+}
+```
+
+#### ScreenManager
+
+`ScreenManager` manages a back stack of `Screen` instances. Use it to navigate between screens.
+
+```kotlin
+// Push a new screen
+screenManager.push(DetailScreen(carContext))
+
+// Pop back
+screenManager.pop()
+
+// Pop to root
+screenManager.popToRoot()
+```
+
+The template depth limit (see Constraints below) applies to the back stack depth.
+
+
+## Templates
+
+### Template Catalog
+---
+
+Car App Library 1.4+ provides a set of templates designed for driver-safe interaction. Each template enforces distraction guidelines at the host level.
+
+#### ListTemplate
+
+Best for: browsable lists of items (settings, song lists, destinations).
+
+```kotlin
+val itemList = ItemList.Builder()
+    .addItem(
+        Row.Builder()
+            .setTitle("Item Title")
+            .addText("Secondary text")
+            .setOnClickListener { screenManager.push(DetailScreen(carContext)) }
+            .setImage(CarIcon.Builder(IconCompat.createWithResource(carContext, R.drawable.ic_item)).build())
+            .build()
+    )
+    .build()
+
+ListTemplate.Builder()
+    .setTitle("Browse")
+    .setSingleList(itemList)
+    .setHeaderAction(Action.BACK)
+    .build()
+```
+
+#### GridTemplate
+
+Best for: icon-driven menus, category selection, home screens with visual tiles.
+
+```kotlin
+val gridItemList = ItemList.Builder()
+    .addItem(
+        GridItem.Builder()
+            .setTitle("Category")
+            .setImage(CarIcon.Builder(icon).build())
+            .setOnClickListener { /* navigate */ }
+            .build()
+    )
+    .build()
+
+GridTemplate.Builder()
+    .setTitle("Home")
+    .setSingleList(gridItemList)
+    .setHeaderAction(Action.APP_ICON)
+    .build()
+```
+
+#### MessageTemplate
+
+Best for: confirmation dialogs, error states, simple informational messages.
+
+```kotlin
+MessageTemplate.Builder("Are you sure you want to cancel navigation?")
+    .setTitle("Confirm")
+    .setIcon(CarIcon.Builder(iconCompat).build())
+    .addAction(
+        Action.Builder()
+            .setTitle("Yes")
+            .setOnClickListener { /* handle */ }
+            .build()
+    )
+    .addAction(
+        Action.Builder()
+            .setTitle("No")
+            .setOnClickListener { screenManager.pop() }
+            .build()
+    )
+    .build()
+```
+
+#### NavigationTemplate
+
+Best for: active turn-by-turn navigation with map rendering.
+
+- Requires `androidx.car.app.category.NAVIGATION` category.
+- Displays routing information, maneuver icons, and ETA.
+- Draws map content via `SurfaceCallback`.
+
+```kotlin
+NavigationTemplate.Builder()
+    .setNavigationInfo(
+        RoutingInfo.Builder()
+            .setCurrentStep(
+                Step.Builder("Main Street")
+                    .setManeuver(
+                        Maneuver.Builder(Maneuver.TYPE_TURN_NORMAL_LEFT)
+                            .setIcon(CarIcon.Builder(turnIcon).build())
+                            .build()
+                    )
+                    .build(),
+                Distance.create(0.5, Distance.UNIT_MILES)
+            )
+            .build()
+    )
+    .setActionStrip(actionStrip)
+    .build()
+```
+
+#### MapTemplate
+
+Best for: map-centric apps that need interactive content alongside the map (POI browsing, parking, charging stations). Available in Car App Library 1.4+.
+
+```kotlin
+MapTemplate.Builder()
+    .setMapController(
+        MapController.Builder()
+            .setMapActionStrip(mapActionStrip)
+            .build()
+    )
+    .setPane(
+        Pane.Builder()
+            .addRow(Row.Builder().setTitle("Station Name").addText("0.3 mi").build())
+            .addAction(Action.Builder().setTitle("Navigate").setOnClickListener { /* ... */ }.build())
+            .build()
+    )
+    .build()
+```
+
+### Template Selection Guide
+
+| Use Case | Template | Notes |
+|----------|----------|-------|
+| Browsable list of items | `ListTemplate` | Most common; supports images, text rows |
+| Visual category grid | `GridTemplate` | Icon-driven; limited text |
+| Simple message/dialog | `MessageTemplate` | Max 2 actions |
+| Active navigation | `NavigationTemplate` | Requires NAVIGATION category |
+| Map with details pane | `MapTemplate` | 1.4+; for POI/charging |
+| Long-form text | `LongMessageTemplate` | Terms of service, legal text |
+| User input | `SearchTemplate` | Voice/keyboard input |
+| Sign-in | `SignInTemplate` | QR code or PIN-based auth |
+
+
+## Media Apps
+
+### MediaBrowserService and MediaSession
+---
+
+Media apps for Android Auto do **not** use the Car App Library. They use the standard `MediaBrowserServiceCompat` + `MediaSessionCompat` pattern. The Auto host renders the UI automatically.
+
+#### MediaBrowserService
+
+Expose a browse tree of playable and browsable `MediaItem` objects.
+
+```kotlin
+class MyMediaBrowserService : MediaBrowserServiceCompat() {
+
+    override fun onCreate() {
+        super.onCreate()
+        val session = MediaSessionCompat(this, "MyMediaService")
+        sessionToken = session.sessionToken
+        session.setCallback(MyMediaSessionCallback())
+        session.isActive = true
+    }
+
+    override fun onGetRoot(
+        clientPackageName: String,
+        clientUid: Int,
+        rootHints: Bundle?
+    ): BrowserRoot {
+        return BrowserRoot("ROOT_ID", null)
+    }
+
+    override fun onLoadChildren(
+        parentId: String,
+        result: Result<MutableList<MediaItem>>
+    ) {
+        result.detach()
+        // Load items asynchronously, then result.sendResult(items)
+    }
+}
+```
+
+#### Browse Tree Structure
+
+```
+ROOT_ID
+├── PLAYLISTS
+│   ├── Playlist A
+│   └── Playlist B
+├── ALBUMS
+│   ├── Album 1
+│   └── Album 2
+└── RECENTLY_PLAYED
+    ├── Song X
+    └── Song Y
+```
+
+- Use `MediaDescriptionCompat` to set title, subtitle, and icon URI.
+- Mark items as `FLAG_BROWSABLE` (folder) or `FLAG_PLAYABLE` (leaf).
+- Limit browse tree depth and breadth per Auto content guidelines.
+
+#### Playback Controls
+
+```kotlin
+class MyMediaSessionCallback : MediaSessionCompat.Callback() {
+    override fun onPlay() { /* start playback */ }
+    override fun onPause() { /* pause */ }
+    override fun onSkipToNext() { /* next track */ }
+    override fun onSkipToPrevious() { /* previous track */ }
+    override fun onPlayFromMediaId(mediaId: String?, extras: Bundle?) { /* play specific item */ }
+    override fun onPlayFromSearch(query: String?, extras: Bundle?) { /* voice search */ }
+}
+```
+
+Set `PlaybackStateCompat` actions to control which buttons appear:
+
+```kotlin
+val stateBuilder = PlaybackStateCompat.Builder()
+    .setActions(
+        PlaybackStateCompat.ACTION_PLAY or
+        PlaybackStateCompat.ACTION_PAUSE or
+        PlaybackStateCompat.ACTION_SKIP_TO_NEXT or
+        PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS
+    )
+    .setState(PlaybackStateCompat.STATE_PLAYING, position, 1.0f)
+mediaSession.setPlaybackState(stateBuilder.build())
+```
+
+
+## Messaging Apps
+
+### Notifications-Based Messaging
+---
+
+Messaging apps on Android Auto work through notifications, not the Car App Library.
+
+#### CarAppExtender
+
+`CarAppExtender` extends standard notifications for the Auto environment. Use `NotificationCompat.Builder` with messaging style.
+
+```kotlin
+val messagingStyle = NotificationCompat.MessagingStyle(selfPerson)
+    .setConversationTitle("Group Chat")
+    .addMessage("Hey, are you on the way?", timestamp, senderPerson)
+
+val replyAction = NotificationCompat.Action.Builder(
+    R.drawable.ic_reply,
+    "Reply",
+    replyPendingIntent
+)
+    .addRemoteInput(
+        RemoteInput.Builder("key_reply")
+            .setLabel("Reply via voice")
+            .build()
+    )
+    .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_REPLY)
+    .setShowsUserInterface(false)
+    .build()
+
+val markAsReadAction = NotificationCompat.Action.Builder(
+    R.drawable.ic_check,
+    "Mark as Read",
+    markAsReadPendingIntent
+)
+    .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_MARK_AS_READ)
+    .setShowsUserInterface(false)
+    .build()
+
+val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+    .setSmallIcon(R.drawable.ic_message)
+    .setStyle(messagingStyle)
+    .addAction(replyAction)
+    .addAction(markAsReadAction)
+    .extend(
+        CarAppExtender.Builder()
+            .setImportance(NotificationManager.IMPORTANCE_HIGH)
+            .build()
+    )
+    .build()
+```
+
+#### Voice Reply
+
+Voice replies are delivered through `RemoteInput`. Handle the reply in a `BroadcastReceiver` or `Service`:
+
+```kotlin
+class ReplyReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val remoteInput = RemoteInput.getResultsFromIntent(intent)
+        val replyText = remoteInput?.getCharSequence("key_reply")
+        // Send the message, then update the notification
+    }
+}
+```
+
+Key requirements:
+- Use `MessagingStyle` notifications (mandatory for Auto).
+- Include `SEMANTIC_ACTION_REPLY` and `SEMANTIC_ACTION_MARK_AS_READ` actions.
+- Set `setShowsUserInterface(false)` on both actions.
+
+
+## Navigation Apps
+
+### Turn-by-Turn Navigation
+---
+
+Navigation apps use the `NavigationTemplate` and the `NavigationManager` API.
+
+#### SurfaceCallback
+
+Implement `SurfaceCallback` to draw maps on the car display surface.
+
+```kotlin
+class MyNavigationSession : Session() {
+
+    private val surfaceCallback = object : SurfaceCallback {
+        override fun onSurfaceAvailable(surfaceContainer: SurfaceContainer) {
+            val surface = surfaceContainer.surface ?: return
+            // Initialize rendering (e.g., OpenGL, Canvas)
+            drawMap(surface)
+        }
+
+        override fun onSurfaceDestroyed(surfaceContainer: SurfaceContainer) {
+            // Release rendering resources
+        }
+
+        override fun onVisibleAreaChanged(visibleArea: Rect) {
+            // Adjust map rendering to visible area (accounts for template overlays)
+        }
+
+        override fun onStableAreaChanged(stableArea: Rect) {
+            // Area that remains constant (safe zone for persistent UI)
+        }
+
+        override fun onScroll(distanceX: Float, distanceY: Float) {
+            // Handle pan gestures
+        }
+
+        override fun onScale(focusX: Float, focusY: Float, scaleFactor: Float) {
+            // Handle pinch-to-zoom
+        }
+    }
+
+    override fun onCreateScreen(intent: Intent): Screen {
+        carContext.getCarService(AppManager::class.java)
+            .setSurfaceCallback(surfaceCallback)
+        return NavigationScreen(carContext)
+    }
+}
+```
+
+#### NavigationManager
+
+Use `NavigationManager` to communicate navigation state to the host (cluster display, notifications).
+
+```kotlin
+val navigationManager = carContext.getCarService(NavigationManager::class.java)
+
+// Start navigation
+navigationManager.navigationStarted()
+
+// Update trip information
+navigationManager.updateTrip(
+    Trip.Builder()
+        .addStep(
+            Step.Builder("Turn left onto Main Street")
+                .setManeuver(Maneuver.Builder(Maneuver.TYPE_TURN_NORMAL_LEFT).build())
+                .build(),
+            Distance.create(200.0, Distance.UNIT_METERS)
+        )
+        .addDestination(
+            Destination.Builder()
+                .setName("Work")
+                .setAddress("123 Main St")
+                .build()
+        )
+        .build()
+)
+
+// End navigation
+navigationManager.navigationEnded()
+```
+
+#### Maneuver Icons
+
+`Maneuver.Builder` accepts a `TYPE_*` constant that maps to standard maneuver icons:
+
+| Constant | Description |
+|----------|-------------|
+| `TYPE_TURN_NORMAL_LEFT` | Standard left turn |
+| `TYPE_TURN_NORMAL_RIGHT` | Standard right turn |
+| `TYPE_U_TURN_LEFT` | U-turn to the left |
+| `TYPE_ROUNDABOUT_ENTER_AND_EXIT_CW` | Roundabout clockwise |
+| `TYPE_MERGE_LEFT` | Merge left |
+| `TYPE_FORK_LEFT` | Fork left |
+| `TYPE_DESTINATION` | Arrival at destination |
+| `TYPE_STRAIGHT` | Continue straight |
+
+You can also provide a custom `CarIcon` for non-standard maneuvers.
+
+
+## POI and Charging Apps
+
+### Point-of-Interest Templates
+---
+
+POI and charging/EV apps use `MapTemplate` (1.4+) and `PlaceListMapTemplate` to display locations on the map alongside detail panes.
+
+#### PlaceListMapTemplate
+
+Shows a list of places pinned on a map.
+
+```kotlin
+val placeList = ItemList.Builder()
+    .addItem(
+        Row.Builder()
+            .setTitle("Charging Station A")
+            .addText("2 chargers available")
+            .setMetadata(
+                Metadata.Builder()
+                    .setPlace(
+                        Place.Builder(
+                            CarLocation.create(37.7749, -122.4194)
+                        )
+                            .setMarker(PlaceMarker.Builder().build())
+                            .build()
+                    )
+                    .build()
+            )
+            .setOnClickListener { screenManager.push(StationDetailScreen(carContext)) }
+            .build()
+    )
+    .build()
+
+PlaceListMapTemplate.Builder()
+    .setTitle("Nearby Chargers")
+    .setItemList(placeList)
+    .setHeaderAction(Action.BACK)
+    .build()
+```
+
+#### MapTemplate for Charging/POI Detail
+
+Use `MapTemplate` with a `Pane` to show details alongside the map.
+
+```kotlin
+MapTemplate.Builder()
+    .setMapController(
+        MapController.Builder()
+            .setMapActionStrip(
+                ActionStrip.Builder()
+                    .addAction(Action.PAN) // allow map panning
+                    .build()
+            )
+            .build()
+    )
+    .setPane(
+        Pane.Builder()
+            .setHeader(PaneTemplate.Header.Builder().setTitle("Station A").build())
+            .addRow(Row.Builder().setTitle("CCS 150kW").addText("Available").build())
+            .addRow(Row.Builder().setTitle("Price").addText("$0.35/kWh").build())
+            .addAction(
+                Action.Builder()
+                    .setTitle("Start Charging")
+                    .setOnClickListener { /* initiate session */ }
+                    .build()
+            )
+            .build()
+    )
+    .build()
+```
+
+Required category for POI apps:
+
+```xml
+<category android:name="androidx.car.app.category.POI" />
+```
+
+For EV charging apps specifically:
+
+```xml
+<category android:name="androidx.car.app.category.CHARGING" />
+```
+
+
+## Constraints and Limitations
+
+### Distraction and Safety Guidelines
+---
+
+Android Auto enforces strict constraints to minimize driver distraction. These are enforced at the host level and cannot be bypassed.
+
+#### Template Depth Limit
+
+- Maximum **5 templates** in the back stack (screen depth).
+- `Screen` pushes beyond this limit will throw an exception.
+- `ScreenManager.popToRoot()` resets the depth counter.
+- Refreshing the current template (calling `invalidate()` on the same `Screen`) does **not** count toward the depth limit.
+
+#### List Item Limits
+
+| Constraint | Limit |
+|------------|-------|
+| `ItemList` items (list/grid) | **6** items (may vary by OEM/host) |
+| `ActionStrip` actions | **4** actions |
+| `Pane` rows | **4** rows |
+| `Pane` actions | **2** actions |
+| `MessageTemplate` actions | **2** actions |
+
+Use `ConstraintManager` to query the actual limits at runtime:
+
+```kotlin
+val constraintManager = carContext.getCarService(ConstraintManager::class.java)
+val listLimit = constraintManager.getContentLimit(ConstraintManager.CONTENT_LIMIT_TYPE_LIST)
+val gridLimit = constraintManager.getContentLimit(ConstraintManager.CONTENT_LIMIT_TYPE_GRID)
+```
+
+#### Additional Constraints
+
+- **Text length**: long strings are truncated by the host. Keep titles and descriptions short.
+- **Images**: use `CarIcon` with appropriate sizing. Large bitmaps are scaled/rejected.
+- **Interaction**: no free-form text input while driving (keyboard disabled). `SearchTemplate` uses voice input while moving.
+- **Refresh rate**: avoid calling `invalidate()` more than once per second. Excessive refreshes are throttled by the host.
+- **No custom views**: all UI must go through templates. You cannot inflate custom layouts.
+- **Dark mode**: support both light and dark `CarIcon` variants. The host switches automatically.
+
+
+## Testing
+
+### Desktop Head Unit (DHU)
+---
+
+The DHU simulates an Android Auto head unit on your development machine.
+
+#### Setup
+
+1. Install the DHU via Android Studio SDK Manager (under SDK Tools > Android Auto Desktop Head Unit Emulator).
+2. Enable developer mode in the Android Auto app on your phone.
+3. Start the head unit server on the phone (Developer settings > Start head unit server).
+4. Connect via ADB:
+
+```bash
+# Forward the TCP port
+adb forward tcp:5277 tcp:5277
+
+# Launch DHU (path varies by SDK location)
+cd $ANDROID_HOME/extras/google/auto
+./desktop-head-unit
+```
+
+#### DHU Commands
+
+```bash
+# Simulate day/night mode toggle
+day
+night
+
+# Simulate microphone input
+mic play <audio_file.wav>
+
+# Simulate navigation focus
+nav focus
+```
+
+### TestCarContext
+---
+
+`TestCarContext` (from `androidx.car.app.testing`) provides a test-friendly `CarContext` for unit tests.
+
+```kotlin
+@Test
+fun mainScreen_displaysListTemplate() {
+    val testCarContext = TestCarContext.createCarContext(ApplicationProvider.getApplicationContext())
+    val screen = MainScreen(testCarContext)
+    val template = screen.onGetTemplate()
+
+    assertThat(template).isInstanceOf(ListTemplate::class.java)
+    val listTemplate = template as ListTemplate
+    assertThat(listTemplate.title).isEqualTo("Main Menu")
+}
+```
+
+#### Testing Screen Navigation
+
+```kotlin
+@Test
+fun clickingItem_pushesDetailScreen() {
+    val testCarContext = TestCarContext.createCarContext(ApplicationProvider.getApplicationContext())
+    val screen = MainScreen(testCarContext)
+    val template = screen.onGetTemplate() as ListTemplate
+
+    // Simulate click on first item
+    val firstItem = template.singleList!!.items[0] as Row
+    firstItem.onClickDelegate.sendClick()
+
+    val screenManager = testCarContext.getCarService(ScreenManager::class.java)
+    assertThat(screenManager.screenStack).hasSize(2)
+}
+```
+
+#### Instrumented Testing
+
+Use `SessionController` for end-to-end session testing:
+
+```kotlin
+@Test
+fun session_createsCorrectInitialScreen() {
+    val session = MySession()
+    val controller = SessionController(
+        session,
+        TestCarContext.createCarContext(ApplicationProvider.getApplicationContext())
+    )
+    controller.create(Intent())
+
+    val currentScreen = session.carContext
+        .getCarService(ScreenManager::class.java)
+        .top
+
+    assertThat(currentScreen).isInstanceOf(MainScreen::class.java)
+}
+```
+
+
+## Lifecycle
+
+### CarAppService Lifecycle
+---
+
+The `CarAppService` and `Session` lifecycle follows Android bound-service semantics, combined with Car App Library-specific callbacks.
+
+#### Connection Flow
+
+```
+Host connects to CarAppService
+    → CarAppService.onCreateSession()
+        → Session.onCreateScreen(intent)
+            → Screen.onGetTemplate()  (initial template rendered)
+        → Session.onNewIntent(intent)  (subsequent intents)
+    → Session lifecycle: ON_CREATE → ON_START → ON_RESUME
+```
+
+#### Disconnection Flow
+
+```
+Host disconnects
+    → Session lifecycle: ON_PAUSE → ON_STOP → ON_DESTROY
+    → CarAppService.onDestroy()  (if no more sessions)
+```
+
+#### Key Lifecycle Callbacks
+
+```kotlin
+class MySession : Session() {
+    override fun onCreateScreen(intent: Intent): Screen {
+        // Called once per session; return the root screen
+        return MainScreen(carContext)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        // Called when a new intent is sent to an existing session
+        // e.g., notification tap while already connected
+    }
+
+    override fun onCarConfigurationChanged(newConfiguration: Configuration) {
+        // Called when car configuration changes (e.g., day/night mode)
+    }
+}
+```
+
+#### Lifecycle-Aware Components
+
+`Session` implements `LifecycleOwner`. Use it to scope work:
+
+```kotlin
+class MySession : Session() {
+    override fun onCreateScreen(intent: Intent): Screen {
+        lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onStart(owner: LifecycleOwner) {
+                // Start location updates
+            }
+            override fun onStop(owner: LifecycleOwner) {
+                // Stop location updates
+            }
+        })
+        return MainScreen(carContext)
+    }
+}
+```
+
+#### CarContext
+
+`CarContext` is available after `onCreateScreen()`. It provides access to car services, navigation intents, and host info:
+
+```kotlin
+// Check API level supported by the connected host
+val hostApiLevel = carContext.carAppApiLevel
+
+// Start navigation in another app
+carContext.startCarApp(
+    Intent(CarContext.ACTION_NAVIGATE, Uri.parse("geo:37.7749,-122.4194"))
+)
+
+// Request permissions
+carContext.requestPermissions(listOf(Manifest.permission.ACCESS_FINE_LOCATION)) { granted, rejected ->
+    // handle result
+}
+```
+
+
+## Distribution
+
+### Play Store for Android Auto
+---
+
+#### App Categories
+
+Declare the appropriate category in your manifest. Only approved categories are accepted:
+
+| Category | Manifest Value |
+|----------|---------------|
+| Navigation | `androidx.car.app.category.NAVIGATION` |
+| Parking / POI | `androidx.car.app.category.POI` |
+| Charging (EV) | `androidx.car.app.category.CHARGING` |
+| Media | Standard `MediaBrowserService` (no category needed) |
+| Messaging | Standard notifications (no category needed) |
+| IoT | `androidx.car.app.category.IOT` |
+
+#### Minimum Requirements
+
+- Declare `minCarAppApiLevel` in `AndroidManifest.xml`:
+
+```xml
+<meta-data
+    android:name="androidx.car.app.minCarAppApiLevel"
+    android:value="5" /> <!-- Car App Library 1.4 = API level 5+ -->
+```
+
+- Target API level 33+ for new submissions.
+- Include both mobile and Auto experiences in the same APK/AAB (Auto is not a separate listing).
+
+#### Review Guidelines
+
+- **No distracting content**: all interaction must go through approved templates. Custom views are rejected.
+- **Functional offline**: apps should handle offline/degraded states gracefully with `MessageTemplate`.
+- **Voice-first**: messaging apps must support voice reply. Navigation apps should support voice-initiated destinations.
+- **Template compliance**: stay within list limits and depth limits. Apps that crash from constraint violations are rejected.
+- **Dark mode support**: provide dark-variant icons. The host controls theme switching.
+- **Permissions**: request only permissions needed for Auto functionality. Justify location, microphone, and notification access.
+
+#### Pre-Launch Checklist
+
+- [ ] Tested on DHU with both day and night modes
+- [ ] Verified list item counts against `ConstraintManager` limits
+- [ ] Template back stack depth does not exceed 5
+- [ ] All `CarIcon` resources include dark mode variants
+- [ ] `minCarAppApiLevel` is set correctly in manifest
+- [ ] Graceful handling of host disconnection
+- [ ] Voice interactions tested (search, reply)
+- [ ] No hardcoded host assumptions (works across different car brands)
+- [ ] Privacy policy URL included in Play Store listing
+- [ ] App category matches declared manifest category

--- a/registry/skills/google-app-development/references/android-automotive-patterns.md
+++ b/registry/skills/google-app-development/references/android-automotive-patterns.md
@@ -1,0 +1,939 @@
+# Android Automotive OS (AAOS) Patterns Reference
+
+Target: AAOS Android 14+
+
+>[toc]
+
+
+## AAOS vs Android Auto
+
+### Architectural Distinction
+---
+Android Automotive OS (AAOS) is a **full embedded operating system** that runs directly on the vehicle's infotainment head unit. It replaces the OEM's proprietary OS entirely — Android is the platform, not a guest.
+
+Android Auto is a **phone projection protocol**. The app runs on the user's phone and projects its UI onto the car's display via USB or wireless connection. The head unit acts as a remote display and input surface.
+
+#### When to Use Which
+
+| Factor | AAOS | Android Auto |
+|--------|------|--------------|
+| **Runtime** | On the vehicle's hardware | On the user's phone |
+| **OS control** | Full (system services, sensors, HALs) | None (sandboxed projection) |
+| **App lifecycle** | Managed by vehicle OS | Managed by phone OS |
+| **Hardware access** | Direct via Car APIs and HALs | Limited via Car App Library abstractions |
+| **Distribution** | Play Store for Automotive | Standard Play Store (phone) |
+| **OEM dependency** | High — app runs on OEM hardware | Low — runs on any compatible phone |
+| **Use case** | Deep vehicle integration, system apps, HVAC, native media | Portable companion apps, navigation, messaging |
+
+#### Shared API Surface
+The **Car App Library** (`androidx.car.app`) provides a common template-based API that works on both Android Auto and AAOS. Apps built with this library can target both platforms from a single codebase, with AAOS-specific capabilities available through runtime checks.
+
+```kotlin
+// Check if running on AAOS (embedded) vs Android Auto (projection)
+val isAutomotive = context.packageManager
+    .hasSystemFeature("android.hardware.type.automotive")
+```
+
+
+## Car App Library on AAOS
+
+### Same API, Additional Capabilities
+---
+On AAOS, the Car App Library provides the same template-driven UI model as Android Auto — `Screen`, `Template`, `Session` — but with expanded capabilities.
+
+#### Key Differences on AAOS
+
+- **Broader template support**: AAOS supports `MapTemplate`, `TabTemplate`, and longer lists without the strict item-count limits enforced on Android Auto.
+- **Background execution**: Apps can perform background work more freely since they run natively on the vehicle OS, not projected from a phone.
+- **Direct hardware access**: Apps can access vehicle hardware APIs alongside Car App Library UI, combining template UI with `CarHardwareManager` data.
+- **Multiple display support**: AAOS supports rendering to instrument cluster and rear-seat displays via `CarAppService` and `SurfaceContainer`.
+
+#### CarAppService on AAOS
+
+```kotlin
+class MyCarAppService : CarAppService() {
+    override fun createHostValidator(): HostValidator {
+        // On AAOS, the host is the system's car app host
+        return HostValidator.ALLOW_ALL_HOSTS_VALIDATOR
+    }
+
+    override fun onCreateSession(): Session {
+        return MySession()
+    }
+}
+
+class MySession : Session() {
+    override fun onCreateScreen(intent: Intent): Screen {
+        return MainScreen(carContext)
+    }
+}
+```
+
+#### Manifest Declaration for AAOS
+
+```xml
+<manifest>
+    <uses-feature
+        android:name="android.hardware.type.automotive"
+        android:required="true" />
+
+    <!-- Declare supported template categories -->
+    <application>
+        <service
+            android:name=".MyCarAppService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="androidx.car.app.CarAppService" />
+                <category android:name="androidx.car.app.category.NAVIGATION" />
+            </intent-filter>
+        </service>
+    </application>
+</manifest>
+```
+
+#### API Level Awareness
+
+```kotlin
+// Check Car App API level for feature availability
+if (carContext.carAppApiLevel >= CarAppApiLevels.LEVEL_5) {
+    // Use TabTemplate, MapTemplate with content refresh
+}
+```
+
+
+## Car Hardware APIs
+
+### CarHardwareManager and Vehicle Sensors
+---
+AAOS exposes vehicle hardware through the `android.car` package. The primary entry points are `Car`, `CarPropertyManager`, `CarSensorManager` (deprecated in favor of `CarPropertyManager`), and the Car App Library's `CarHardware` abstraction.
+
+#### Connecting to the Car Service
+
+```kotlin
+private lateinit var car: Car
+private lateinit var propertyManager: CarPropertyManager
+
+fun connectCarService(context: Context) {
+    car = Car.createCar(context)
+    propertyManager = car.getCarManager(Car.PROPERTY_SERVICE) as CarPropertyManager
+}
+```
+
+#### CarInfo — Vehicle Metadata
+
+`CarInfo` provides static and semi-static vehicle information accessible from the Car App Library.
+
+```kotlin
+val carHardware = carContext.getCarService(CarHardwareManager::class.java)
+val carInfo = carHardware.carInfo
+
+// Observe vehicle model info
+carInfo.fetchModel { modelInfo ->
+    val manufacturer = modelInfo.manufacturer?.value ?: "Unknown"
+    val model = modelInfo.name?.value ?: "Unknown"
+    val year = modelInfo.year?.value ?: 0
+}
+
+// Observe energy profile (fuel type, EV connector types)
+carInfo.fetchEnergyProfile { profile ->
+    val fuelTypes = profile.fuelTypes?.value ?: emptyList()
+    val evConnectorTypes = profile.evConnectorTypes?.value ?: emptyList()
+}
+```
+
+#### CarSensors — Live Vehicle Data
+
+```kotlin
+val carSensors = carHardware.carSensors
+
+// Observe accelerometer
+carSensors.addAccelerometerListener(
+    CarSensors.UPDATE_RATE_NORMAL,
+    executor
+) { data ->
+    val x = data.forces.value?.get(0) ?: 0f
+    val y = data.forces.value?.get(1) ?: 0f
+    val z = data.forces.value?.get(2) ?: 0f
+}
+
+// Observe compass
+carSensors.addCompassListener(
+    CarSensors.UPDATE_RATE_NORMAL,
+    executor
+) { data ->
+    val bearings = data.orientations.value
+}
+
+// Observe gyroscope
+carSensors.addGyroscopeListener(
+    CarSensors.UPDATE_RATE_NORMAL,
+    executor
+) { data ->
+    val rotations = data.rotations.value
+}
+```
+
+#### CarPropertyManager — Direct Property Access
+
+For system-privileged apps or apps with appropriate permissions, `CarPropertyManager` provides fine-grained access to the Vehicle HAL (VHAL).
+
+```kotlin
+// Read vehicle speed
+val speed = propertyManager.getProperty<Float>(
+    VehiclePropertyIds.PERF_VEHICLE_SPEED, 0
+)
+
+// Register for property change callbacks
+propertyManager.registerCallback(
+    object : CarPropertyManager.CarPropertyEventCallback {
+        override fun onChangeEvent(event: CarPropertyValue<*>) {
+            when (event.propertyId) {
+                VehiclePropertyIds.PERF_VEHICLE_SPEED -> {
+                    val speedKmh = event.value as Float
+                }
+                VehiclePropertyIds.ENGINE_RPM -> {
+                    val rpm = event.value as Float
+                }
+            }
+        }
+        override fun onErrorEvent(propId: Int, zone: Int) {
+            Log.e(TAG, "Error reading property $propId in zone $zone")
+        }
+    },
+    VehiclePropertyIds.PERF_VEHICLE_SPEED,
+    CarPropertyManager.SENSOR_RATE_NORMAL
+)
+```
+
+#### Permissions
+
+Vehicle sensor access requires specific permissions declared in the manifest:
+
+```xml
+<uses-permission android:name="android.car.permission.CAR_SPEED" />
+<uses-permission android:name="android.car.permission.CAR_ENERGY" />
+<uses-permission android:name="android.car.permission.CAR_DYNAMICS_STATE" />
+```
+
+Third-party apps have access to a limited subset. Many properties are restricted to system-signed apps.
+
+
+## System UI Integration
+
+### Status Bar, Navigation Bar, and Distraction Optimization
+---
+
+#### System Bars on AAOS
+
+AAOS uses a custom system UI (`CarSystemUI`) that differs from phone/tablet Android:
+
+- **Status bar**: Displays vehicle-specific indicators (connectivity, user, time). Located at the top. Apps cannot fully hide it — they render below it.
+- **Navigation bar**: Provides the app launcher, home, and notification panel. Typically a persistent bar at the bottom or side of the screen. Not dismissible by third-party apps.
+- **Control bar**: Some OEMs include a persistent climate/media control bar.
+
+#### Insets and Layout
+
+```kotlin
+// Handle system bar insets properly
+ViewCompat.setOnApplyWindowInsetsListener(rootView) { view, insets ->
+    val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+    view.setPadding(
+        systemBars.left,
+        systemBars.top,
+        systemBars.right,
+        systemBars.bottom
+    )
+    WindowInsetsCompat.CONSUMED
+}
+```
+
+#### Distraction Optimization (DO)
+
+AAOS enforces **Driver Distraction** guidelines. When the vehicle is in motion, the platform restricts UI interactions:
+
+- Lists are capped to a maximum number of visible items (typically 6).
+- Text length is truncated.
+- Keyboard input is blocked.
+- Touch targets must meet minimum size requirements.
+
+```kotlin
+// Check driving state
+val carUxRestrictionsManager = car.getCarManager(
+    Car.CAR_UX_RESTRICTION_SERVICE
+) as CarUxRestrictionsManager
+
+carUxRestrictionsManager.registerListener { restrictions ->
+    val isDistractionOptimized = restrictions.isRequiresDistractionOptimization
+    val activeRestrictions = restrictions.activeRestrictions
+
+    if (activeRestrictions and CarUxRestrictions.UX_RESTRICTIONS_NO_KEYBOARD != 0) {
+        // Disable keyboard input
+    }
+    if (activeRestrictions and CarUxRestrictions.UX_RESTRICTIONS_LIMIT_STRING_LENGTH != 0) {
+        // Truncate displayed strings
+    }
+}
+```
+
+#### Car App Library Built-in DO
+
+When using the Car App Library, distraction optimization is handled automatically by the host. Templates enforce item limits, text truncation, and input restrictions without manual intervention.
+
+
+## Media Apps on AAOS
+
+### Native Playback and Audio Focus
+---
+
+#### MediaBrowserService Pattern
+
+Media apps on AAOS follow the standard `MediaBrowserServiceCompat` pattern. The vehicle's system media app (OEM media center) browses and controls playback through this service.
+
+```kotlin
+class MyMediaBrowserService : MediaBrowserServiceCompat() {
+
+    private lateinit var mediaSession: MediaSessionCompat
+
+    override fun onCreate() {
+        super.onCreate()
+        mediaSession = MediaSessionCompat(this, "MyMediaService").apply {
+            setCallback(mediaSessionCallback)
+            isActive = true
+        }
+        sessionToken = mediaSession.sessionToken
+    }
+
+    override fun onGetRoot(
+        clientPackageName: String,
+        clientUid: Int,
+        rootHints: Bundle?
+    ): BrowserRoot {
+        // Return browsable root; validate caller package
+        return BrowserRoot("root", null)
+    }
+
+    override fun onLoadChildren(
+        parentId: String,
+        result: Result<MutableList<MediaBrowserCompat.MediaItem>>
+    ) {
+        result.detach()
+        // Load and send media items asynchronously
+        val items = loadMediaItems(parentId)
+        result.sendResult(items)
+    }
+}
+```
+
+#### Audio Focus on AAOS
+
+AAOS uses the standard `AudioManager` API for audio focus, but vehicle-specific behavior applies:
+
+```kotlin
+val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+val focusRequest = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN).apply {
+    setAudioAttributes(
+        AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_MEDIA)
+            .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+            .build()
+    )
+    setOnAudioFocusChangeListener { focusChange ->
+        when (focusChange) {
+            AudioManager.AUDIOFOCUS_GAIN -> resumePlayback()
+            AudioManager.AUDIOFOCUS_LOSS -> stopPlayback()
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> pausePlayback()
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> duckVolume()
+        }
+    }
+}.build()
+
+audioManager.requestAudioFocus(focusRequest)
+```
+
+#### Multi-Zone Audio
+
+AAOS supports multi-zone audio for vehicles with multiple audio zones (front, rear, etc.):
+
+```kotlin
+val carAudioManager = car.getCarManager(Car.AUDIO_SERVICE) as CarAudioManager
+
+// Get available audio zones
+val audioZones = carAudioManager.audioZoneIds
+
+// Get the zone for a specific occupant
+val rearZone = carAudioManager.getZoneIdForOccupant(
+    CarOccupantZoneManager.OCCUPANT_TYPE_REAR_PASSENGER
+)
+
+// Audio routing is typically handled at the system level.
+// Third-party apps play audio normally; the system routes it
+// to the appropriate zone based on the active user context.
+```
+
+#### Manifest for Media on AAOS
+
+```xml
+<service
+    android:name=".MyMediaBrowserService"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="android.media.browse.MediaBrowserService" />
+    </intent-filter>
+</service>
+
+<meta-data
+    android:name="com.google.android.gms.car.application"
+    android:resource="@xml/automotive_app_desc" />
+```
+
+`res/xml/automotive_app_desc.xml`:
+
+```xml
+<automotiveApp>
+    <uses name="media" />
+</automotiveApp>
+```
+
+
+## Maps and Navigation
+
+### Full Map Rendering and Cluster Display
+---
+
+#### SurfaceContainer for Map Rendering
+
+Navigation apps on AAOS can render directly to a `Surface` provided by the host, enabling full OpenGL/Vulkan map rendering instead of template-only UI.
+
+```kotlin
+class NavigationScreen(carContext: CarContext) : Screen(carContext) {
+
+    private val surfaceCallback = object : SurfaceCallback {
+        override fun onSurfaceAvailable(container: SurfaceContainer) {
+            val surface = container.surface
+            val width = container.width
+            val height = container.height
+            val dpi = container.dpi
+            // Initialize map renderer with this surface
+            mapRenderer.onSurfaceCreated(surface, width, height, dpi)
+        }
+
+        override fun onSurfaceDestroyed(container: SurfaceContainer) {
+            mapRenderer.onSurfaceDestroyed()
+        }
+
+        override fun onVisibleAreaChanged(visibleArea: Rect) {
+            // Adjust map UI to avoid overlap with template chrome
+            mapRenderer.setVisibleArea(visibleArea)
+        }
+
+        override fun onStableAreaChanged(stableArea: Rect) {
+            // Stable area excludes transient UI like notifications
+            mapRenderer.setStableArea(stableArea)
+        }
+
+        override fun onScroll(distanceX: Float, distanceY: Float) {
+            mapRenderer.pan(distanceX, distanceY)
+        }
+
+        override fun onScale(focusX: Float, focusY: Float, scaleFactor: Float) {
+            mapRenderer.zoom(focusX, focusY, scaleFactor)
+        }
+    }
+
+    override fun onGetTemplate(): Template {
+        return NavigationTemplate.Builder()
+            .setMapActionStrip(buildMapActions())
+            .setActionStrip(buildActionStrip())
+            .build()
+    }
+}
+```
+
+#### AppManager Surface Registration
+
+```kotlin
+class MySession : Session() {
+    override fun onCreateScreen(intent: Intent): Screen {
+        val appManager = carContext.getCarService(AppManager::class.java)
+        appManager.setSurfaceCallback(surfaceCallback)
+        return NavigationScreen(carContext)
+    }
+}
+```
+
+#### Cluster Display (Instrument Cluster)
+
+AAOS supports rendering navigation information on the instrument cluster behind the steering wheel. This is exposed through the `NavigationManager`:
+
+```kotlin
+val navigationManager = carContext.getCarService(NavigationManager::class.java)
+
+// Send navigation metadata to the cluster
+navigationManager.navigationStarted()
+
+// Update trip info
+val trip = Trip.Builder()
+    .addStep(
+        Step.Builder("Turn right on Main St")
+            .setManeuver(
+                Maneuver.Builder(Maneuver.TYPE_TURN_NORMAL_RIGHT).build()
+            )
+            .build(),
+        TravelEstimate.Builder(
+            Distance.create(500.0, Distance.UNIT_METERS),
+            DateTimeWithZone.create(arrivalTime, timeZone)
+        ).build()
+    )
+    .addDestination(destination, destinationEstimate)
+    .setLoading(false)
+    .build()
+
+navigationManager.updateTrip(trip)
+
+// When navigation ends
+navigationManager.navigationEnded()
+```
+
+#### Permissions for Navigation
+
+```xml
+<uses-permission android:name="androidx.car.app.NAVIGATION_TEMPLATES" />
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+```
+
+
+## HVAC and Climate
+
+### CarPropertyManager for Climate Control
+---
+
+HVAC control on AAOS is accessed through `CarPropertyManager` using VHAL property IDs. This is typically reserved for **system-privileged apps** (OEM climate apps).
+
+#### Common HVAC Property IDs
+
+| Property | ID Constant | Type | Description |
+|----------|------------|------|-------------|
+| Fan speed | `HVAC_FAN_SPEED` | `Int` | Fan speed level (0 to max) |
+| Fan direction | `HVAC_FAN_DIRECTION` | `Int` | Airflow direction bitmask |
+| Temperature set | `HVAC_TEMPERATURE_SET` | `Float` | Target temperature in Celsius |
+| AC on/off | `HVAC_AC_ON` | `Boolean` | Air conditioning toggle |
+| Auto mode | `HVAC_AUTO_ON` | `Boolean` | Automatic climate control |
+| Defroster | `HVAC_DEFROSTER` | `Boolean` | Front/rear defroster state |
+| Seat heating | `HVAC_SEAT_TEMPERATURE` | `Int` | Seat heater/cooler level |
+| Steering wheel heating | `HVAC_STEERING_WHEEL_HEAT` | `Int` | Steering wheel heater level |
+
+#### Reading and Writing HVAC Properties
+
+```kotlin
+val propertyManager = car.getCarManager(Car.PROPERTY_SERVICE) as CarPropertyManager
+
+// Read current temperature setpoint for driver zone
+val driverTemp = propertyManager.getFloatProperty(
+    VehiclePropertyIds.HVAC_TEMPERATURE_SET,
+    VehicleAreaSeat.SEAT_ROW_1_LEFT
+)
+
+// Set temperature for driver zone
+propertyManager.setFloatProperty(
+    VehiclePropertyIds.HVAC_TEMPERATURE_SET,
+    VehicleAreaSeat.SEAT_ROW_1_LEFT,
+    22.0f  // Celsius
+)
+
+// Toggle AC
+propertyManager.setBooleanProperty(
+    VehiclePropertyIds.HVAC_AC_ON,
+    VehicleAreaSeat.SEAT_ROW_1_LEFT,
+    true
+)
+```
+
+#### Zone Targeting
+
+HVAC properties are **zoned** — each property can have different values per vehicle zone. Zones are defined by `VehicleAreaSeat`:
+
+```kotlin
+// Zone constants
+VehicleAreaSeat.SEAT_ROW_1_LEFT   // Driver (LHD)
+VehicleAreaSeat.SEAT_ROW_1_RIGHT  // Front passenger
+VehicleAreaSeat.SEAT_ROW_2_LEFT   // Rear left
+VehicleAreaSeat.SEAT_ROW_2_RIGHT  // Rear right
+VehicleAreaSeat.SEAT_ROW_2_CENTER // Rear center
+
+// Query supported zones for a property
+val config = propertyManager.getCarPropertyConfig(
+    VehiclePropertyIds.HVAC_TEMPERATURE_SET
+)
+val supportedZones = config?.areaIds ?: intArrayOf()
+
+// Set temperature per zone
+for (zone in supportedZones) {
+    propertyManager.setFloatProperty(
+        VehiclePropertyIds.HVAC_TEMPERATURE_SET,
+        zone,
+        22.0f
+    )
+}
+```
+
+#### Listening for HVAC Changes
+
+```kotlin
+propertyManager.registerCallback(
+    object : CarPropertyManager.CarPropertyEventCallback {
+        override fun onChangeEvent(event: CarPropertyValue<*>) {
+            val zone = event.areaId
+            when (event.propertyId) {
+                VehiclePropertyIds.HVAC_TEMPERATURE_SET -> {
+                    val temp = event.value as Float
+                    updateTempDisplay(zone, temp)
+                }
+                VehiclePropertyIds.HVAC_AC_ON -> {
+                    val isOn = event.value as Boolean
+                    updateAcToggle(zone, isOn)
+                }
+            }
+        }
+        override fun onErrorEvent(propId: Int, zone: Int) {
+            Log.e(TAG, "HVAC property error: $propId, zone: $zone")
+        }
+    },
+    VehiclePropertyIds.HVAC_TEMPERATURE_SET,
+    CarPropertyManager.SENSOR_RATE_ONCHANGE
+)
+```
+
+#### Permissions
+
+```xml
+<uses-permission android:name="android.car.permission.CONTROL_CAR_CLIMATE" />
+```
+
+This permission is signature-level. Third-party apps cannot control HVAC unless explicitly granted by the OEM.
+
+
+## User Management
+
+### Multi-User, Driver Profiles, and Privacy
+---
+
+#### Multi-User Architecture
+
+AAOS is a **multi-user OS**. Each driver or occupant can have their own Android user profile with separate:
+
+- App data and preferences
+- Accounts (Google, third-party)
+- Media libraries and playback history
+- Navigation favorites and history
+- Notification state
+
+#### User Lifecycle
+
+```kotlin
+val carUserManager = car.getCarManager(Car.CAR_USER_SERVICE) as CarUserManager
+
+// Observe user switching events
+carUserManager.addListener(executor) { event ->
+    when (event.eventType) {
+        CarUserManager.USER_LIFECYCLE_EVENT_TYPE_SWITCHING -> {
+            // Clean up current user's state
+            clearUserSession()
+        }
+        CarUserManager.USER_LIFECYCLE_EVENT_TYPE_UNLOCKED -> {
+            // Initialize new user's data
+            initializeUserSession(event.userId)
+        }
+    }
+}
+```
+
+#### CarOccupantZoneManager
+
+Maps physical zones (driver, front passenger, rear) to Android user profiles:
+
+```kotlin
+val occupantZoneManager = car.getCarManager(
+    Car.CAR_OCCUPANT_ZONE_SERVICE
+) as CarOccupantZoneManager
+
+// Get all occupant zones
+val zones = occupantZoneManager.allOccupantZones
+
+for (zone in zones) {
+    val userId = occupantZoneManager.getUserForOccupant(zone)
+    val displays = occupantZoneManager.getAllDisplaysForOccupant(zone)
+    Log.d(TAG, "Zone: ${zone.occupantType}, User: $userId, Displays: ${displays.size}")
+}
+```
+
+#### Privacy Considerations
+
+- **User isolation**: Each user profile is sandboxed. Apps cannot access other users' data without explicit system-level permissions.
+- **Guest mode**: AAOS supports a guest user for temporary drivers (e.g., valets). Guest data is ephemeral and wiped on switch.
+- **Location data**: Navigation history and location permissions are per-user. Clearing one user's data does not affect others.
+- **Account data**: Apps should scope authentication tokens and session data to the current Android user ID.
+
+```kotlin
+// Scope data storage to current user
+val currentUser = Process.myUserHandle()
+val userSpecificPrefs = context.getSharedPreferences(
+    "prefs_${currentUser.identifier}",
+    Context.MODE_PRIVATE
+)
+```
+
+
+## OEM Customization
+
+### System vs Third-Party Apps and Privileged APIs
+---
+
+#### App Tiers on AAOS
+
+| Tier | Signing | Capabilities | Examples |
+|------|---------|-------------|----------|
+| **System/Platform** | OEM platform key | Full VHAL access, system UI, privileged APIs | Settings, Climate, Instrument Cluster |
+| **Privileged** | Pre-installed, allowlisted | Select privileged permissions | OEM media, OEM navigation |
+| **Third-party** | Developer key | Car App Library, MediaBrowserService, standard Android APIs | Spotify, Waze, third-party apps |
+
+#### Privileged API Access
+
+System apps signed with the platform key can access the full `android.car` API surface:
+
+```kotlin
+// Only available to system apps
+val vehicleManager = car.getCarManager(Car.VEHICLE_SERVICE) as VehicleManager
+val diagnosticManager = car.getCarManager(Car.DIAGNOSTIC_SERVICE) as CarDiagnosticManager
+val watchdogManager = car.getCarManager(Car.CAR_WATCHDOG_SERVICE) as CarWatchdogManager
+```
+
+#### OEM Customization Points
+
+- **CarUiLib**: OEMs can customize shared UI components (toolbars, list items, preferences) via `car-ui-lib` resource overlays without modifying app source.
+- **Runtime Resource Overlays (RRO)**: OEMs apply RROs to change colors, dimensions, drawables, and layouts system-wide.
+- **System UI**: `CarSystemUI` is fully customizable — navigation bar position, status bar content, notification shade behavior.
+- **VHAL extensions**: OEMs can define custom VHAL properties beyond the AOSP standard set for proprietary vehicle features.
+
+#### Third-Party App Constraints
+
+Third-party apps on AAOS:
+
+- Must use Car App Library templates or `MediaBrowserService` — no arbitrary `Activity`-based UI (unless the app targets specific categories like video or browser on Android 14+).
+- Cannot access privileged car properties (HVAC, diagnostics, etc.).
+- Must comply with distraction optimization requirements.
+- Are subject to Play Store for Automotive policies.
+
+
+## Testing
+
+### AAOS Emulator, GSI, and HAL Simulation
+---
+
+#### AAOS Emulator
+
+Android Studio provides an AAOS system image for the emulator. This is the primary development and testing tool.
+
+```bash
+# Create an AAOS AVD via command line
+sdkmanager "system-images;android-34;google_apis_playstore;x86_64"
+
+avdmanager create avd \
+    --name "AAOS_API_34" \
+    --package "system-images;android-34;google_apis_playstore;x86_64" \
+    --tag "google_apis_playstore" \
+    --device "automotive_1024p_landscape"
+```
+
+The AAOS emulator includes:
+
+- Simulated VHAL with configurable properties
+- Multi-display support (main display + cluster)
+- Multi-user support
+- Audio zone simulation
+
+#### VHAL Property Injection
+
+The emulator's extended controls panel allows injecting VHAL property values at runtime for testing:
+
+```bash
+# Inject vehicle speed via ADB
+adb shell cmd car_service inject-vhal-event 0x11600207 --value 60.0
+
+# Inject gear selection (PARK = 4, DRIVE = 8)
+adb shell cmd car_service inject-vhal-event 0x11400400 --value 8
+```
+
+#### Generic System Image (GSI)
+
+For testing on real hardware without OEM customization:
+
+```bash
+# Flash GSI to a supported development board
+fastboot flash system system-arm64-ab-vanilla.img
+fastboot flash vbmeta vbmeta.img --disable-verity --disable-verification
+fastboot reboot
+```
+
+#### Desktop Head Unit (DHU) for Car App Library
+
+For testing Car App Library apps without the full AAOS emulator:
+
+```bash
+# Start the Desktop Head Unit
+$ANDROID_HOME/extras/google/auto/desktop-head-unit
+
+# Configure DHU for automotive mode
+./desktop-head-unit --type=automotive
+```
+
+#### Automated Testing
+
+```kotlin
+// Use CarAppServiceController for testing Car App Library screens
+@Test
+fun testNavigationScreen() {
+    val scenario = SessionScenario.launch(MyCarAppService::class.java)
+
+    scenario.onSession { session ->
+        val screen = session.carContext.getCarService(ScreenManager::class.java)
+            .top as NavigationScreen
+
+        val template = screen.onGetTemplate() as NavigationTemplate
+        assertThat(template.actionStrip).isNotNull()
+    }
+}
+
+// Unit test VHAL property handling
+@Test
+fun testHvacPropertyCallback() {
+    val callback = HvacPropertyCallback()
+    val event = CarPropertyValue(
+        VehiclePropertyIds.HVAC_TEMPERATURE_SET,
+        VehicleAreaSeat.SEAT_ROW_1_LEFT,
+        22.0f
+    )
+    callback.onChangeEvent(event)
+    assertThat(callback.currentTemp).isEqualTo(22.0f)
+}
+```
+
+#### HAL Simulation
+
+For development boards or custom hardware, AAOS provides a default VHAL implementation that can be configured:
+
+```json
+// Default VHAL config (hardware/interfaces/automotive/vehicle/aidl)
+{
+    "properties": [
+        {
+            "property": "VehicleProperty::PERF_VEHICLE_SPEED",
+            "defaultValue": { "floatValues": [0.0] },
+            "areas": [{ "areaId": 0 }]
+        }
+    ]
+}
+```
+
+
+## Distribution
+
+### Play Store for Automotive, Compliance, and Platform Variants
+---
+
+#### Play Store for Automotive
+
+AAOS apps are distributed through the **Google Play Store for Automotive**, a separate track from the phone/tablet Play Store:
+
+- Apps must be submitted specifically for the Automotive form factor.
+- Separate APK/AAB or build variant targeting `android.hardware.type.automotive`.
+- Independent review process with automotive-specific guidelines.
+- OEMs can pre-install apps or make them available through the store.
+
+#### Build Configuration
+
+```kotlin
+// build.gradle.kts
+android {
+    defaultConfig {
+        minSdk = 29  // AAOS minimum
+        targetSdk = 34
+    }
+
+    flavorDimensions += "platform"
+    productFlavors {
+        create("auto") {
+            dimension = "platform"
+            // No uses-feature for phone
+        }
+        create("automotive") {
+            dimension = "platform"
+            // automotive-specific dependencies
+        }
+    }
+}
+
+dependencies {
+    implementation("androidx.car.app:app:1.4.0")
+    // Automotive-only dependency
+    "automotiveImplementation"("androidx.car.app:app-automotive:1.4.0")
+}
+```
+
+#### GAS vs AOSP Builds
+
+| Aspect | GAS (Google Automotive Services) | AOSP-only |
+|--------|----------------------------------|-----------|
+| **Play Store** | Available | Not available |
+| **Google Maps** | Pre-installed | Not available |
+| **Google Assistant** | Integrated | Not available |
+| **GMS APIs** | Full suite (Firebase, etc.) | Not available |
+| **App distribution** | Play Store for Automotive | OEM sideloading or custom store |
+| **OEM examples** | Polestar, Volvo, GM, Ford, Honda | Some Chinese OEMs, custom implementations |
+
+#### AOSP-Only Considerations
+
+For vehicles without GAS:
+
+```kotlin
+// Check for Google Play Services availability
+fun hasGooglePlayServices(context: Context): Boolean {
+    return try {
+        GoogleApiAvailability.getInstance()
+            .isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS
+    } catch (e: Exception) {
+        false
+    }
+}
+
+// Provide fallback for GMS-dependent features
+if (hasGooglePlayServices(context)) {
+    // Use Firebase, Google Maps, etc.
+} else {
+    // Use alternatives: OSM, custom analytics, etc.
+}
+```
+
+#### Compliance Requirements
+
+Apps submitted to Play Store for Automotive must meet:
+
+- **Distraction optimization**: All interactive UI must comply with driver distraction guidelines.
+- **Template usage**: Car App Library apps must use approved templates — no custom `Activity` rendering for navigation/POI categories.
+- **Media apps**: Must implement `MediaBrowserService` correctly; no audio-only playback hacks.
+- **Privacy**: Must comply with Automotive-specific data handling policies, especially for location and driving data.
+- **Quality guidelines**: Must handle multi-user, screen size variation, day/night mode, and landscape orientation.
+
+#### Android 14+ App Categories
+
+Android 14 expanded the categories of apps allowed on AAOS:
+
+| Category | UI Model | Notes |
+|----------|----------|-------|
+| **Navigation** | Car App Library (map surface) | Full map rendering via `SurfaceContainer` |
+| **Media** | `MediaBrowserService` | System media app handles UI |
+| **Messaging** | Car App Library | Template-based conversations |
+| **POI / Parking** | Car App Library | Points of interest, charging, fuel |
+| **Video** | Standard `Activity` | Only when parked; new in Android 13+ |
+| **Browser** | Standard `Activity` | Only when parked; new in Android 14+ |
+| **VoIP** | `ConnectionService` | In-app calling |

--- a/registry/skills/google-app-development/references/android-lifecycle.md
+++ b/registry/skills/google-app-development/references/android-lifecycle.md
@@ -1,0 +1,1004 @@
+# Android Lifecycle Reference (Compose-First)
+
+>[toc]
+
+
+## Activity Lifecycle
+
+### Overview
+---
+Every Android Activity follows a predictable sequence of callbacks. In a Compose-first app, Activities are thin shells -- they host `setContent {}` and delegate everything else to composables and ViewModels.
+
+#### Callback Sequence
+
+```
+onCreate  ->  onStart  ->  onResume
+                              |
+onPause  ->  onStop  ->  onDestroy
+```
+
+| Callback | Lifecycle State | Typical Use | Compose-First Notes |
+|----------|----------------|-------------|---------------------|
+| `onCreate` | `CREATED` | Call `setContent {}`, set up edge-to-edge, enable predictive back | Primary entry point; keep minimal |
+| `onStart` | `STARTED` | Activity becomes visible; register broad observers | Rarely overridden in Compose apps |
+| `onResume` | `RESUMED` | Activity gains focus; start camera, sensors, animations | Use `LifecycleEventEffect` instead |
+| `onPause` | `STARTED` | Another activity partially covers; pause heavy resources | Commit transient UI state if needed |
+| `onStop` | `CREATED` | Activity no longer visible; release UI-bound resources | System may kill process after this |
+| `onDestroy` | `DESTROYED` | Activity is finishing or config change | Do NOT rely on this for cleanup -- use ViewModel `onCleared()` |
+
+#### Minimal Compose Activity
+
+```kotlin
+@AndroidEntryPoint
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            MyAppTheme {
+                MyAppNavHost()
+            }
+        }
+    }
+}
+```
+
+#### Common Pitfalls
+
+- **Leaking references**: Never hold a reference to `Activity` or `Context` inside a ViewModel. Use `applicationContext` when absolutely necessary.
+- **Heavy work in `onCreate`**: heavy I/O blocks the main thread and delays first frame. Offload initialization to coroutines scoped to a ViewModel or the App Startup library.
+- **Assuming `onDestroy` is called**: The system can kill the process without calling `onDestroy`. Persist critical state via `SavedStateHandle` or `rememberSaveable`.
+- **Recreating work on config change**: If you launch a coroutine in `onCreate` without scoping it to a ViewModel, it restarts on every rotation.
+- **Ignoring multi-window / PiP**: in multi-window mode an Activity can be in `STARTED` (visible) but not `RESUMED`. Do not gate essential UI updates on `onResume` alone.
+
+
+## Fragment Lifecycle
+
+### Fragment vs View Lifecycle
+---
+Fragments have **two** distinct lifecycles:
+
+1. **Fragment lifecycle** (`onCreate` -> `onDestroy`) -- tied to the Fragment instance.
+2. **View lifecycle** (`onCreateView` -> `onDestroyView`) -- tied to the Fragment's view hierarchy. Accessible via `viewLifecycleOwner`.
+
+```
+Fragment:  onCreate ---------------------------------------- onDestroy
+View:              onCreateView -- onDestroyView
+                   (may repeat when back-stacked)
+```
+
+When a Fragment is on the back stack, its view is destroyed (`onDestroyView`) but the Fragment instance survives. This means:
+- `viewLifecycleOwner` is scoped to the view and is the correct owner for UI observations.
+- The Fragment's own lifecycle outlives the view -- observing on `this` instead of `viewLifecycleOwner` causes duplicate observers and leaks.
+
+#### viewLifecycleOwner in Practice
+
+```kotlin
+// CORRECT -- scoped to view lifecycle
+viewLifecycleOwner.lifecycleScope.launch {
+    viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        viewModel.uiState.collect { state -> /* update UI */ }
+    }
+}
+
+// WRONG -- survives view destruction, leaks observers across view recreations
+lifecycleScope.launch {
+    repeatOnLifecycle(Lifecycle.State.STARTED) {
+        viewModel.uiState.collect { state -> /* update UI */ }
+    }
+}
+```
+
+### When to Use Fragments in Compose-First Apps
+---
+In a Compose-first architecture, Fragments are generally **unnecessary**. Prefer Compose Navigation (`NavHost`, `composable()` destinations). Valid exceptions:
+
+- **Legacy interop**: Existing Fragment-based features being migrated incrementally.
+- **Third-party SDKs**: Some SDKs (e.g., Maps, CameraX viewfinder) still require Fragment or View hosts.
+- **Multi-module navigation with legacy modules**: When some modules still use Fragment-based navigation.
+
+For new features, use composable destinations with `NavHost` instead of Fragments. If you must mix, host Compose inside a Fragment via `ComposeView` in `onCreateView` and scope state to `viewLifecycleOwner`.
+
+
+## ViewModel
+
+### Creation and Scoping
+---
+ViewModels survive configuration changes and are scoped to a `ViewModelStoreOwner` (Activity, Fragment, or `NavBackStackEntry`).
+
+#### Basic ViewModel with Hilt
+
+```kotlin
+@HiltViewModel
+class ProfileViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+    private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    val userId: String = savedStateHandle["userId"]
+        ?: error("userId argument is required")
+
+    val uiState: StateFlow<ProfileUiState> = userRepository
+        .observeUser(userId)
+        .map { ProfileUiState.Success(it) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ProfileUiState.Loading)
+}
+```
+
+#### Accessing in Compose
+
+```kotlin
+// Scoped to the nearest NavBackStackEntry (default with Hilt Navigation Compose)
+@Composable
+fun ProfileScreen(
+    viewModel: ProfileViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    // ...
+}
+
+// Scoped to Activity (shared ViewModel)
+@Composable
+fun SomeChildScreen(
+    sharedViewModel: SharedViewModel = hiltViewModel(
+        viewModelStoreOwner = LocalContext.current as ComponentActivity
+    )
+) { /* ... */ }
+
+// Scoped to parent nav graph
+@Composable
+fun FeatureScreen(
+    navController: NavController,
+    viewModel: FeatureSharedViewModel = hiltViewModel(
+        viewModelStoreOwner = navController.getBackStackEntry("feature_graph")
+    )
+) { /* ... */ }
+```
+
+### SavedStateHandle
+---
+`SavedStateHandle` is a key-value map that survives **process death**. Hilt automatically provides it.
+
+```kotlin
+@HiltViewModel
+class SearchViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    // Automatically saved and restored across process death
+    val query = savedStateHandle.getStateFlow("query", "")
+
+    // Alternative: property delegate with Compose state
+    var queryState by savedStateHandle.saveable { mutableStateOf("") }
+        private set
+
+    fun onQueryChange(newQuery: String) {
+        savedStateHandle["query"] = newQuery
+    }
+}
+```
+
+Rules for `SavedStateHandle`:
+- Store only small, serializable data (IDs, query strings, scroll positions).
+- Do not store large objects (bitmaps, lists of hundreds of items). Use a local database or cache instead.
+- Maximum bundle size is ~1 MB across the entire saved state tree; exceeding it causes a `TransactionTooLargeException`.
+
+### CreationExtras
+---
+`CreationExtras` (Lifecycle 2.5+) provide a type-safe way to pass arguments to ViewModel factories without custom `ViewModelProvider.Factory` boilerplate.
+
+```kotlin
+class MyViewModel(
+    private val repository: Repository,
+    private val itemId: String,
+) : ViewModel() {
+
+    companion object {
+        val ITEM_ID_KEY = object : CreationExtras.Key<String> {}
+
+        val Factory = object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+                val app = extras[APPLICATION_KEY] as MyApplication
+                val itemId = extras[ITEM_ID_KEY] ?: error("itemId required")
+                @Suppress("UNCHECKED_CAST")
+                return MyViewModel(app.repository, itemId) as T
+            }
+        }
+    }
+}
+```
+
+With Hilt, `CreationExtras` are rarely needed directly -- Hilt's `@AssistedInject` or `SavedStateHandle` cover most use cases.
+
+### Scoping Strategies
+---
+
+| Scope | Owner | When to Use |
+|-------|-------|-------------|
+| Activity | `ComponentActivity` | App-wide shared state (auth, theme) |
+| Navigation graph | `NavBackStackEntry` (nested graph) | Feature-level state (multi-screen wizard) |
+| Destination | `NavBackStackEntry` | Screen-level state (default) |
+
+Avoid scoping ViewModels to the Activity unless the data genuinely needs to outlive individual screens. Over-scoping leads to memory waste and unclear ownership.
+
+
+## Configuration Changes
+
+### What Triggers a Config Change
+---
+
+| Trigger | Default Behavior | `configChanges` Override |
+|---------|-----------------|--------------------------|
+| Screen rotation | Activity destroyed and recreated | `orientation\|screenSize` |
+| Dark/light mode toggle | Activity destroyed and recreated | `uiMode` |
+| Locale change | Activity destroyed and recreated | `locale` |
+| Font size change | Activity destroyed and recreated | `fontScale` |
+| Multi-window resize | Activity destroyed and recreated | `screenSize\|smallestScreenSize\|screenLayout` |
+| Keyboard availability | Activity destroyed and recreated | `keyboard\|keyboardHidden` |
+
+### What Survives and What Does Not
+
+| Mechanism | Survives Config Change | Survives Process Death |
+|-----------|:---------------------:|:---------------------:|
+| `ViewModel` | Yes | No |
+| `SavedStateHandle` | Yes | Yes |
+| `rememberSaveable` | Yes | Yes |
+| `remember` | No | No |
+| Static / global state | Yes | No |
+| Local variable | No | No |
+| SharedPreferences / DataStore | Yes | Yes |
+| Room database | Yes | Yes |
+
+### Handling in Compose
+
+```kotlin
+@Composable
+fun CounterScreen(viewModel: CounterViewModel = hiltViewModel()) {
+    // Survives config change (ViewModel) AND process death (SavedStateHandle)
+    val count by viewModel.count.collectAsStateWithLifecycle()
+
+    // Survives config change AND process death
+    var userInput by rememberSaveable { mutableStateOf("") }
+
+    // Lost on config change
+    var ephemeral by remember { mutableStateOf(false) }
+}
+```
+
+### Overriding Config Changes (Use Sparingly)
+---
+
+```xml
+<!-- AndroidManifest.xml -- prevents recreation but you must handle changes manually -->
+<activity
+    android:name=".MainActivity"
+    android:configChanges="orientation|screenSize|uiMode|locale" />
+```
+
+```kotlin
+class MainActivity : ComponentActivity() {
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        // Manually handle the change -- Compose recomposes automatically for most cases
+    }
+}
+```
+
+Overriding `configChanges` is **discouraged** in Compose-first apps. Compose handles recomposition naturally; let the system recreate the Activity and rely on ViewModel + SavedStateHandle. The override is acceptable only for performance-sensitive surfaces (video players, games) where recreation is too expensive.
+
+
+## Process Death
+
+### Overview
+---
+Android can kill a backgrounded process at any time to reclaim memory. When the user returns, the system recreates the Activity and restores the saved instance state bundle.
+
+**Key distinction**: ViewModel instances are destroyed. Only `SavedStateHandle` and `rememberSaveable` data survive.
+
+#### What is Preserved
+
+- Anything written to `SavedStateHandle`.
+- Composable state stored via `rememberSaveable`.
+- Navigation back stack (Navigation component serializes it automatically).
+- Pending intents and alarms.
+- SharedPreferences, DataStore, Room data (persisted to disk).
+
+#### What is Lost
+
+- ViewModel instances and all in-memory data.
+- Singleton / object state.
+- Coroutine jobs.
+- Network connections, open files.
+
+### SavedStateHandle for Process Death
+---
+
+```kotlin
+@HiltViewModel
+class FormViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    // These survive process death
+    val name = savedStateHandle.getStateFlow("name", "")
+    val email = savedStateHandle.getStateFlow("email", "")
+
+    fun updateName(value: String) { savedStateHandle["name"] = value }
+    fun updateEmail(value: String) { savedStateHandle["email"] = value }
+}
+```
+
+### rememberSaveable in Compose
+---
+
+```kotlin
+@Composable
+fun FormScreen() {
+    // Primitives -- saved automatically
+    var text by rememberSaveable { mutableStateOf("") }
+
+    // Custom objects -- provide a Saver
+    var selection by rememberSaveable(stateSaver = SelectionSaver) {
+        mutableStateOf(Selection.None)
+    }
+}
+
+// Custom Saver using mapSaver
+val SelectionSaver = mapSaver(
+    save = { mapOf("id" to it.id, "label" to it.label) },
+    restore = { Selection(id = it["id"] as String, label = it["label"] as String) }
+)
+
+// Custom Saver using Saver directly
+val MyItemSaver = Saver<MyItem, Bundle>(
+    save = { bundleOf("id" to it.id, "name" to it.name) },
+    restore = { MyItem(it.getString("id")!!, it.getString("name")!!) }
+)
+```
+
+### Testing Process Death
+---
+
+#### Manual Testing
+
+1. **"Don't keep activities"**: Enable **Developer Options > Don't keep activities** to simulate aggressive destruction. Open your app, navigate to the screen under test, press Home, then return via Recents. Verify all user-visible state is restored. Note: this destroys Activities on every navigation, which is more aggressive than real process death.
+2. **Android Studio**: Run -> "Terminate Application" while the app is in the background, then relaunch from the recents screen.
+3. **ADB**: `adb shell am kill <package_name>` (the app must be backgrounded first).
+
+#### Automated Testing
+
+```kotlin
+// ActivityScenario-based test
+@Test
+fun savedState_survives_processRecreation() {
+    val scenario = launchActivity<MainActivity>()
+    // Enter data ...
+    scenario.recreate() // Simulates process death + recreation
+    // Assert data is restored
+}
+
+// ViewModel unit test with SavedStateHandle
+@Test
+fun `restores query after process death`() {
+    val savedState = SavedStateHandle(mapOf("query" to "test"))
+    val viewModel = SearchViewModel(savedState)
+
+    assertEquals("test", viewModel.query.value)
+}
+```
+
+
+## Navigation Component
+
+### NavController Lifecycle
+---
+`NavController` manages a back stack of `NavBackStackEntry` objects. Each entry is a `LifecycleOwner` and `ViewModelStoreOwner`.
+
+| Event | When |
+|-------|------|
+| `CREATED` | Destination pushed onto back stack |
+| `STARTED` | Destination visible (e.g., under a dialog or in multi-pane) |
+| `RESUMED` | Destination is on top, fully interactive |
+| `DESTROYED` | Destination popped off back stack; its ViewModels are cleared |
+
+### Compose NavHost Setup
+
+```kotlin
+@Composable
+fun MyAppNavHost(
+    navController: NavHostController = rememberNavController(),
+    startDestination: String = "home",
+) {
+    NavHost(navController = navController, startDestination = startDestination) {
+        composable("home") {
+            HomeScreen(onNavigateToDetail = { id ->
+                navController.navigate("detail/$id")
+            })
+        }
+        composable(
+            route = "detail/{itemId}",
+            arguments = listOf(navArgument("itemId") { type = NavType.StringType }),
+        ) {
+            DetailScreen()
+        }
+    }
+}
+```
+
+### Back Stack Management
+---
+
+```kotlin
+// Navigate and clear back stack up to "home", avoiding duplicate entries
+navController.navigate("settings") {
+    popUpTo("home") { inclusive = false }
+    launchSingleTop = true
+}
+
+// Navigate and pop the current destination (replace)
+navController.navigate("home") {
+    popUpTo("login") { inclusive = true }
+    launchSingleTop = true
+}
+
+// Pop back to a specific destination
+navController.popBackStack("home", inclusive = false)
+
+// Bottom navigation pattern -- single instance of each tab
+fun NavHostController.navigateToTab(route: String) {
+    navigate(route) {
+        popUpTo(graph.findStartDestination().id) {
+            saveState = true
+        }
+        launchSingleTop = true
+        restoreState = true
+    }
+}
+```
+
+#### popUpTo vs launchSingleTop
+
+| Option | Behavior |
+|--------|----------|
+| `popUpTo("route")` | Pops all destinations above `route` before navigating |
+| `inclusive = true` | Also pops the `route` destination itself |
+| `launchSingleTop = true` | If destination is already on top of back stack, do not create a new instance |
+| `saveState = true` | Save the state of popped destinations (for bottom nav) |
+| `restoreState = true` | Restore previously saved state when navigating back |
+
+Key rules:
+- Always use `launchSingleTop = true` for tabs and root destinations to avoid duplicate entries.
+- Use `popUpTo` with `inclusive = true` when replacing flows (e.g., after login -> home).
+- Do not hold references to `NavBackStackEntry` outside of composition -- it may be destroyed.
+
+### Result Sharing Between Destinations
+---
+Use `SavedStateHandle` on the **previous** back stack entry to pass results backward without tight coupling:
+
+```kotlin
+// In destination B -- set the result
+navController.previousBackStackEntry
+    ?.savedStateHandle
+    ?.set("selected_item_id", itemId)
+navController.popBackStack()
+
+// In destination A -- observe the result
+val result = navController.currentBackStackEntry
+    ?.savedStateHandle
+    ?.getStateFlow<String?>("selected_item_id", null)
+    ?.collectAsStateWithLifecycle()
+```
+
+For complex flows, prefer a shared ViewModel scoped to a nested navigation graph.
+
+
+## Lifecycle-Aware Components
+
+### DefaultLifecycleObserver
+---
+Use when you need to react to lifecycle events from non-Compose code (e.g., a manager class, analytics tracker).
+
+```kotlin
+class AnalyticsTracker(
+    private val analytics: Analytics,
+) : DefaultLifecycleObserver {
+
+    override fun onResume(owner: LifecycleOwner) {
+        analytics.trackScreenView(owner::class.simpleName ?: "Unknown")
+    }
+
+    override fun onPause(owner: LifecycleOwner) {
+        analytics.trackScreenExit()
+    }
+}
+
+// Register in Activity or via Hilt
+class MainActivity : ComponentActivity() {
+    @Inject lateinit var tracker: AnalyticsTracker
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        lifecycle.addObserver(tracker)
+        setContent { AppContent() }
+    }
+}
+```
+
+### LifecycleEventEffect in Compose
+---
+Preferred approach in Compose for reacting to lifecycle events (Lifecycle 2.7+).
+
+```kotlin
+@Composable
+fun PlayerScreen(viewModel: PlayerViewModel = hiltViewModel()) {
+
+    // Runs when the composable reaches ON_RESUME, cleans up on ON_PAUSE
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        viewModel.startPlayback()
+    }
+
+    LifecycleEventEffect(Lifecycle.Event.ON_PAUSE) {
+        viewModel.pausePlayback()
+    }
+
+    // For paired start/stop behavior
+    LifecycleStartEffect(Unit) {
+        viewModel.connectSensor()
+        onStopOrDispose {
+            viewModel.disconnectSensor()
+        }
+    }
+
+    // For paired resume/pause behavior
+    LifecycleResumeEffect(Unit) {
+        viewModel.resumeUpdates()
+        onPauseOrDispose {
+            viewModel.pauseUpdates()
+        }
+    }
+}
+```
+
+### Observing Lifecycle State as Compose State
+---
+
+```kotlin
+@Composable
+fun MyScreen() {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val lifecycleState by lifecycleOwner.lifecycle.currentStateFlow
+        .collectAsStateWithLifecycle()
+
+    if (lifecycleState.isAtLeast(Lifecycle.State.RESUMED)) {
+        // Only perform work when fully resumed
+    }
+}
+```
+
+### DisposableEffect for Manual Observer Management
+---
+
+```kotlin
+@Composable
+fun LocationTracker(locationClient: FusedLocationProviderClient) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_START -> locationClient.requestUpdates()
+                Lifecycle.Event.ON_STOP -> locationClient.removeUpdates()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+}
+```
+
+### collectAsStateWithLifecycle
+---
+The lifecycle-aware alternative to `collectAsState`. Stops collection when the UI is not visible, reducing wasted work.
+
+```kotlin
+@Composable
+fun DashboardScreen(viewModel: DashboardViewModel = hiltViewModel()) {
+    // Collection pauses when lifecycle drops below STARTED (default)
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    // Custom minimum lifecycle state
+    val backgroundState by viewModel.backgroundData
+        .collectAsStateWithLifecycle(minActiveState = Lifecycle.State.CREATED)
+}
+```
+
+
+## App Startup
+
+### Application Class
+---
+The `Application` class is created before any Activity and lives for the entire process lifetime. Use it sparingly.
+
+```kotlin
+@HiltAndroidApp
+class MyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        // Minimal setup: logging, crash reporting, strict mode (debug)
+        if (BuildConfig.DEBUG) {
+            StrictMode.enableDefaults()
+        }
+    }
+}
+```
+
+Things that belong here: DI initialization (Hilt `@HiltAndroidApp`), crash reporting (Firebase Crashlytics), strict mode, Timber/logging setup.
+
+Things that do **not** belong here: heavy I/O, network calls, UI setup, anything that can be deferred.
+
+### ProcessLifecycleOwner
+---
+Tracks the entire app's foreground/background state (not individual Activities).
+
+| Event | Meaning |
+|-------|---------|
+| `ON_START` | App moved to foreground (at least one Activity started) |
+| `ON_STOP` | App moved to background (no Activities started) -- delayed ~700ms to ignore config changes |
+| `ON_RESUME` / `ON_PAUSE` | Mirrors foreground Activity |
+| `ON_DESTROY` | **Never** emitted |
+
+```kotlin
+class AppLifecycleObserver @Inject constructor(
+    private val analytics: Analytics,
+) : DefaultLifecycleObserver {
+
+    override fun onStart(owner: LifecycleOwner) {
+        // App moved to foreground
+        analytics.trackAppOpen()
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        // App moved to background (all Activities stopped)
+        analytics.trackAppBackground()
+    }
+}
+
+// Register in Application.onCreate or via Hilt initializer
+ProcessLifecycleOwner.get().lifecycle.addObserver(appLifecycleObserver)
+```
+
+### App Startup Library (Jetpack)
+---
+Replaces `ContentProvider`-based initialization with a more efficient, dependency-ordered mechanism.
+
+```kotlin
+// 1. Define Initializers
+class TimberInitializer : Initializer<Unit> {
+    override fun create(context: Context) {
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
+    }
+
+    override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
+}
+
+class AnalyticsInitializer : Initializer<Unit> {
+    override fun create(context: Context) {
+        Analytics.init(context)
+    }
+
+    // Depends on Timber being initialized first
+    override fun dependencies(): List<Class<out Initializer<*>>> =
+        listOf(TimberInitializer::class.java)
+}
+```
+
+```xml
+<!-- 2. Register in AndroidManifest.xml -->
+<provider
+    android:name="androidx.startup.InitializationProvider"
+    android:authorities="${applicationId}.androidx-startup"
+    android:exported="false"
+    tools:node="merge">
+    <meta-data
+        android:name="com.example.AnalyticsInitializer"
+        android:value="androidx.startup" />
+</provider>
+```
+
+### Splash Screen API (Android 12+)
+---
+
+```kotlin
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        val splashScreen = installSplashScreen()
+
+        // Keep splash visible while loading initial data
+        splashScreen.setKeepOnScreenCondition {
+            viewModel.isLoading.value
+        }
+
+        // Optional exit animation
+        splashScreen.setOnExitAnimationListener { provider ->
+            provider.view.animate()
+                .alpha(0f)
+                .setDuration(300L)
+                .withEndAction { provider.remove() }
+                .start()
+        }
+
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            MyAppTheme {
+                MyAppNavHost()
+            }
+        }
+    }
+}
+```
+
+Theme configuration in `res/values/themes.xml`:
+
+```xml
+<style name="Theme.App.Starting" parent="Theme.SplashScreen">
+    <item name="windowSplashScreenBackground">@color/splash_bg</item>
+    <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+    <item name="postSplashScreenTheme">@style/Theme.App</item>
+</style>
+```
+
+
+## Multi-Activity vs Single-Activity
+
+### Decision Framework
+---
+
+#### Single-Activity (Default and Recommended)
+
+The modern Android recommendation is a **single Activity** with Compose Navigation. This is the default for all new Compose-first projects.
+
+| Aspect | Single-Activity | Multi-Activity |
+|--------|----------------|----------------|
+| Navigation | Compose Navigation / NavHost | Intent-based, each screen is an Activity |
+| Shared state | ViewModel scoped to Activity or nav graph | Requires IPC or shared persistence |
+| Animations | Smooth, customizable transitions | System Activity transitions |
+| Deep links | Handled by NavController | Each Activity declares intent filters |
+| Complexity | Lower for most apps | Higher coordination overhead |
+| Back stack | Managed by NavController | Managed by Activity task stack |
+
+**Advantages of single-Activity:**
+- Simpler shared state via navigation-graph-scoped ViewModels.
+- Smoother transitions and animations (no Activity transition overhead).
+- Consistent back stack management through `NavController`.
+- Easier deep link handling -- one entry point.
+- Better support for edge-to-edge, predictive back gestures, and Material transitions.
+
+**Architecture:**
+
+```
+MainActivity (setContent)
+  |-- NavHost
+        |-- HomeScreen
+        |-- DetailScreen
+        |-- SettingsGraph (nested)
+        |     |-- SettingsScreen
+        |     |-- ProfileScreen
+        |-- AuthGraph (nested)
+              |-- LoginScreen
+              |-- RegisterScreen
+```
+
+#### When Multi-Activity is Appropriate
+
+| Scenario | Reason |
+|----------|--------|
+| Separate process needed | e.g., video playback in `:player` process |
+| Third-party SDK requires its own Activity | Payment SDKs, OAuth redirect Activities |
+| Different launch modes (`singleTask`, `singleInstance`) | Task/affinity isolation for notifications |
+| Wear OS, TV, or Auto targets | Platform may mandate separate Activities |
+| Large legacy codebase | Gradual migration -- keep existing Activities, add Compose incrementally |
+| Picture-in-picture, floating windows | Separate task affinity |
+
+#### Anti-Patterns
+
+- Using multiple Activities solely for "code separation" -- use navigation graphs and feature modules instead.
+- Passing large data between Activities via Intent extras -- use an ID and load from repository.
+- Overriding `onBackPressed()` -- use `OnBackPressedDispatcher` or predictive back APIs.
+
+### Recommended Single-Activity Pattern
+
+```kotlin
+// One Activity, one NavHost, multiple composable destinations
+@AndroidEntryPoint
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            MyAppTheme {
+                val navController = rememberNavController()
+                Scaffold(
+                    bottomBar = { BottomNavBar(navController) }
+                ) { padding ->
+                    NavHost(
+                        navController = navController,
+                        startDestination = "home",
+                        modifier = Modifier.padding(padding),
+                    ) {
+                        composable("home") { HomeScreen(navController) }
+                        composable("search") { SearchScreen(navController) }
+                        composable("profile") { ProfileScreen(navController) }
+                        navigation(startDestination = "settings/main", route = "settings") {
+                            composable("settings/main") { SettingsScreen(navController) }
+                            composable("settings/notifications") { NotificationsScreen(navController) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+
+## Deep Links and Intents
+
+### Intent Filters in AndroidManifest
+---
+
+```xml
+<activity
+    android:name=".MainActivity"
+    android:exported="true"
+    android:launchMode="singleTop">
+
+    <!-- App Links (verified, HTTPS only) -->
+    <intent-filter android:autoVerify="true">
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data
+            android:scheme="https"
+            android:host="www.example.com"
+            android:pathPrefix="/product" />
+    </intent-filter>
+
+    <!-- Custom scheme deep link -->
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data
+            android:scheme="myapp"
+            android:host="open" />
+    </intent-filter>
+</activity>
+```
+
+Enable **App Links verification** (`android:autoVerify="true"`) and host a `/.well-known/assetlinks.json` file on your domain for `https` links.
+
+### NavDeepLink in Compose Navigation
+---
+
+```kotlin
+NavHost(navController = navController, startDestination = "home") {
+    composable(
+        route = "product/{productId}",
+        arguments = listOf(navArgument("productId") { type = NavType.StringType }),
+        deepLinks = listOf(
+            navDeepLink {
+                uriPattern = "https://www.example.com/product/{productId}"
+            },
+            navDeepLink {
+                uriPattern = "myapp://open/product/{productId}"
+            },
+            navDeepLink {
+                // Handle share intents
+                action = Intent.ACTION_SEND
+                mimeType = "text/plain"
+            }
+        ),
+    ) { backStackEntry ->
+        val productId = backStackEntry.arguments?.getString("productId")
+        ProductScreen(productId = productId.orEmpty())
+    }
+}
+```
+
+### Handling Incoming Intents
+---
+In a single-Activity setup, handle intents in `onCreate` and `onNewIntent`:
+
+```kotlin
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            val navController = rememberNavController()
+            MyAppTheme {
+                MyAppNavHost(navController = navController)
+            }
+            // NavController automatically handles the initial intent
+            // when navDeepLink patterns are declared in the NavHost
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        // Required for singleTop/singleTask launch modes
+        // NavController handles deep links automatically if navDeepLink is declared
+        navController.handleDeepLink(intent)
+    }
+}
+
+// For custom intent extras or actions beyond URI matching:
+private fun handleDeepLink(intent: Intent, navController: NavController) {
+    when (intent.action) {
+        "com.example.ACTION_SHOW_NOTIFICATION" -> {
+            val notificationId = intent.getStringExtra("notification_id") ?: return
+            navController.navigate("notifications/$notificationId")
+        }
+    }
+}
+```
+
+### Implicit vs Explicit Deep Links
+
+| Type | Mechanism | Use Case |
+|------|-----------|----------|
+| **Implicit** | URI-based intent filter + `navDeepLink` | External links (browser, email, other apps) |
+| **Explicit** | `PendingIntent` with `NavDeepLinkBuilder` or `TaskStackBuilder` | Notifications, widgets, shortcuts |
+
+### PendingIntent (Notifications, Widgets, Alarms)
+---
+
+#### Using NavDeepLinkBuilder (with XML nav graph)
+
+```kotlin
+fun createNotificationDeepLink(context: Context, productId: String): PendingIntent {
+    return NavDeepLinkBuilder(context)
+        .setGraph(R.navigation.nav_graph)
+        .setDestination("product/{productId}")
+        .setArguments(bundleOf("productId" to productId))
+        .setComponentName(MainActivity::class.java)
+        .createPendingIntent()
+}
+```
+
+#### Using TaskStackBuilder (Compose-only, no XML graph)
+
+```kotlin
+fun createDeepLinkPendingIntent(context: Context, itemId: String): PendingIntent {
+    val deepLinkIntent = Intent(
+        Intent.ACTION_VIEW,
+        "https://www.example.com/product/$itemId".toUri(),
+        context,
+        MainActivity::class.java,
+    )
+
+    return TaskStackBuilder.create(context).run {
+        addNextIntentWithParentStack(deepLinkIntent)
+        getPendingIntent(
+            itemId.hashCode(),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )!!
+    }
+}
+```
+
+### Key Rules for Deep Links
+---
+- Always use `FLAG_IMMUTABLE` for PendingIntents targeting Android 12+.
+- Validate and sanitize all incoming deep link parameters -- they are untrusted external input.
+- Test deep links via ADB: `adb shell am start -a android.intent.action.VIEW -d "https://www.example.com/product/123" com.example.app`.
+- For Compose Navigation, ensure deep link URI patterns match the route argument names exactly.
+- Handle the case where a deep link targets a destination that requires authentication -- redirect to login first, then forward to the original destination after auth completes.
+- For custom schemes (`myapp://`), consider migrating to App Links (`https://`) for better security and user experience.

--- a/registry/skills/google-app-development/references/compose-patterns.md
+++ b/registry/skills/google-app-development/references/compose-patterns.md
@@ -1,0 +1,608 @@
+# Jetpack Compose Patterns Reference
+
+## Composable Design
+
+### Stateless vs Stateful
+
+```kotlin
+// Stateless — receives state, emits events (preferred)
+@Composable
+fun UserCard(
+    name: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(modifier = modifier.clickable(onClick = onClick)) {
+        Text(name, style = MaterialTheme.typography.titleMedium)
+    }
+}
+
+// Stateful — owns its own state (use sparingly)
+@Composable
+fun ExpandableCard(title: String, modifier: Modifier = Modifier) {
+    var expanded by remember { mutableStateOf(false) }
+    Card(modifier = modifier.clickable { expanded = !expanded }) {
+        Text(title)
+        AnimatedVisibility(expanded) { Text("Details...") }
+    }
+}
+```
+
+Rules:
+- Prefer stateless composables — easier to test, preview, and reuse.
+- Hoist state to the caller. The composable that *creates* the state should be the one that *owns* it.
+- Accept `modifier: Modifier = Modifier` as the first optional parameter.
+
+### Slot-Based APIs
+
+```kotlin
+@Composable
+fun AppBar(
+    title: @Composable () -> Unit,
+    navigationIcon: @Composable () -> Unit = {},
+    actions: @Composable RowScope.() -> Unit = {},
+) {
+    TopAppBar(
+        title = title,
+        navigationIcon = navigationIcon,
+        actions = actions,
+    )
+}
+
+// Usage
+AppBar(
+    title = { Text("Home") },
+    navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, null) } },
+    actions = { IconButton(onClick = onSettings) { Icon(Icons.Default.Settings, null) } },
+)
+```
+
+Use `@Composable` lambda parameters (slots) instead of configuration parameters for flexible composition.
+
+
+## State Management
+
+### remember and rememberSaveable
+
+```kotlin
+// remember — survives recomposition, lost on config change
+var count by remember { mutableIntStateOf(0) }
+
+// rememberSaveable — survives config change AND process death
+var query by rememberSaveable { mutableStateOf("") }
+
+// remember with keys — recomputes when key changes
+val filtered = remember(items, query) { items.filter { it.contains(query) } }
+```
+
+### derivedStateOf
+
+```kotlin
+// Avoid recomposition when the derived value hasn't changed
+val hasItems by remember { derivedStateOf { items.isNotEmpty() } }
+
+// Good: LazyColumn recomposes only when firstVisibleItemIndex crosses threshold
+val showButton by remember {
+    derivedStateOf { listState.firstVisibleItemIndex > 0 }
+}
+```
+
+Use `derivedStateOf` when the derived value changes less often than its inputs.
+
+### snapshotFlow
+
+```kotlin
+// Convert Compose state to a Flow
+LaunchedEffect(listState) {
+    snapshotFlow { listState.firstVisibleItemIndex }
+        .distinctUntilChanged()
+        .collect { index -> analytics.trackScroll(index) }
+}
+```
+
+### State Holders
+
+```kotlin
+// For complex state logic, extract a state holder
+class SearchBarState(
+    initialQuery: String = "",
+    private val onSearch: (String) -> Unit,
+) {
+    var query by mutableStateOf(initialQuery)
+        private set
+    var active by mutableStateOf(false)
+        private set
+
+    fun updateQuery(new: String) { query = new }
+    fun submit() { onSearch(query); active = false }
+    fun activate() { active = true }
+}
+
+@Composable
+fun rememberSearchBarState(onSearch: (String) -> Unit): SearchBarState {
+    return remember { SearchBarState(onSearch = onSearch) }
+}
+```
+
+
+## Recomposition
+
+### What Triggers Recomposition
+
+- Reading a `State<T>` value that has changed.
+- Parent composable recomposing and passing new parameters.
+
+### Stability
+
+```kotlin
+// Stable — Compose can skip recomposition when equal
+data class User(val id: String, val name: String)  // data class with immutable vals = stable
+
+// Unstable — Compose must always recompose
+data class UserList(val users: MutableList<User>)   // mutable collection = unstable
+
+// Fix: use immutable collections
+data class UserList(val users: List<User>)           // List (read-only interface) = stable
+```
+
+### @Stable and @Immutable
+
+```kotlin
+// Mark types that Compose can't infer stability for
+@Stable
+interface UserRepository {
+    fun getUser(id: String): Flow<User>
+}
+
+// @Immutable — guarantees all properties will never change after construction
+@Immutable
+data class Theme(val primary: Color, val background: Color)
+```
+
+### Performance Pitfalls
+
+```kotlin
+// BAD — lambda created every recomposition, causes child to recompose
+items.forEach { item ->
+    ItemCard(onClick = { viewModel.select(item) })
+}
+
+// GOOD — stable lambda reference
+items.forEach { item ->
+    val onClick = remember(item.id) { { viewModel.select(item) } }
+    ItemCard(onClick = onClick)
+}
+
+// BAD — new list every recomposition
+val sorted = items.sortedBy { it.name }
+
+// GOOD — derived state
+val sorted by remember { derivedStateOf { items.sortedBy { it.name } } }
+```
+
+
+## Navigation
+
+### NavHost and Type-Safe Navigation
+
+```kotlin
+// Define routes as serializable classes (type-safe navigation)
+@Serializable data object Home
+@Serializable data class Profile(val userId: String)
+@Serializable data object Settings
+
+@Composable
+fun AppNavGraph(navController: NavHostController = rememberNavController()) {
+    NavHost(navController = navController, startDestination = Home) {
+        composable<Home> {
+            HomeScreen(onUserClick = { id -> navController.navigate(Profile(id)) })
+        }
+        composable<Profile> { backStackEntry ->
+            val profile: Profile = backStackEntry.toRoute()
+            ProfileScreen(userId = profile.userId)
+        }
+        composable<Settings> { SettingsScreen() }
+    }
+}
+```
+
+### Nested Graphs
+
+```kotlin
+NavHost(navController, startDestination = Home) {
+    composable<Home> { HomeScreen() }
+    navigation<AuthGraph>(startDestination = Login) {
+        composable<Login> { LoginScreen() }
+        composable<Register> { RegisterScreen() }
+    }
+}
+```
+
+### Bottom Navigation
+
+```kotlin
+@Composable
+fun MainScreen() {
+    val navController = rememberNavController()
+    Scaffold(
+        bottomBar = {
+            NavigationBar {
+                val backStackEntry by navController.currentBackStackEntryAsState()
+                val currentRoute = backStackEntry?.destination
+
+                topLevelRoutes.forEach { route ->
+                    NavigationBarItem(
+                        selected = currentRoute?.hasRoute(route.route::class) == true,
+                        onClick = {
+                            navController.navigate(route.route) {
+                                popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        },
+                        icon = { Icon(route.icon, contentDescription = route.label) },
+                        label = { Text(route.label) },
+                    )
+                }
+            }
+        },
+    ) { innerPadding ->
+        NavHost(navController, startDestination = Home, Modifier.padding(innerPadding)) { ... }
+    }
+}
+```
+
+### Deep Links
+
+```kotlin
+composable<Profile>(
+    deepLinks = listOf(navDeepLink<Profile>(basePath = "https://example.com/user")),
+) { ... }
+```
+
+
+## Side Effects
+
+| Effect | When to Use |
+|---|---|
+| `LaunchedEffect(key)` | Run suspend code when key changes; cancels on key change or leave |
+| `DisposableEffect(key)` | Set up / tear down non-suspend resources (listeners, callbacks) |
+| `SideEffect` | Publish Compose state to non-Compose code every recomposition |
+| `rememberCoroutineScope()` | Launch coroutines from event handlers (onClick, etc.) |
+| `rememberUpdatedState(value)` | Capture latest value in a long-lived effect without restarting it |
+| `produceState(initial)` | Convert non-Compose state (Flow, callback) into Compose State |
+
+```kotlin
+// LaunchedEffect — one-time load
+LaunchedEffect(userId) {
+    viewModel.loadUser(userId)
+}
+
+// DisposableEffect — register/unregister
+DisposableEffect(lifecycleOwner) {
+    val observer = LifecycleEventObserver { _, event -> ... }
+    lifecycleOwner.lifecycle.addObserver(observer)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+}
+
+// rememberUpdatedState — capture latest callback in long-running effect
+@Composable
+fun Timer(onTick: () -> Unit) {
+    val currentOnTick by rememberUpdatedState(onTick)
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(1000)
+            currentOnTick()
+        }
+    }
+}
+
+// produceState — convert Flow to State
+@Composable
+fun UserName(userId: String): State<String?> = produceState<String?>(null, userId) {
+    repository.observeUser(userId).collect { value = it.name }
+}
+```
+
+
+## Lists and Grids
+
+### LazyColumn
+
+```kotlin
+LazyColumn(
+    contentPadding = PaddingValues(16.dp),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+) {
+    // ALWAYS provide keys for stable identity
+    items(items = users, key = { it.id }) { user ->
+        UserCard(user)
+    }
+
+    // Sticky headers
+    stickyHeader { SectionHeader("Active") }
+    items(activeUsers, key = { it.id }) { UserCard(it) }
+}
+```
+
+### LazyVerticalGrid
+
+```kotlin
+LazyVerticalGrid(
+    columns = GridCells.Adaptive(minSize = 160.dp),
+    contentPadding = PaddingValues(16.dp),
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+) {
+    items(items = photos, key = { it.id }) { photo ->
+        PhotoCard(photo)
+    }
+}
+```
+
+### Pagination with Paging 3
+
+```kotlin
+@Composable
+fun UserListScreen(viewModel: UserViewModel = viewModel()) {
+    val users = viewModel.userPager.collectAsLazyPagingItems()
+
+    LazyColumn {
+        items(count = users.itemCount, key = users.itemKey { it.id }) { index ->
+            users[index]?.let { UserCard(it) }
+        }
+
+        when (users.loadState.append) {
+            is LoadState.Loading -> item { LoadingIndicator() }
+            is LoadState.Error -> item { RetryButton(onClick = { users.retry() }) }
+            else -> {}
+        }
+    }
+}
+```
+
+
+## Theming and Material 3
+
+### Custom Theme
+
+```kotlin
+private val LightColors = lightColorScheme(
+    primary = Color(0xFF6750A4),
+    secondary = Color(0xFF625B71),
+    tertiary = Color(0xFF7D5260),
+)
+
+private val DarkColors = darkColorScheme(
+    primary = Color(0xFFD0BCFF),
+    secondary = Color(0xFFCCC2DC),
+    tertiary = Color(0xFFEFB8C8),
+)
+
+@Composable
+fun AppTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit,
+) {
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            if (darkTheme) dynamicDarkColorScheme(LocalContext.current)
+            else dynamicLightColorScheme(LocalContext.current)
+        }
+        darkTheme -> DarkColors
+        else -> LightColors
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = AppTypography,
+        content = content,
+    )
+}
+```
+
+### CompositionLocal
+
+```kotlin
+// Define
+data class AppDimens(val spacing: Dp = 16.dp, val cardElevation: Dp = 4.dp)
+val LocalAppDimens = staticCompositionLocalOf { AppDimens() }
+
+// Provide
+CompositionLocalProvider(LocalAppDimens provides AppDimens(spacing = 24.dp)) {
+    content()
+}
+
+// Consume
+val spacing = LocalAppDimens.current.spacing
+```
+
+Use `CompositionLocal` sparingly — prefer explicit parameters. Good for: theme, navigation, analytics.
+
+
+## Animations
+
+```kotlin
+// animate*AsState — simple value animation
+val alpha by animateFloatAsState(if (visible) 1f else 0f, label = "alpha")
+
+// AnimatedVisibility — show/hide with transition
+AnimatedVisibility(
+    visible = expanded,
+    enter = fadeIn() + expandVertically(),
+    exit = fadeOut() + shrinkVertically(),
+) {
+    DetailsContent()
+}
+
+// AnimatedContent — animate between different content
+AnimatedContent(targetState = screen, label = "screen") { target ->
+    when (target) {
+        Screen.Home -> HomeContent()
+        Screen.Profile -> ProfileContent()
+    }
+}
+
+// Shared element transitions (Compose 1.7+)
+SharedTransitionLayout {
+    AnimatedContent(targetState = showDetail) { isDetail ->
+        if (isDetail) {
+            DetailScreen(
+                Modifier.sharedElement(
+                    rememberSharedContentState(key = "image-$id"),
+                    animatedVisibilityScope = this@AnimatedContent,
+                )
+            )
+        } else {
+            ListItem(
+                Modifier.sharedElement(
+                    rememberSharedContentState(key = "image-$id"),
+                    animatedVisibilityScope = this@AnimatedContent,
+                )
+            )
+        }
+    }
+}
+```
+
+
+## Modifiers
+
+### Ordering Matters
+
+```kotlin
+// Padding THEN background — padding is outside the background
+Box(Modifier.padding(16.dp).background(Color.Red))
+
+// Background THEN padding — padding is inside the background
+Box(Modifier.background(Color.Red).padding(16.dp))
+```
+
+### Custom Modifier (Modern Approach — Modifier.Node)
+
+```kotlin
+// Modifier.Node — preferred for performance
+fun Modifier.shimmer(): Modifier = this then ShimmerElement()
+
+private class ShimmerElement : ModifierNodeElement<ShimmerNode>() {
+    override fun create() = ShimmerNode()
+    override fun update(node: ShimmerNode) {}
+    override fun hashCode() = "shimmer".hashCode()
+    override fun equals(other: Any?) = other is ShimmerElement
+}
+
+private class ShimmerNode : DrawModifierNode, Modifier.Node() {
+    override fun ContentDrawScope.draw() {
+        drawContent()
+        // draw shimmer overlay
+    }
+}
+```
+
+
+## Dialogs, Sheets, Snackbars
+
+```kotlin
+// AlertDialog
+var showDialog by remember { mutableStateOf(false) }
+if (showDialog) {
+    AlertDialog(
+        onDismissRequest = { showDialog = false },
+        title = { Text("Delete?") },
+        text = { Text("This cannot be undone.") },
+        confirmButton = { TextButton(onClick = { onDelete(); showDialog = false }) { Text("Delete") } },
+        dismissButton = { TextButton(onClick = { showDialog = false }) { Text("Cancel") } },
+    )
+}
+
+// ModalBottomSheet
+var showSheet by remember { mutableStateOf(false) }
+if (showSheet) {
+    ModalBottomSheet(onDismissRequest = { showSheet = false }) {
+        Column(Modifier.padding(16.dp)) {
+            Text("Options", style = MaterialTheme.typography.titleLarge)
+            // sheet content
+        }
+    }
+}
+
+// Snackbar with Scaffold
+val snackbarHostState = remember { SnackbarHostState() }
+Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { padding ->
+    // To show:
+    val scope = rememberCoroutineScope()
+    Button(onClick = {
+        scope.launch {
+            val result = snackbarHostState.showSnackbar("Item deleted", actionLabel = "Undo")
+            if (result == SnackbarResult.ActionPerformed) viewModel.undo()
+        }
+    }) { Text("Delete") }
+}
+```
+
+
+## Text and Input
+
+```kotlin
+// TextField with validation
+var email by rememberSaveable { mutableStateOf("") }
+var emailError by rememberSaveable { mutableStateOf<String?>(null) }
+
+OutlinedTextField(
+    value = email,
+    onValueChange = { email = it; emailError = null },
+    label = { Text("Email") },
+    isError = emailError != null,
+    supportingText = emailError?.let { { Text(it) } },
+    keyboardOptions = KeyboardOptions(
+        keyboardType = KeyboardType.Email,
+        imeAction = ImeAction.Next,
+    ),
+    keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
+    singleLine = true,
+)
+
+// Focus management
+val focusManager = LocalFocusManager.current
+val (emailFocus, passwordFocus) = remember { FocusRequester.createRefs() }
+
+OutlinedTextField(
+    modifier = Modifier.focusRequester(emailFocus),
+    keyboardActions = KeyboardActions(onNext = { passwordFocus.requestFocus() }),
+    ...
+)
+OutlinedTextField(
+    modifier = Modifier.focusRequester(passwordFocus),
+    keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus(); submit() }),
+    ...
+)
+```
+
+
+## Performance
+
+### Rules
+
+1. **Provide keys** in `LazyColumn`/`LazyRow` — enables stable item identity.
+2. **Use `derivedStateOf`** when derived values change less often than source.
+3. **Avoid allocations in composition** — no `listOf()`, `mapOf()`, lambdas in body without `remember`.
+4. **Use `@Stable`/`@Immutable`** on classes Compose can't infer stability for.
+5. **Defer reads** — pass lambda instead of value when possible (`Modifier.offset { intOffset }` not `Modifier.offset(offset)`).
+6. **Use `Modifier.Node`** for custom modifiers instead of `Modifier.composed`.
+
+### Debugging
+
+```kotlin
+// Print recomposition count in debug builds
+@Composable
+fun DebugRecomposition(tag: String) {
+    if (BuildConfig.DEBUG) {
+        val count = remember { mutableIntStateOf(0) }
+        count.intValue++
+        Log.d("Recomposition", "$tag: ${count.intValue}")
+    }
+}
+```
+
+Use Layout Inspector in Android Studio to visualize recomposition counts and identify unnecessary recompositions.

--- a/registry/skills/google-app-development/references/concurrency.md
+++ b/registry/skills/google-app-development/references/concurrency.md
@@ -1,0 +1,929 @@
+# Android Concurrency Reference
+
+> Covers Android-specific concurrency patterns only. For coroutines fundamentals (Flow, Channels,
+> exception handling, cancellation, structured concurrency, `runTest` basics), see the
+> `kotlin-development` skill's `coroutines.md` reference.
+
+## Contents
+- viewModelScope — auto-cancellation, launching operations
+- lifecycleScope — lifecycle-aware coroutine launching
+- repeatOnLifecycle — restarting collection on lifecycle state changes
+- collectAsStateWithLifecycle — Compose lifecycle-aware collection
+- StateFlow in ViewModels — `stateIn`, `SharingStarted` strategies, combining flows
+- WorkManager — Workers, constraints, chaining, periodic work, expedited work
+- Foreground Services — types, notification requirement, starting/stopping
+- Background Limits — Doze, App Standby, background execution limits
+- AlarmManager — exact vs inexact alarms, alarms vs WorkManager
+- Testing — ViewModel testing, TestDispatcher injection, Turbine
+
+
+## viewModelScope
+
+`viewModelScope` is a `CoroutineScope` tied to the `ViewModel`. It uses `SupervisorJob() + Dispatchers.Main.immediate` and cancels automatically in `onCleared()`.
+
+```kotlin
+class OrderViewModel(
+    private val repository: OrderRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<OrderUiState>(OrderUiState.Loading)
+    val uiState: StateFlow<OrderUiState> = _uiState.asStateFlow()
+
+    fun loadOrders() {
+        viewModelScope.launch {
+            _uiState.value = OrderUiState.Loading
+            try {
+                val orders = repository.getOrders() // suspend, runs on caller dispatcher
+                _uiState.value = OrderUiState.Success(orders)
+            } catch (e: IOException) {
+                _uiState.value = OrderUiState.Error("Network error")
+            }
+        }
+    }
+
+    // Parallel decomposition inside viewModelScope
+    fun loadDashboard() {
+        viewModelScope.launch {
+            coroutineScope {
+                val orders = async { repository.getOrders() }
+                val profile = async { repository.getProfile() }
+                _uiState.value = OrderUiState.Dashboard(orders.await(), profile.await())
+            }
+        }
+    }
+}
+```
+
+Key points:
+- Uses `SupervisorJob` so one failed child does not cancel siblings.
+- Dispatches on `Main.immediate` by default; switch with `withContext(Dispatchers.IO)` for blocking calls inside the repository layer, not the ViewModel.
+- No manual cancellation needed; the scope is cancelled when the ViewModel is cleared (screen destroyed permanently).
+- Survives configuration changes (rotation, dark mode toggle) because ViewModel outlives the Activity/Fragment.
+
+
+## lifecycleScope
+
+`lifecycleScope` is available on any `LifecycleOwner` (Activity, Fragment). It cancels when the lifecycle reaches `DESTROYED`. Uses `SupervisorJob() + Dispatchers.Main.immediate`.
+
+```kotlin
+class OrderListActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // One-shot work — fine with lifecycleScope.launch
+        lifecycleScope.launch {
+            val config = fetchRemoteConfig()
+            applyConfig(config)
+        }
+    }
+}
+```
+
+### When to use lifecycleScope vs viewModelScope
+
+| Scope | Survives rotation | Tied to | Use for |
+|---|---|---|---|
+| `viewModelScope` | Yes | ViewModel clear | Data loading, business logic, state management |
+| `lifecycleScope` | No | Activity/Fragment destroy | UI operations, one-shot lifecycle work, collecting flows |
+
+Do **not** use `lifecycleScope.launch` to collect Flows directly. The coroutine stays active in the background when the UI is not visible, wasting resources and potentially updating a detached UI. Use `repeatOnLifecycle` instead.
+
+
+## repeatOnLifecycle
+
+`repeatOnLifecycle` suspends, then launches its block every time the lifecycle reaches the target state, and cancels it each time the lifecycle falls below that state. This is the correct way to collect flows in Activities and Fragments.
+
+```kotlin
+class OrderListActivity : ComponentActivity() {
+
+    private val viewModel: OrderViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                // This block runs when STARTED, cancels when STOPPED,
+                // restarts when STARTED again.
+                viewModel.uiState.collect { state ->
+                    when (state) {
+                        is OrderUiState.Loading -> showLoading()
+                        is OrderUiState.Success -> showOrders(state.orders)
+                        is OrderUiState.Error -> showError(state.message)
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+### Collecting multiple flows
+
+Launch separate coroutines inside `repeatOnLifecycle` so they collect concurrently:
+
+```kotlin
+lifecycleScope.launch {
+    repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launch { viewModel.uiState.collect { updateUi(it) } }
+        launch { viewModel.events.collect { handleEvent(it) } }
+    }
+}
+```
+
+### Why repeatOnLifecycle over launchWhenStarted
+
+`launchWhenStarted` / `launchWhenResumed` are **deprecated**. They only **suspend** the coroutine when the lifecycle drops below the target state but keep the upstream Flow active:
+- The upstream flow producer keeps emitting while the coroutine is suspended.
+- Emissions are buffered, wasting memory and CPU.
+- When the lifecycle resumes, all buffered values are delivered at once.
+
+`repeatOnLifecycle` properly **cancels** the block when the lifecycle drops below the state and **restarts** it when the lifecycle returns. No wasted work, no buffered emissions.
+
+```kotlin
+// Bad — deprecated, wastes resources
+lifecycleScope.launchWhenStarted {
+    viewModel.locationUpdates.collect { /* suspended but producer still running */ }
+}
+
+// Good — cancels collection, stops upstream work
+lifecycleScope.launch {
+    repeatOnLifecycle(Lifecycle.State.STARTED) {
+        viewModel.locationUpdates.collect { updateLocationUI(it) }
+    }
+}
+```
+
+### flowWithLifecycle — single-flow convenience
+
+```kotlin
+lifecycleScope.launch {
+    viewModel.uiState
+        .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+        .collect { updateUI(it) }
+}
+```
+
+Use `repeatOnLifecycle` when collecting multiple flows. Use `flowWithLifecycle` when collecting a single flow.
+
+
+## collectAsStateWithLifecycle
+
+The Compose equivalent of `repeatOnLifecycle`. Converts a Flow to Compose `State` while respecting the lifecycle. Stops collection when the composable's lifecycle falls below the specified state.
+
+Dependency: `androidx.lifecycle:lifecycle-runtime-compose`
+
+```kotlin
+@Composable
+fun OrderListScreen(viewModel: OrderViewModel = viewModel()) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when (val state = uiState) {
+        is OrderUiState.Loading -> LoadingIndicator()
+        is OrderUiState.Success -> OrderList(state.orders)
+        is OrderUiState.Error -> ErrorMessage(state.message)
+    }
+}
+```
+
+### Parameters
+
+```kotlin
+// Default — collects while STARTED or above
+val state by flow.collectAsStateWithLifecycle()
+
+// Custom lifecycle minimum
+val state by flow.collectAsStateWithLifecycle(
+    minActiveState = Lifecycle.State.RESUMED,
+)
+
+// With initial value for non-StateFlow sources
+val results by searchFlow.collectAsStateWithLifecycle(initialValue = emptyList())
+```
+
+Always prefer `collectAsStateWithLifecycle()` over `collectAsState()` in Android. The plain `collectAsState` does not stop collection when the app is in the background.
+
+
+## StateFlow in ViewModels
+
+### stateIn — convert cold Flow to StateFlow
+
+```kotlin
+class SearchViewModel(
+    private val repository: SearchRepository,
+) : ViewModel() {
+
+    private val query = MutableStateFlow("")
+
+    val searchResults: StateFlow<List<Result>> = query
+        .debounce(300)
+        .filter { it.length >= 2 }
+        .flatMapLatest { repository.search(it) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = emptyList(),
+        )
+
+    fun onQueryChanged(newQuery: String) {
+        query.value = newQuery
+    }
+}
+```
+
+### SharingStarted strategies
+
+| Strategy | Upstream active | Use case |
+|---|---|---|
+| `WhileSubscribed(stopTimeoutMillis)` | While subscribers exist + timeout after last unsubscribe | Most UI state (recommended default) |
+| `Eagerly` | Immediately, never stops | Data that must always be fresh (connectivity status) |
+| `Lazily` | On first subscriber, never stops | Expensive computation needed for ViewModel lifetime |
+
+`WhileSubscribed(5_000)` is the recommended default for UI state. The 5-second timeout keeps the upstream alive during configuration changes (screen rotation typically completes in under 5 seconds) but releases resources when the user navigates away.
+
+```kotlin
+// With replay expiration — reset to initialValue when upstream stops
+SharingStarted.WhileSubscribed(
+    stopTimeoutMillis = 5_000,
+    replayExpirationMillis = 0,  // reset cached value immediately on stop
+)
+```
+
+### Combining multiple flows
+
+```kotlin
+class DashboardViewModel(
+    ordersRepo: OrderRepository,
+    profileRepo: ProfileRepository,
+    notificationRepo: NotificationRepository,
+) : ViewModel() {
+
+    private val orders = ordersRepo.observeOrders()
+    private val profile = profileRepo.observeProfile()
+    private val isRefreshing = MutableStateFlow(false)
+
+    val uiState: StateFlow<DashboardUiState> = combine(
+        orders,
+        profile,
+        isRefreshing,
+    ) { orderList, userProfile, refreshing ->
+        DashboardUiState(
+            orders = orderList,
+            profile = userProfile,
+            isRefreshing = refreshing,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = DashboardUiState(),
+    )
+}
+```
+
+### Atomic state updates with MutableStateFlow.update
+
+```kotlin
+// Atomic read-modify-write — safe from concurrent coroutines
+_uiState.update { current -> current.copy(isLoading = false, items = newItems) }
+
+// Avoid direct assignment when reading previous state — race condition risk
+// Bad:
+_uiState.value = _uiState.value.copy(isLoading = false)
+// Good:
+_uiState.update { it.copy(isLoading = false) }
+```
+
+
+## WorkManager
+
+WorkManager is the recommended solution for deferrable, guaranteed background work that must survive process death and device reboots. Uses JobScheduler (API 23+) under the hood.
+
+### When to use WorkManager
+
+| Scenario | Solution |
+|---|---|
+| Deferrable background task (sync, upload, cleanup) | WorkManager |
+| Must complete even after app killed | WorkManager |
+| Immediate coroutine work tied to UI | viewModelScope |
+| User-visible ongoing operation | Foreground Service |
+| Exact time trigger | AlarmManager |
+
+### Worker types
+
+```kotlin
+// CoroutineWorker — preferred for async work
+class SyncWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        return try {
+            val repository = SyncRepository(applicationContext)
+            repository.syncAll()
+            Result.success()
+        } catch (e: Exception) {
+            if (runAttemptCount < 3) Result.retry() else Result.failure()
+        }
+    }
+}
+```
+
+### Result types
+
+| Result | Behavior |
+|---|---|
+| `Result.success()` | Work completed. Optionally pass output data via `Result.success(outputData)`. |
+| `Result.failure()` | Work failed permanently. Dependent chained work is not executed. |
+| `Result.retry()` | Retry with the configured backoff policy. |
+
+### Enqueuing work with constraints
+
+```kotlin
+val constraints = Constraints.Builder()
+    .setRequiredNetworkType(NetworkType.CONNECTED)
+    .setRequiresBatteryNotLow(true)
+    .setRequiresStorageNotLow(true)
+    .build()
+
+val syncRequest = OneTimeWorkRequestBuilder<SyncWorker>()
+    .setConstraints(constraints)
+    .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+    .setInputData(workDataOf("userId" to userId))
+    .addTag("sync")
+    .build()
+
+WorkManager.getInstance(context).enqueueUniqueWork(
+    "sync-$userId",
+    ExistingWorkPolicy.KEEP,  // KEEP, REPLACE, or APPEND
+    syncRequest,
+)
+```
+
+### Chaining work
+
+```kotlin
+WorkManager.getInstance(context)
+    .beginWith(listOf(downloadWork, fetchConfigWork))  // parallel
+    .then(processWork)                                  // sequential after both complete
+    .then(uploadWork)
+    .enqueue()
+```
+
+### Periodic work
+
+```kotlin
+val periodicSync = PeriodicWorkRequestBuilder<SyncWorker>(
+    repeatInterval = 1, TimeUnit.HOURS,
+    flexInterval = 15, TimeUnit.MINUTES,  // run within last 15 min of each hour
+)
+    .setConstraints(constraints)
+    .build()
+
+WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+    "periodic-sync",
+    ExistingPeriodicWorkPolicy.UPDATE,
+    periodicSync,
+)
+```
+
+Minimum repeat interval is 15 minutes.
+
+### Expedited work
+
+For urgent work that must start immediately (e.g., user-initiated upload, payment processing). On API 31+, uses JobScheduler expedited jobs. On older APIs, falls back to a foreground service.
+
+```kotlin
+val urgentUpload = OneTimeWorkRequestBuilder<UploadWorker>()
+    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+    .build()
+
+WorkManager.getInstance(context).enqueue(urgentUpload)
+```
+
+The Worker must override `getForegroundInfo()` to provide a notification (required for pre-API 31 fallback):
+
+```kotlin
+class UploadWorker(ctx: Context, params: WorkerParameters) : CoroutineWorker(ctx, params) {
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        val notification = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
+            .setContentTitle("Uploading...")
+            .setSmallIcon(R.drawable.ic_upload)
+            .build()
+        return ForegroundInfo(NOTIFICATION_ID, notification)
+    }
+
+    override suspend fun doWork(): Result { /* ... */ }
+}
+```
+
+### Observing work status
+
+```kotlin
+// In ViewModel — observe as Flow
+val syncStatus: Flow<WorkInfo?> = WorkManager.getInstance(context)
+    .getWorkInfoByIdFlow(syncRequest.id)
+
+// In Compose
+@Composable
+fun SyncStatusIndicator(workId: UUID) {
+    val workInfo by WorkManager.getInstance(LocalContext.current)
+        .getWorkInfoByIdFlow(workId)
+        .collectAsStateWithLifecycle(initialValue = null)
+
+    when (workInfo?.state) {
+        WorkInfo.State.RUNNING -> CircularProgressIndicator()
+        WorkInfo.State.SUCCEEDED -> Icon(Icons.Default.Check, contentDescription = "Done")
+        WorkInfo.State.FAILED -> Icon(Icons.Default.Error, contentDescription = "Failed")
+        else -> {}
+    }
+}
+```
+
+
+## Foreground Services
+
+Use a Foreground Service for long-running, user-perceptible tasks that must continue even if the user navigates away (e.g., music playback, navigation, active location tracking).
+
+### When to use
+
+| Scenario | Solution |
+|---|---|
+| Deferred, can survive process restart | WorkManager |
+| User-initiated, must complete soon | WorkManager (expedited) |
+| Long-running, user-perceptible | Foreground Service |
+| Exact timing required | AlarmManager |
+
+### Foreground Service types (API 34+)
+
+As of API 34, you must declare a specific foreground service type in `AndroidManifest.xml` and the corresponding permission:
+
+```xml
+<manifest>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+
+    <service
+        android:name=".TrackingService"
+        android:foregroundServiceType="location"
+        android:exported="false" />
+</manifest>
+```
+
+Available types: `camera`, `connectedDevice`, `dataSync`, `health`, `location`, `mediaPlayback`, `mediaProjection`, `microphone`, `phoneCall`, `remoteMessaging`, `shortService`, `specialUse`, `systemExempted`.
+
+### Implementation
+
+```kotlin
+class TrackingService : Service() {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val notification = createNotification()
+
+        // Must call startForeground within 5 seconds of service start
+        ServiceCompat.startForeground(
+            this,
+            NOTIFICATION_ID,
+            notification,
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION,
+        )
+
+        scope.launch {
+            locationProvider.locationUpdates().collect { location ->
+                updateNotification(location)
+                saveLocation(location)
+            }
+        }
+
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun createNotification(): Notification {
+        // NotificationChannel is required on API 26+
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Location Tracking",
+            NotificationManager.IMPORTANCE_LOW,
+        )
+        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Tracking location")
+            .setSmallIcon(R.drawable.ic_location)
+            .setOngoing(true)
+            .build()
+    }
+
+    companion object {
+        private const val NOTIFICATION_ID = 1
+        private const val CHANNEL_ID = "location_tracking"
+    }
+}
+```
+
+### Starting and stopping
+
+```kotlin
+// Starting from Activity, Fragment, or other component
+val intent = Intent(context, TrackingService::class.java)
+ContextCompat.startForegroundService(context, intent)
+
+// Stopping from outside
+context.stopService(Intent(context, TrackingService::class.java))
+
+// Stopping from within the service
+stopForeground(STOP_FOREGROUND_REMOVE)
+stopSelf()
+```
+
+### Restrictions
+
+**API 31+ (Android 12):** Apps cannot start foreground services from the background except in specific exemptions (high-priority FCM message, exact alarm callback, `SYSTEM_ALERT_WINDOW` permission, etc.). Use WorkManager with `setExpedited()` for background-initiated urgent work.
+
+**API 35+ (Android 15):** The `dataSync` foreground service type has a 6-hour time limit. For longer sync tasks, use WorkManager or the `mediaProcessing` type where applicable. The `shortService` type has a 3-minute limit.
+
+
+## Background Limits
+
+Android progressively restricts background work to preserve battery. Understanding these limits is essential for reliable app behavior.
+
+### Doze mode (API 23+)
+
+When the device is stationary, unplugged, and screen-off for a period, the system enters Doze mode:
+- Network access is suspended.
+- Wake locks are ignored.
+- `AlarmManager` alarms (inexact) are deferred to maintenance windows.
+- `JobScheduler` / `WorkManager` jobs are deferred.
+- `SyncAdapter` runs are deferred.
+
+Maintenance windows periodically open to allow deferred work to execute. The intervals between windows increase over time (minutes to hours).
+
+**What still works in Doze:**
+- `setExactAndAllowWhileIdle()` alarms (limited to approximately 1 per 9 minutes)
+- FCM high-priority messages (grant a short execution window)
+- Foreground Services already running
+
+### App Standby Buckets (API 28+)
+
+The system categorizes apps by recent usage into buckets that determine job and alarm frequency:
+
+| Bucket | Criteria | Job frequency |
+|---|---|---|
+| Active | Currently in use | No restrictions |
+| Working Set | Used regularly | Deferred up to 2 hours |
+| Frequent | Used often, not daily | Deferred up to 8 hours |
+| Rare | Rarely used | Deferred up to 24 hours |
+| Restricted (API 31+) | Minimal usage + high battery drain | 1 job per day, no expedited jobs, no alarms |
+
+### Background execution limits (API 26+)
+
+- Apps in the background cannot start services freely. Use `startForegroundService()` and call `startForeground()` within 5 seconds, or use WorkManager.
+- Background location access requires `ACCESS_BACKGROUND_LOCATION` permission (API 29+) and Play Store policy approval.
+- Implicit broadcast receivers registered in the manifest are restricted. Register them dynamically at runtime or use explicit broadcasts.
+
+### Practical design implications
+
+- Design for eventual execution, not exact timing, for all deferrable work.
+- Use WorkManager as the default for background processing — it handles Doze, Standby, and restart automatically.
+- Use FCM high-priority messages for time-sensitive server-driven events.
+- Test your app's behavior across buckets using `adb shell am set-standby-bucket <package> <bucket>`.
+
+
+## AlarmManager
+
+Use AlarmManager only when you need execution at an exact time regardless of app state (e.g., calendar reminders, medication alerts). For most other background work, prefer WorkManager.
+
+### Exact vs inexact alarms
+
+```kotlin
+val alarmManager = context.getSystemService<AlarmManager>()
+
+// Inexact — system batches with other alarms to save battery
+alarmManager.set(
+    AlarmManager.RTC_WAKEUP,
+    triggerTimeMillis,
+    pendingIntent,
+)
+
+// Inexact but survives Doze
+alarmManager.setAndAllowWhileIdle(
+    AlarmManager.RTC_WAKEUP,
+    triggerTimeMillis,
+    pendingIntent,
+)
+
+// Exact — requires SCHEDULE_EXACT_ALARM permission (API 31+)
+if (alarmManager.canScheduleExactAlarms()) {
+    alarmManager.setExactAndAllowWhileIdle(
+        AlarmManager.RTC_WAKEUP,
+        triggerTimeMillis,
+        pendingIntent,
+    )
+}
+```
+
+### Permissions (API 31+)
+
+```xml
+<!-- For clock, timer, and calendar apps — auto-granted, Play Store restricted -->
+<uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+
+<!-- For other exact alarms — user must grant in Settings -->
+<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+```
+
+```kotlin
+// Check and request exact alarm permission
+if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    if (!alarmManager.canScheduleExactAlarms()) {
+        startActivity(Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM))
+    }
+}
+```
+
+### Alarm receiver pattern
+
+Keep work minimal in the receiver (10-second execution limit). For longer work, delegate to WorkManager:
+
+```kotlin
+class ReminderReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val reminderId = intent.getLongExtra("reminderId", -1)
+
+        // Delegate longer work to WorkManager
+        val workRequest = OneTimeWorkRequestBuilder<ReminderNotificationWorker>()
+            .setInputData(workDataOf("reminderId" to reminderId))
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .build()
+        WorkManager.getInstance(context).enqueue(workRequest)
+    }
+}
+```
+
+### Alarms vs WorkManager
+
+| Criteria | AlarmManager | WorkManager |
+|---|---|---|
+| Exact timing | Yes | No (approximate) |
+| Survives reboot | Yes (with `RECEIVE_BOOT_COMPLETED`) | Yes (built-in) |
+| Constraints (network, battery) | No | Yes |
+| Retry / chaining | Manual | Built-in |
+| Battery-friendly | No | Yes |
+| Guaranteed execution | Time-based | Condition-based |
+
+Rules:
+- Prefer inexact alarms unless the app genuinely needs exact timing (alarms, reminders, calendar).
+- On API 31+, exact alarms require permission and user consent.
+- Alarms are cleared on device reboot — re-register in a `BOOT_COMPLETED` receiver if needed.
+- Combine AlarmManager (time trigger) with WorkManager (execution) for robust patterns.
+
+
+## Testing
+
+The `kotlin-development` skill covers `runTest`, `TestDispatcher`, and basic StateFlow testing. This section covers Android-specific testing patterns.
+
+### MainDispatcherRule — replacing Dispatchers.Main in tests
+
+`Dispatchers.Main` requires the Android main looper, unavailable in unit tests. `viewModelScope` uses `Dispatchers.Main.immediate`, so this rule is required for any ViewModel test:
+
+```kotlin
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}
+```
+
+### Testing ViewModels
+
+```kotlin
+@OptIn(ExperimentalCoroutinesApi::class)
+class OrderViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val fakeRepository = FakeOrderRepository()
+
+    @Test
+    fun `loadOrders emits success state`() = runTest {
+        val viewModel = OrderViewModel(fakeRepository)
+
+        viewModel.loadOrders()
+        advanceUntilIdle()
+
+        assertIs<OrderUiState.Success>(viewModel.uiState.value)
+    }
+
+    @Test
+    fun `loadOrders emits error on failure`() = runTest {
+        fakeRepository.shouldFail = true
+        val viewModel = OrderViewModel(fakeRepository)
+
+        viewModel.loadOrders()
+        advanceUntilIdle()
+
+        assertIs<OrderUiState.Error>(viewModel.uiState.value)
+    }
+}
+```
+
+### Dispatcher injection for full control
+
+Inject dispatchers as constructor parameters to control execution in tests:
+
+```kotlin
+// Production code
+class OrderViewModel(
+    private val repository: OrderRepository,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : ViewModel() {
+
+    fun loadOrders() {
+        viewModelScope.launch {
+            val orders = withContext(ioDispatcher) { repository.getOrders() }
+            _uiState.value = OrderUiState.Success(orders)
+        }
+    }
+}
+
+// Test
+@Test
+fun `loadOrders with injected dispatcher`() = runTest {
+    val testDispatcher = StandardTestDispatcher(testScheduler)
+    val viewModel = OrderViewModel(fakeRepository, ioDispatcher = testDispatcher)
+
+    viewModel.loadOrders()
+    advanceUntilIdle()
+
+    assertIs<OrderUiState.Success>(viewModel.uiState.value)
+}
+```
+
+### StandardTestDispatcher vs UnconfinedTestDispatcher
+
+| Dispatcher | Behavior | Use when |
+|---|---|---|
+| `StandardTestDispatcher` | Coroutines do not run until explicitly advanced (`advanceUntilIdle()`, `advanceTimeBy()`) | You need fine-grained control over execution order and timing |
+| `UnconfinedTestDispatcher` | Coroutines run eagerly on `launch` | You want simpler tests; useful for flow collectors that must start immediately |
+
+```kotlin
+// StandardTestDispatcher — need advanceUntilIdle() to execute
+@Test
+fun `with standard dispatcher`() = runTest {
+    val states = mutableListOf<OrderUiState>()
+    val job = launch(StandardTestDispatcher(testScheduler)) {
+        viewModel.uiState.toList(states)
+    }
+    viewModel.loadOrders()
+    advanceUntilIdle()  // required to execute coroutines
+    // assert states
+    job.cancel()
+}
+
+// UnconfinedTestDispatcher — collector starts immediately
+@Test
+fun `with unconfined dispatcher`() = runTest {
+    val states = mutableListOf<OrderUiState>()
+    val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+        viewModel.uiState.toList(states)
+    }
+    viewModel.loadOrders()
+    advanceUntilIdle()  // still needed if ViewModel work uses delays
+    // assert states
+    job.cancel()
+}
+```
+
+### Testing Flows with Turbine
+
+[Turbine](https://github.com/cashapp/turbine) provides a clean API for testing Flow emissions without manual collection boilerplate.
+
+```kotlin
+// testImplementation("app.cash.turbine:turbine:<version>")
+
+@Test
+fun `search emits results after debounce`() = runTest {
+    val viewModel = SearchViewModel(FakeSearchRepository())
+
+    viewModel.searchResults.test {
+        // Initial value from stateIn
+        assertEquals(emptyList<Result>(), awaitItem())
+
+        viewModel.onQueryChanged("kotlin")
+        advanceTimeBy(300)  // debounce delay
+
+        val results = awaitItem()
+        assertTrue(results.isNotEmpty())
+        assertTrue(results.all { it.title.contains("kotlin", ignoreCase = true) })
+
+        cancelAndIgnoreRemainingEvents()
+    }
+}
+```
+
+### Turbine with SharedFlow (one-shot events)
+
+```kotlin
+@Test
+fun `shows snackbar on save error`() = runTest {
+    val viewModel = EditorViewModel(FailingRepository())
+
+    viewModel.events.test {
+        viewModel.save()
+        val event = awaitItem()
+        assertIs<UiEvent.ShowSnackbar>(event)
+        assertEquals("Save failed", event.message)
+    }
+}
+```
+
+### Turbine with combined StateFlow
+
+```kotlin
+@Test
+fun `dashboard combines user and orders`() = runTest {
+    val userRepo = FakeUserRepository()
+    val orderRepo = FakeOrderRepository()
+    val viewModel = DashboardViewModel(userRepo, orderRepo, FakeNotificationRepository())
+
+    viewModel.uiState.test {
+        val initial = awaitItem()
+        assertEquals("", initial.userName)
+
+        userRepo.emitUser(User("Alice"))
+        orderRepo.emitOrders(listOf(testOrder))
+
+        val updated = expectMostRecentItem()
+        assertEquals("Alice", updated.userName)
+        assertEquals(1, updated.recentOrders.size)
+
+        cancelAndIgnoreRemainingEvents()
+    }
+}
+```
+
+### Testing WorkManager
+
+Use `TestListenableWorkerBuilder` from the `work-testing` artifact to test Workers in isolation:
+
+```kotlin
+// testImplementation("androidx.work:work-testing:<version>")
+
+@Test
+fun `SyncWorker returns success on valid data`() = runTest {
+    val worker = TestListenableWorkerBuilder<SyncWorker>(
+        context = ApplicationProvider.getApplicationContext(),
+    )
+        .setInputData(workDataOf("userId" to "123"))
+        .build()
+
+    val result = worker.doWork()
+
+    assertEquals(ListenableWorker.Result.success(), result)
+}
+
+@Test
+fun `SyncWorker retries on network error`() = runTest {
+    val worker = TestListenableWorkerBuilder<SyncWorker>(
+        context = ApplicationProvider.getApplicationContext(),
+    )
+        .setRunAttemptCount(0)
+        .build()
+
+    val result = worker.doWork()
+
+    assertEquals(ListenableWorker.Result.retry(), result)
+}
+```
+
+### Common test pitfalls
+
+| Pitfall | Fix |
+|---|---|
+| `Dispatchers.Main` unavailable in unit tests | Use `MainDispatcherRule` to replace with test dispatcher |
+| StateFlow `.value` checked before coroutine completes | Call `advanceUntilIdle()` or use Turbine's `awaitItem()` |
+| Flaky tests due to timing | Use `StandardTestDispatcher` for deterministic control |
+| `stateIn(WhileSubscribed)` not emitting in tests | Ensure a collector is active before triggering; use `UnconfinedTestDispatcher` for the collector coroutine |
+| Testing WorkManager without `work-testing` | Use `TestListenableWorkerBuilder`, not a real `WorkManager` instance |
+| `runTest` completes before child coroutines finish | Call `advanceUntilIdle()` to drain the test scheduler |
+| Turbine `awaitItem()` hangs | Ensure the flow actually emits; check that `advanceUntilIdle()` or `advanceTimeBy()` is called for time-dependent flows |

--- a/registry/skills/google-app-development/references/fire-tablet-patterns.md
+++ b/registry/skills/google-app-development/references/fire-tablet-patterns.md
@@ -1,0 +1,365 @@
+# Fire Tablet Patterns Reference
+
+This reference covers Amazon Fire Tablet-specific concerns when adapting Android apps for the Fire Tablet lineup. General Android tablet patterns (adaptive layouts, WindowSizeClass, multi-window, input support) are documented in `tablet-patterns.md` and are not repeated here. Amazon ecosystem fundamentals (IAP, ADM, missing GMS, Login with Amazon, feature detection) are documented in `fire-tv-patterns.md` and are not repeated here.
+
+
+## Overview
+
+Fire Tablets are AOSP-based Android tablets manufactured by Amazon. They run standard Android APKs but diverge from mainstream Android tablets in several ways:
+
+- **No Google Play Services** -- no GMS core, no Google Play Store, no FCM, no Google Sign-In. See `fire-tv-patterns.md` for the full missing-services table and Amazon alternatives (IAP, ADM, LWA).
+- **Amazon ecosystem** -- apps are distributed through the Amazon Appstore, purchases use Amazon IAP, and Alexa is the voice assistant.
+- **Fire OS** -- a fork of AOSP. Fire OS version determines the underlying Android API level. Fire OS 8 is based on Android 11 (API 30). Always check the [Fire OS version mapping](https://developer.amazon.com/docs/fire-tablets/fire-os-overview.html) when setting `minSdkVersion` / `targetSdkVersion`.
+- **Touch-first device** -- unlike Fire TV, Fire Tablets are touchscreen devices. Standard Android touch UIs work, but you must account for the specific screen sizes, densities, and hardware constraints of the Fire lineup.
+- **Price-driven hardware** -- Fire Tablets are budget to mid-range. Performance, RAM, and display quality vary significantly across the lineup. The Fire 7 in particular requires careful optimization.
+
+
+## Device Lineup
+
+### Hardware Comparison
+
+| Model | Display | Resolution | Density | RAM | Storage | Fire OS | API Level |
+|---|---|---|---|---|---|---|---|
+| Fire 7 (2022) | 7" IPS | 1024 x 600 | ~170 dpi (mdpi) | 2 GB | 16/32 GB | 8 | 30 (Android 11) |
+| Fire HD 8 (2022) | 8" IPS | 1280 x 800 | ~189 dpi (mdpi/hdpi) | 2 GB | 32/64 GB | 8 | 30 (Android 11) |
+| Fire HD 10 (2023) | 10.1" IPS | 1920 x 1200 | ~224 dpi (hdpi) | 3 GB | 32/64 GB | 8 | 30 (Android 11) |
+| Fire Max 11 (2023) | 11" IPS | 2000 x 1200 | ~213 dpi (hdpi) | 4 GB | 64/128 GB | 8 | 30 (Android 11) |
+
+### Performance Tiers
+
+- **Low tier** (Fire 7): Slowest SoC, 2 GB RAM, lowest resolution. Treat this as a constrained device -- reduce image cache sizes, avoid heavy animations, limit background work. The 1024x600 resolution at 7" yields ~170 dpi, which maps to `mdpi` density bucket.
+- **Mid tier** (Fire HD 8): Modest improvement over Fire 7. Still 2 GB RAM but a faster processor and higher resolution. Standard experience with moderate asset quality.
+- **High tier** (Fire HD 10, Fire Max 11): 3-4 GB RAM, faster SoCs, higher resolution displays. Full experience with richer layouts and larger assets. Fire Max 11 supports stylus input (Amazon-branded stylus).
+
+### Density Bucket Mapping
+
+Fire Tablets cluster around `mdpi` and `hdpi`. If your app only ships `xxhdpi` and `xxxhdpi` drawables (common for phone-optimized apps), resources will be downscaled at runtime, wasting memory. Ship `mdpi` and `hdpi` assets or use vector drawables to avoid this.
+
+
+## Amazon Appstore for Tablets
+
+### Publishing
+
+- Apps are submitted through the [Amazon Developer Console](https://developer.amazon.com/apps-and-games).
+- Amazon accepts signed APKs. AAB support is limited -- check current status before submitting.
+- Provide **tablet-specific screenshots** in the listing. Amazon requires separate screenshot sets for different device categories. Upload screenshots at 1920x1200 or 2000x1200 for the HD 10 and Max 11 listings.
+- Review typically takes 1-3 business days.
+
+### Device Targeting
+
+- In the Developer Console, select which Fire Tablet models your app supports.
+- To restrict your app to Fire Tablets only (excluding Fire TV), avoid declaring `amazon.hardware.fire_tv` as required and instead rely on touchscreen and screen size features:
+
+```xml
+<uses-feature android:name="android.hardware.touchscreen" android:required="true" />
+```
+
+- To detect Fire Tablet at runtime:
+
+```kotlin
+fun isFireTablet(): Boolean {
+    return Build.MANUFACTURER.equals("Amazon", ignoreCase = true) &&
+        !context.packageManager.hasSystemFeature("amazon.hardware.fire_tv")
+}
+```
+
+### Compatibility Testing
+
+- Use the **Amazon App Testing Service** (in the Developer Console) to run automated compatibility checks on real Fire Tablet hardware before submission.
+- Amazon runs its own compatibility tests during review and may reject apps that crash on targeted devices.
+
+
+## UI Adaptation
+
+### Screen Sizes and Density
+
+Fire Tablets span from 7" to 11", mapping to `COMPACT` through `EXPANDED` WindowSizeClass in portrait and landscape. Key considerations:
+
+- **Fire 7 (1024x600)**: At 7" this is roughly 600dp wide in landscape -- right at the `COMPACT` / `MEDIUM` boundary. Test both orientations carefully. In portrait, width is ~350dp (firmly `COMPACT`).
+- **Fire HD 10 and Max 11**: These hit `EXPANDED` width in landscape (~960dp+) and `MEDIUM` in portrait (~600dp+). List-detail layouts should activate in landscape.
+
+Use `WindowSizeClass` as documented in `tablet-patterns.md` rather than hardcoding Fire-specific breakpoints.
+
+### Landscape and Portrait Handling
+
+All Fire Tablets support both orientations. The default launcher orientation varies by model:
+
+- Fire 7 and Fire HD 8 default to **portrait**.
+- Fire HD 10 and Fire Max 11 default to **landscape** (wider form factor is more natural in landscape).
+
+Ensure your app handles both orientations gracefully. Do not lock orientation unless your app genuinely requires it.
+
+### Show Mode (Dock Mode)
+
+Fire HD 8 and Fire HD 10 support **Show Mode**, which transforms the tablet into an Alexa-powered smart display when docked. In Show Mode:
+
+- The device enters a simplified full-screen UI with large text and touch targets, similar to an Echo Show.
+- Third-party apps are not directly affected unless they integrate with Alexa Smart Home or Alexa routines.
+- Detect Show Mode with:
+
+```kotlin
+fun isShowMode(context: Context): Boolean {
+    return Settings.Global.getInt(
+        context.contentResolver,
+        "show_mode_active", 0
+    ) == 1
+}
+```
+
+- If your app has a "kiosk" or "display" mode, consider activating it when Show Mode is detected.
+- In Show Mode, the system UI is minimized. Avoid relying on the status bar or navigation bar being visible.
+
+### Notch and Cutout Handling
+
+Newer Fire Tablets (Fire Max 11) have a front camera cutout. Handle display cutouts using the standard Android API:
+
+```kotlin
+if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+    window.attributes.layoutInDisplayCutoutMode =
+        WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+}
+```
+
+Use `WindowInsets.displayCutout` in Compose to avoid placing interactive content under the cutout area.
+
+
+## Amazon Services Integration
+
+### Login with Amazon (LWA)
+
+See `fire-tv-patterns.md` for the core LWA API. On Fire Tablets, LWA has an additional advantage: the user's Amazon account is already linked to the device, so the sign-in flow can be streamlined. The `AuthorizationManager` will use the device account if the user consents.
+
+### Amazon Device Messaging (ADM)
+
+See `fire-tv-patterns.md` for ADM setup. ADM works identically on Fire Tablets. The one difference: Fire Tablets are more likely to be in a low-power doze state (as personal devices, they sit idle more). Test that ADM messages wake the device and display notifications correctly when the tablet is in doze mode.
+
+### Alexa on Tablet
+
+Fire Tablets have built-in Alexa accessible via the home button (long press) or "Alexa" wake word (on supported models). Unlike Fire TV:
+
+- Alexa on Fire Tablets is a general assistant, not a media-focused voice interface.
+- There is no Video Skill API integration for tablets -- that is Fire TV only.
+- You can use **Alexa for Apps** to handle deep links from Alexa into your app on tablets, similar to Fire TV.
+- The Alexa Smart Home SDK can be used if your app controls IoT devices, but this is not tablet-specific.
+
+
+## Kindle Integration
+
+### Reading and Content Apps
+
+If building reading or content apps, be aware of the Kindle ecosystem on Fire Tablets:
+
+- The Kindle app is pre-installed. Users expect reading apps to behave similarly (page-turn gestures, adjustable font sizes, dark mode).
+- **Whispersync**: Amazon's cross-device sync for bookmarks, highlights, and reading position. This is available only to Amazon's own Kindle app and is not exposed as a public API for third-party apps. If you need cross-device sync for your reading app, build it yourself (e.g., using AWS AppSync or a custom backend).
+
+### Low-End Display Considerations (Fire 7)
+
+The Fire 7's 1024x600 display at ~170 dpi is closer in pixel density to early e-readers than modern tablets:
+
+- Text rendering at small font sizes can appear blurry. Default to larger font sizes (16sp minimum body text) and ensure users can adjust text size.
+- High-frequency UI updates (animations, scrolling effects) may appear less smooth on the Fire 7's slower refresh rate. Simplify animations on this device tier.
+- Use `mdpi` assets to avoid unnecessary downscaling overhead.
+
+
+## Kids Edition and Amazon Kids+
+
+### Overview
+
+Fire Tablets are widely used as kids' devices. Amazon sells "Kids Edition" bundles and runs **Amazon Kids+** (formerly FreeTime Unlimited), a subscription service for curated kids' content.
+
+### Parental Controls and Kid Profiles
+
+- Fire Tablets support child profiles via **Amazon Kids** (built into the OS). When a child profile is active, the device runs in a restricted environment.
+- In a kid profile, apps are subject to:
+  - **No in-app purchases** -- IAP calls will fail or be blocked. Your app must handle `PurchaseResponse.RequestStatus.NOT_SUPPORTED` gracefully.
+  - **No web browsing** -- WebView access may be restricted or filtered. Apps relying on WebView for core functionality should degrade gracefully.
+  - **No social features** -- sharing, chat, and social login may be blocked by parental controls.
+  - **Content filtering** -- only parent-approved apps appear in the child's app library.
+
+### Detecting a Kid Profile
+
+There is no public API to detect whether your app is running in an Amazon Kids profile. Instead, design defensively:
+
+```kotlin
+// Attempt IAP and handle restriction gracefully
+PurchasingService.purchase("com.example.premium")
+
+// In your PurchasingListener
+override fun onPurchaseResponse(response: PurchaseResponse) {
+    when (response.requestStatus) {
+        PurchaseResponse.RequestStatus.SUCCESSFUL -> { /* deliver content */ }
+        PurchaseResponse.RequestStatus.NOT_SUPPORTED -> {
+            // Likely a restricted/kid profile -- hide purchase UI
+            hidePurchaseOptions()
+        }
+        PurchaseResponse.RequestStatus.FAILED -> { /* handle error */ }
+        else -> { /* handle other cases */ }
+    }
+}
+```
+
+### Amazon Kids+ App Integration
+
+- If your app is part of the Amazon Kids+ catalog, Amazon handles distribution and parental consent.
+- Amazon Kids+ apps must meet Amazon's content guidelines for children, including COPPA compliance.
+- Test your app within a child profile to verify it functions correctly with restricted permissions.
+
+
+## Ads and Lockscreen (Special Offers)
+
+### Ad-Supported Fire Tablets
+
+Many Fire Tablets are sold "with Special Offers" -- ad-supported models that display advertisements on the lockscreen at a reduced device price. Users can pay to remove ads.
+
+### Implications for Your App
+
+- **Lockscreen ads do not affect your app while it is running.** Special Offers ads only appear on the lockscreen and in the notification bar when the device is locked.
+- **Your app's own ads are unaffected.** If you display ads (via Amazon Mobile Ads or a third-party SDK), they function independently of Special Offers.
+- **No API to detect Special Offers vs. ad-free models.** Amazon does not expose this to third-party apps. Do not try to detect or change behavior based on the ad-supported status.
+
+### Amazon Mobile Ads SDK
+
+If displaying ads in your app on Fire Tablets, use the **Amazon Mobile Ads SDK** (Amazon Publisher Services) rather than Google AdMob, which depends on Google Play Services:
+
+```groovy
+implementation "com.amazon.android:aps-sdk:9.+"
+```
+
+AdMob mediation adapters exist for Amazon, so you can integrate Amazon ads as a mediation source if you also ship on Google Play.
+
+
+## Testing
+
+### ADB Connection
+
+Fire Tablets support ADB over USB and (on some models) over Wi-Fi:
+
+1. Enable **Developer Options**: Settings > Device Options > tap Serial Number 7 times.
+2. Enable **ADB Debugging** (USB debugging).
+3. Connect via USB cable.
+
+```bash
+adb devices
+# Verify the Fire Tablet appears
+```
+
+For wireless ADB (Fire OS 8+):
+
+```bash
+# With tablet connected via USB first
+adb tcpip 5555
+adb connect <tablet-ip>:5555
+```
+
+### Emulator Availability
+
+Amazon does not provide a dedicated Fire Tablet emulator. Use standard Android emulators configured to match Fire Tablet specs:
+
+- Create an AVD with a custom hardware profile matching Fire Tablet resolutions (e.g., 1920x1200 for HD 10, 1024x600 for Fire 7).
+- Set the density to match (189 dpi for HD 8, 224 dpi for HD 10).
+- This covers layout testing but does not cover Amazon-specific APIs (IAP, ADM). For those, test on a physical device.
+
+### Amazon App Testing Service
+
+The **Amazon App Testing Service** (accessible from the Developer Console) runs your APK on real Fire Tablet hardware in the cloud. It performs:
+
+- Installation and launch verification.
+- Screenshot capture across device models.
+- Basic crash detection and compatibility checks.
+
+Use this before submission to catch device-specific issues without owning every Fire Tablet model.
+
+### Testing Checklist for Fire Tablets
+
+- [ ] App installs and launches without Google Play Services errors.
+- [ ] Layout renders correctly on Fire 7 (1024x600) without clipping or overlap.
+- [ ] Layout adapts properly on Fire HD 10 and Max 11 in both orientations.
+- [ ] Amazon IAP flows complete (purchase, restore, subscription).
+- [ ] ADM push notifications arrive, including from doze state.
+- [ ] App handles restricted/kid profile gracefully (IAP blocked, WebView restricted).
+- [ ] Show Mode does not break the UI on supported devices.
+- [ ] Display cutout areas do not obscure interactive content (Fire Max 11).
+- [ ] Performance is acceptable on Fire 7 (scrolling, transitions, memory usage).
+- [ ] App passes Amazon Appstore submission checks.
+
+
+## Common Pitfalls
+
+### Fire 7 Performance
+
+The Fire 7 is the weakest device in the lineup. Common issues:
+
+- **Out of memory**: 2 GB total RAM, ~1-1.2 GB available to apps after system overhead. Large image caches or multiple retained Bitmaps will trigger OOM. Use `Coil` or `Glide` with strict memory cache limits.
+- **Slow rendering**: The GPU is underpowered. Avoid stacked translucent layers, complex `Canvas` drawing, and blur effects. Simplify or skip animations on this tier.
+- **1024x600 resolution**: This is below the `sw600dp` breakpoint commonly used for tablet layouts. Some apps treat this as a large phone rather than a small tablet. Test your `WindowSizeClass`-based layout decisions at this resolution.
+
+### Memory Constraints
+
+Monitor memory usage across the lineup:
+
+```bash
+adb shell dumpsys meminfo <package>
+```
+
+Set per-tier memory budgets:
+
+| Tier | Device | App Heap Target |
+|---|---|---|
+| Low | Fire 7 | < 80 MB |
+| Mid | Fire HD 8 | < 120 MB |
+| High | Fire HD 10, Max 11 | < 200 MB |
+
+### Missing Sensors
+
+Fire Tablets lack several sensors common on mainstream Android tablets:
+
+- **No GPS** (Wi-Fi-based location only via Amazon Location Service or IP geolocation).
+- **No barometer, gyroscope** (Fire 7, Fire HD 8). The Fire HD 10 and Max 11 have an accelerometer but may lack a gyroscope.
+- **No NFC, no IR blaster**.
+- **Camera** -- front camera only on most models (no rear camera on Fire 7). Check `PackageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_FRONT)`.
+
+Declare sensor features as optional in the manifest to avoid being filtered out on the Amazon Appstore:
+
+```xml
+<uses-feature android:name="android.hardware.sensor.gyroscope" android:required="false" />
+<uses-feature android:name="android.hardware.location.gps" android:required="false" />
+<uses-feature android:name="android.hardware.camera" android:required="false" />
+```
+
+### Google Play Services Feature Detection
+
+Use the same detection pattern documented in `fire-tv-patterns.md`:
+
+```kotlin
+fun isAmazonDevice(): Boolean {
+    return Build.MANUFACTURER.equals("Amazon", ignoreCase = true)
+}
+```
+
+Guard all GMS-dependent code paths. Common failures on Fire Tablets:
+
+- **Google Maps** -- use a WebView-based map (Mapbox, OpenStreetMap) or Amazon Maps API.
+- **Firebase Analytics** -- use the REST-based Firebase SDK or Amazon Pinpoint.
+- **FCM** -- use ADM (see `fire-tv-patterns.md`).
+- **Google Play Billing** -- use Amazon IAP (see `fire-tv-patterns.md`).
+
+### WebView Differences
+
+Fire Tablets ship with **Amazon WebView**, which is Chromium-based but may lag behind the Chrome version on mainstream Android:
+
+- Check `WebView.getCurrentWebViewPackage()` to determine the engine version.
+- Test JavaScript-heavy web content on a physical Fire Tablet. Some modern Web APIs (WebGL 2, newer CSS features) may behave differently or be unavailable.
+- Amazon WebView does not receive updates through the Play Store. Updates come through Fire OS system updates, which are less frequent.
+- If your app relies on Chrome Custom Tabs, note that Fire Tablets do not have Chrome installed. The system will use the Silk browser (Amazon's default browser) or fall back to a basic WebView.
+
+### Microphone and Alexa Conflict
+
+Fire Tablets use the built-in microphone for Alexa. If your app needs microphone access (e.g., voice input, audio recording):
+
+- Request `android.permission.RECORD_AUDIO` as usual.
+- Be aware that Alexa's wake word detection may be listening concurrently. This can cause contention in rare cases. Test audio recording while Alexa is active.
+- Users can disable the Alexa wake word, but your app should not assume this.
+
+### Silk Browser as Default
+
+The default browser on Fire Tablets is **Amazon Silk**, not Chrome. If your app opens URLs via `Intent.ACTION_VIEW`, they will open in Silk. Ensure any web content you link to works correctly in Silk (which is Chromium-based but may have minor rendering differences).

--- a/registry/skills/google-app-development/references/fire-tv-patterns.md
+++ b/registry/skills/google-app-development/references/fire-tv-patterns.md
@@ -1,0 +1,367 @@
+# Fire TV Patterns Reference
+
+This reference covers Amazon Fire TV-specific concerns when adapting Android TV apps. General TV patterns (focus management, D-pad navigation, media playback architecture) are documented in `tv-patterns.md` and are not repeated here.
+
+## Overview
+
+Fire TV runs on AOSP (Android Open Source Project) — not the Google-certified Android TV platform. Fire TV devices run standard Android APKs, but the runtime environment differs in important ways:
+
+- **No Google Play Services** — no GMS core, no Google Play Store, no Google APIs that depend on Play Services.
+- **Amazon ecosystem** — apps are distributed through the Amazon Appstore, purchases go through Amazon IAP, and the voice assistant is Alexa (not Google Assistant).
+- **AOSP base** — Fire OS is a fork of Android. Fire OS 5 is based on Android 5.1 (API 22), Fire OS 6 on Android 7.1 (API 25), Fire OS 7 on Android 9 (API 28), and Fire OS 8 on Android 11 (API 30). Always check the Fire OS version mapping when setting `minSdkVersion` / `targetSdkVersion`.
+- **Leanback library** — Fire TV supports `androidx.leanback` but with caveats (see Common Pitfalls).
+
+A single codebase can target both Google TV / Android TV and Fire TV with proper feature detection and build flavors.
+
+
+## Amazon Appstore
+
+### Publishing
+
+- Apps are submitted through the [Amazon Developer Console](https://developer.amazon.com/apps-and-games).
+- You upload a signed APK (or AAB converted to APK — Amazon does not natively accept AAB as of Fire OS 8).
+- The Amazon Appstore has its own review process, separate from Google Play. Expect 1-3 business days for review.
+- Fire TV apps must declare the `android.software.leanback` feature (use `android:required="false"` if the app also runs on mobile).
+
+### Device Targeting
+
+- In the Amazon Developer Console, you select which Fire TV devices your app supports.
+- Use the `amazon.hardware.fire_tv` feature in your manifest to restrict to Fire TV only:
+
+```xml
+<uses-feature android:name="amazon.hardware.fire_tv" android:required="true" />
+```
+
+### App Compatibility
+
+- Apps targeting `android.hardware.touchscreen` with `required="true"` will be filtered out on Fire TV. Set it to `false`:
+
+```xml
+<uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+```
+
+- Avoid declaring permissions or features that Fire TV cannot fulfill (e.g., telephony, camera, NFC, GPS).
+- Amazon runs automated compatibility tests during submission. You can also use the **Amazon App Testing Service** to pre-validate.
+
+
+## In-App Purchases
+
+Fire TV does not support Google Play Billing. Use the **Amazon In-App Purchasing (IAP) API** instead.
+
+### Setup
+
+Add the Amazon Appstore SDK dependency:
+
+```groovy
+implementation "com.amazon.device:amazon-appstore-sdk:3.+"
+```
+
+### Core API
+
+Amazon IAP uses two primary interfaces:
+
+- **`PurchasingService`** — static methods to initiate purchases, check user data, and query product information.
+- **`PurchasingListener`** — callback interface your app implements to receive purchase results.
+
+```kotlin
+// Register the listener (typically in Activity.onResume)
+PurchasingService.registerListener(context, myPurchasingListener)
+
+// Get user data
+PurchasingService.getUserData()
+
+// Get product data
+PurchasingService.getProductData(setOf("com.example.premium"))
+
+// Initiate a purchase
+PurchasingService.purchase("com.example.premium")
+```
+
+### PurchasingListener Callbacks
+
+```kotlin
+class MyPurchasingListener : PurchasingListener {
+    override fun onUserDataResponse(response: UserDataResponse) { /* user/marketplace info */ }
+    override fun onProductDataResponse(response: ProductDataResponse) { /* product details */ }
+    override fun onPurchaseResponse(response: PurchaseResponse) { /* purchase result + receipt */ }
+    override fun onPurchaseUpdatesResponse(response: PurchaseUpdatesResponse) { /* pending/past purchases */ }
+}
+```
+
+### Receipts and Validation
+
+- Amazon returns a `Receipt` object with a `receiptId`. Validate receipts server-side using the [Amazon Receipt Verification Service (RVS)](https://developer.amazon.com/docs/in-app-purchasing/iap-rvs-for-android-apps.html).
+- Always call `PurchasingService.notifyFulfillment()` after delivering the purchased content to avoid duplicate delivery.
+
+### Subscriptions
+
+- Amazon IAP supports subscriptions with auto-renewal.
+- Subscription management (cancel, upgrade) is handled through the Amazon Appstore app, not in your app.
+- Use `PurchasingService.getPurchaseUpdates(false)` to sync subscription state on app start.
+
+### Multi-Platform Billing Strategy
+
+Use build flavors or a billing abstraction layer:
+
+```kotlin
+interface BillingProvider {
+    fun initialize(context: Context)
+    fun queryProducts(skus: Set<String>)
+    fun purchase(sku: String)
+}
+
+// Implementations: GooglePlayBillingProvider, AmazonIapProvider
+```
+
+
+## Alexa Integration
+
+### Voice Search
+
+- Fire TV uses **Alexa** for voice, not Google Assistant. The voice remote button triggers Alexa.
+- Fire TV supports the Leanback `SearchFragment`, but voice queries come from Alexa, not the Google speech recognizer.
+- To make your content discoverable by Alexa voice search, integrate with the **Alexa Video Skill API** (catalog integration on the Amazon side) or implement a deep link handler for Alexa-initiated searches.
+
+### Video Skill API
+
+- The Video Skill API allows Alexa to search, browse, and control playback within your app.
+- This is configured on the Amazon developer portal (not purely in-app code). You provide a content catalog and implement directive handlers.
+- Directives include: `SearchAndPlay`, `SearchAndDisplayResults`, `FastForward`, `Rewind`, `Pause`, `Play`.
+
+### Alexa for Apps
+
+- **Alexa for Apps** lets Alexa deep-link into your app or trigger specific actions via custom intents.
+- Register a custom skill or use the App Links framework with Alexa.
+
+### Voice Remote Differences
+
+- Fire TV remotes send standard Android `KeyEvent` codes for D-pad and media buttons.
+- The **microphone button** on Fire TV remotes triggers Alexa system-wide — your app does not receive this key event.
+- Fire TV remotes include a dedicated **menu button** (`KEYCODE_MENU`), which Android TV remotes may not have.
+
+
+## Missing Google Play Services
+
+### What Is Unavailable
+
+| Google Service | Status on Fire TV |
+|---|---|
+| Google Play Billing | Not available — use Amazon IAP |
+| Firebase Cloud Messaging (FCM) | Not available — use Amazon Device Messaging (ADM) or Amazon SNS |
+| Google Sign-In | Not available — use Login with Amazon (LWA) |
+| Google Maps | Not available — Amazon Maps API (limited) or web-based maps |
+| Google Cast | Not available — Fire TV has its own casting protocol |
+| Google Analytics / Firebase Analytics | Partially available (REST-based Firebase works, but Play Services-dependent SDKs do not) |
+| ML Kit (on-device) | Not available — use TensorFlow Lite directly or Amazon ML services |
+
+### Alternatives
+
+#### Push Notifications
+Use **Amazon Device Messaging (ADM)**:
+
+```xml
+<uses-permission android:name="com.amazon.device.messaging.permission.RECEIVE" />
+```
+
+```kotlin
+// Register for ADM
+val adm = ADM(context)
+if (adm.registrationId == null) {
+    adm.startRegister()
+}
+```
+
+ADM is structurally similar to FCM. Server-side, you can also use **Amazon SNS** as a unified push service that fans out to both FCM and ADM.
+
+#### Authentication
+Use **Login with Amazon (LWA)** for OAuth-based sign-in:
+
+```kotlin
+AuthorizationManager.authorize(
+    AuthorizeRequest.Builder(requestContext)
+        .addScopes(ProfileScope.profile(), ProfileScope.postalCode())
+        .build()
+)
+```
+
+#### Feature Detection Pattern
+
+```kotlin
+fun hasGooglePlayServices(context: Context): Boolean {
+    return try {
+        Class.forName("com.google.android.gms.common.GoogleApiAvailability")
+        val availability = com.google.android.gms.common.GoogleApiAvailability.getInstance()
+        availability.isGooglePlayServicesAvailable(context) == com.google.android.gms.common.ConnectionResult.SUCCESS
+    } catch (e: ClassNotFoundException) {
+        false
+    }
+}
+
+fun isAmazonDevice(): Boolean {
+    return Build.MANUFACTURER.equals("Amazon", ignoreCase = true)
+}
+```
+
+
+## Media Playback
+
+### ExoPlayer on Fire TV
+
+- **ExoPlayer / Media3** works on Fire TV. It is the recommended player for streaming apps.
+- No special configuration is needed beyond what you would do for Android TV.
+- Ensure you bundle any required decoders — Fire TV does not ship Google Play Services media codecs.
+
+### DRM
+
+- Fire TV devices support **Widevine L1** (hardware-level) on most models, enabling HD and UHD DRM-protected content.
+- Check the Widevine security level at runtime:
+
+```kotlin
+val mediaDrm = MediaDrm(C.WIDEVINE_UUID)
+val securityLevel = mediaDrm.getPropertyString("securityLevel")
+// "L1" = hardware, "L3" = software
+```
+
+- PlayReady DRM is also supported on Fire TV (not available on standard Android TV).
+
+### Audio Output
+
+- Fire TV supports Dolby Atmos (via Dolby Digital Plus) on supported devices (Fire TV Stick 4K, Fire TV Cube).
+- Use `AudioManager` to query supported encodings before selecting an audio track.
+- Pass-through audio (e.g., for AV receivers) is supported — configure via `AudioAttributes` with `CONTENT_TYPE_MOVIE` and `USAGE_MEDIA`.
+
+
+## Device Capabilities
+
+### Hardware Comparison
+
+| Feature | Fire TV Stick (3rd Gen) | Fire TV Stick 4K Max | Fire TV Cube (3rd Gen) |
+|---|---|---|---|
+| Fire OS | 7 (Android 9) | 7 (Android 9) | 7 (Android 9) |
+| Processor | Quad-core 1.7 GHz | Quad-core 1.8 GHz | Octa-core 2.2 GHz |
+| RAM | 1 GB | 2 GB | 2 GB |
+| Storage | 8 GB | 16 GB | 16 GB |
+| Max Resolution | 1080p | 4K UHD, HDR10+, Dolby Vision | 4K UHD, HDR10+, Dolby Vision |
+| Dolby Atmos | No | Yes | Yes |
+| Ethernet | No (USB adapter) | No (USB adapter) | Built-in |
+| Hands-free Alexa | No | No | Yes (built-in mic array) |
+
+### Performance Tiers
+
+For a multi-device app, consider defining performance tiers:
+
+- **Low tier** (Fire TV Stick, 1 GB RAM): minimize background services, reduce image cache sizes, limit concurrent network requests, avoid complex animations.
+- **Mid tier** (Fire TV Stick 4K, 2 GB RAM): standard experience, moderate caching.
+- **High tier** (Fire TV Cube, 2 GB RAM + faster CPU): full experience, richer animations, background prefetching.
+
+### Memory and Storage Constraints
+
+- 1 GB devices have roughly 500-600 MB available to apps after system overhead. Budget your heap accordingly.
+- Internal storage is limited (8-16 GB, minus OS). Use streaming over local storage. If caching, set strict eviction policies.
+- Test with `adb shell dumpsys meminfo <package>` to monitor memory usage.
+
+
+## Web App Support
+
+### Fire TV Web Apps
+
+- Fire TV supports web apps via the **Amazon WebView** (based on Chromium).
+- You can wrap a web app in a WebView-based Android app or use the Amazon Web App Starter Kit.
+- Web apps have access to D-pad navigation if the page handles keyboard events properly.
+
+### Hybrid App Patterns
+
+- For hybrid apps (native shell + web content), use `WebView` with hardware acceleration enabled.
+- Inject a JavaScript interface to bridge between web content and native Amazon APIs (IAP, ADM):
+
+```kotlin
+webView.addJavascriptInterface(AmazonBridge(context), "AmazonBridge")
+```
+
+- Ensure the WebView content is optimized for TV: large touch targets replaced with focus-based navigation, 10-foot UI design principles.
+
+
+## Testing
+
+### Connecting via ADB
+
+Fire TV devices support ADB over the network:
+
+1. Enable **Developer Options** on the Fire TV (Settings > My Fire TV > About > click Build 7 times).
+2. Enable **ADB Debugging** and **Apps from Unknown Sources**.
+3. Find the device IP address in Settings > My Fire TV > About > Network.
+4. Connect:
+
+```bash
+adb connect <fire-tv-ip>:5555
+```
+
+### Sideloading
+
+```bash
+adb install -r myapp.apk
+```
+
+### Fire TV Emulator Limitations
+
+- There is no official Fire TV emulator from Amazon. Use the **standard Android TV emulator** (from Android SDK) for basic layout and navigation testing.
+- For Amazon-specific features (IAP, ADM, Alexa), you must test on a physical Fire TV device.
+- The **Amazon App Testing Service** (in the Developer Console) can run automated tests on real Fire TV hardware in the cloud.
+
+### Testing Checklist for Fire TV
+
+- [ ] App installs and launches without Google Play Services errors.
+- [ ] D-pad navigation works on all screens (this is shared with Android TV — see `tv-patterns.md`).
+- [ ] Amazon IAP flows complete (purchase, restore, subscription).
+- [ ] ADM push notifications are received.
+- [ ] Voice search deep links resolve correctly.
+- [ ] App does not crash on 1 GB RAM devices under memory pressure.
+- [ ] Content plays correctly with DRM (if applicable).
+- [ ] App passes Amazon Appstore submission checks.
+
+
+## Common Pitfalls
+
+### Leanback Library Differences
+
+- `BrowseSupportFragment` and `SearchSupportFragment` work on Fire TV, but the built-in voice search integration assumes Google Assistant. Override the speech recognizer or handle Alexa voice input separately.
+- `Recommendation` API (legacy Leanback notifications for the home screen) does not work on Fire TV. Fire TV uses its own content recommendation API.
+- Leanback's `DetailsFragment` renders correctly, but test thoroughly — some theme attributes may differ between Fire OS and stock Android TV.
+
+### Missing APIs and Features
+
+- **Google TV Channels / Watch Next**: not available on Fire TV. Fire TV has its own "Recent" row, populated through a different content provider.
+- **Google Assistant App Actions**: not applicable. Use Alexa Video Skill API instead.
+- **Cast Connect**: not available. Fire TV uses a proprietary casting/mirroring protocol.
+
+### Feature Detection for Multi-Platform Builds
+
+When shipping a single codebase for both Google TV and Fire TV, use build flavors combined with runtime detection:
+
+```kotlin
+// Build flavor approach (preferred for compile-time separation)
+// build.gradle
+flavorDimensions += "store"
+productFlavors {
+    create("google") { dimension = "store" }
+    create("amazon") { dimension = "store" }
+}
+
+// Runtime detection (for shared code paths)
+object TvPlatform {
+    val isFireTv: Boolean by lazy {
+        Build.MANUFACTURER.equals("Amazon", ignoreCase = true)
+    }
+
+    val isAndroidTv: Boolean by lazy {
+        !isFireTv // simplistic — refine with feature checks
+    }
+}
+```
+
+### Other Gotchas
+
+- **`PackageManager.hasSystemFeature("amazon.hardware.fire_tv")`** returns `true` only on Fire TV. Use this for definitive Fire TV detection at runtime.
+- Fire TV devices may not have Bluetooth HID profile enabled by default — game controller support requires explicit testing.
+- Fire OS updates lag behind AOSP releases. Do not assume the latest Android APIs are available; always check Fire OS version mappings.
+- The Fire TV home screen launcher is Amazon-controlled. You cannot replace it or deeply customize home screen presence the way you might with Android TV's home screen channels.

--- a/registry/skills/google-app-development/references/java-interop.md
+++ b/registry/skills/google-app-development/references/java-interop.md
@@ -1,0 +1,485 @@
+# Java-Kotlin Interop Reference
+
+> This reference focuses on practical Java-Kotlin interoperability in Android projects.
+> For Kotlin language fundamentals, see the `kotlin-development` skill.
+> **Always prefer Kotlin for new code.**
+
+
+## Calling Java from Kotlin
+
+### Platform Types
+---
+When Kotlin calls Java code, the return types become **platform types** (shown as `Type!` in IDE tooltips). The Kotlin compiler does not enforce nullability on these types, which means you lose null-safety guarantees at the boundary.
+
+```kotlin
+// Java method: String getName() — no nullability annotation
+val name = javaObject.name // inferred as String! (platform type)
+
+// DANGER: this compiles but crashes at runtime if getName() returns null
+val length = javaObject.name.length
+```
+
+#### Best practices
+- Assign platform types to explicitly typed variables immediately:
+  ```kotlin
+  val name: String? = javaObject.name // safe
+  ```
+- Treat every un-annotated Java return value as nullable until proven otherwise.
+- Add `@NonNull` / `@Nullable` annotations to Java code you own.
+
+### Handling Nullability from Java
+---
+```kotlin
+// Safe patterns when consuming Java APIs
+val result: String = javaObject.name ?: "default"
+val length: Int = javaObject.name?.length ?: 0
+```
+
+
+## Calling Kotlin from Java
+
+### @JvmStatic
+---
+Makes a companion object function or property accessible as a real Java static member.
+
+```kotlin
+class Analytics {
+    companion object {
+        @JvmStatic
+        fun track(event: String) { /* ... */ }
+    }
+}
+```
+```java
+// Without @JvmStatic: Analytics.Companion.track("click");
+// With @JvmStatic:    Analytics.track("click");
+```
+
+### @JvmField
+---
+Exposes a Kotlin property as a plain Java field (no getter/setter generated).
+
+```kotlin
+class Config {
+    @JvmField
+    val MAX_RETRIES = 3
+}
+```
+```java
+int retries = config.MAX_RETRIES; // direct field access
+```
+
+Use `@JvmField` on `companion object` constants and public properties consumed from Java. For compile-time constants, prefer `const val` inside a `companion object`.
+
+### @JvmOverloads
+---
+Generates overloaded Java methods for Kotlin functions with default parameters.
+
+```kotlin
+class CustomView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr)
+```
+
+Without this annotation, Java callers must provide every argument. This is critical for custom Android views, which require specific constructor overloads for inflation.
+
+### @JvmName
+---
+Changes the JVM name of a generated method or file facade. Useful for resolving signature clashes.
+
+```kotlin
+@get:JvmName("isActive")
+val active: Boolean = true
+
+// Resolves clashes between type-erased signatures
+@JvmName("filterStrings")
+fun filter(list: List<String>): List<String> = TODO()
+
+@JvmName("filterInts")
+fun filter(list: List<Int>): List<Int> = TODO()
+```
+
+
+## SAM Conversions
+
+### Java Functional Interfaces in Kotlin
+---
+Kotlin automatically converts lambdas to Java single-abstract-method (SAM) interfaces.
+
+```kotlin
+// Java interface: interface OnClickListener { void onClick(View v); }
+button.setOnClickListener { view ->
+    // lambda body
+}
+```
+
+### Kotlin fun interface
+---
+For SAM conversion to work with Kotlin-defined interfaces, declare them with `fun interface`.
+
+```kotlin
+fun interface EventHandler {
+    fun handle(event: AppEvent)
+}
+
+// Callers can use a lambda
+val handler = EventHandler { event -> log(event) }
+```
+
+Without `fun`, Kotlin interfaces require explicit `object :` syntax. Prefer `fun interface` over `typealias` for function types that carry semantic meaning.
+
+
+## Nullability Annotations
+
+### Recognized Annotations
+---
+Kotlin recognizes nullability annotations from multiple packages. In Android projects, prefer AndroidX annotations.
+
+| Annotation Source | Package | Notes |
+|---|---|---|
+| AndroidX | `androidx.annotation` | Preferred for Android code |
+| JetBrains | `org.jetbrains.annotations` | Preferred for pure Kotlin/JVM libraries |
+| JSR-305 | `javax.annotation` | Widely supported, legacy |
+
+### Applying Annotations in Java Code
+---
+```java
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class UserRepository {
+    @NonNull
+    public String getDisplayName() { return "Guest"; }
+
+    @Nullable
+    public String getEmail() { return null; }
+}
+```
+
+Kotlin then infers correct types automatically:
+```kotlin
+val displayName: String = repo.displayName   // String (non-null)
+val email: String? = repo.email              // String? (nullable)
+```
+
+### Package-Level Defaults
+---
+Use `@ParametersAreNonnullByDefault` (JSR-305) or AndroidX `@NonNull` at the package level via `package-info.java` to reduce annotation noise:
+
+```java
+@ParametersAreNonnullByDefault
+package com.example.data;
+```
+
+
+## Collection Interop
+
+### Mutable vs Immutable at the Boundary
+---
+Kotlin distinguishes `List` (read-only) from `MutableList`, but both map to `java.util.List` on the JVM. Java code receiving a Kotlin `List` can still mutate it at runtime.
+
+```kotlin
+// Kotlin side
+fun getItems(): List<String> = listOf("a", "b")
+
+// Java side — compiles and mutates the underlying list
+List<String> items = getItems();
+items.add("c"); // UnsupportedOperationException at runtime for listOf()
+```
+
+### Defensive Copying
+---
+When passing collections across the boundary, copy defensively:
+
+```kotlin
+// Kotlin receiving from Java — wrap to be safe
+val safeList: List<Item> = ArrayList(javaObject.items)
+
+// Kotlin exposing to Java — return a copy
+fun getItems(): MutableList<Item> = items.toMutableList()
+```
+
+When Java code must receive a mutable collection, return `toMutableList()` or `toMutableMap()` explicitly rather than exposing internal state.
+
+
+## Type Mapping
+
+### Primitives
+---
+| Kotlin Type | JVM / Java Type | Notes |
+|---|---|---|
+| `Int` | `int` / `Integer` | Nullable `Int?` boxes to `Integer` |
+| `Long` | `long` / `Long` | Same boxing rule |
+| `Boolean` | `boolean` / `Boolean` | Same boxing rule |
+| `Double` | `double` / `Double` | Same boxing rule |
+
+Kotlin uses primitives when possible; nullable types and generics force boxing.
+
+### Arrays
+---
+| Kotlin | Java |
+|---|---|
+| `IntArray` | `int[]` |
+| `Array<Int>` | `Integer[]` |
+| `ByteArray` | `byte[]` |
+
+Prefer `IntArray`, `LongArray`, etc. over `Array<Int>` for performance-critical code and JNI interop.
+
+### Unit vs void
+---
+- Kotlin `Unit` maps to `void` in generated bytecode for regular functions.
+- When `Unit` is used as a generic type argument (e.g., `Continuation<Unit>`), it becomes `kotlin.Unit` on the JVM.
+
+```java
+// Calling a Kotlin function that returns Unit from Java
+kotlinObject.doWork(); // works fine, void return
+
+// When Unit is a type parameter
+Function1<String, Unit> callback = s -> {
+    System.out.println(s);
+    return Unit.INSTANCE; // required
+};
+```
+
+
+## Coroutines and Java
+
+### Calling Suspend Functions from Java
+---
+Suspend functions compile to methods with an extra `Continuation` parameter. Calling them directly from Java is impractical. Instead, expose a bridge.
+
+```kotlin
+// Kotlin bridge for Java callers
+object UserApi {
+    // Suspend function (Kotlin callers)
+    suspend fun getUser(id: String): User = repository.fetchUser(id)
+
+    // Bridge for Java callers
+    @JvmStatic
+    fun getUserAsync(id: String): ListenableFuture<User> {
+        return GlobalScope.future { getUser(id) }
+    }
+}
+```
+
+With `kotlinx-coroutines-jdk8`, use `future {}` to return `CompletableFuture`:
+
+```kotlin
+@JvmStatic
+fun getUserAsync(id: String): CompletableFuture<User> =
+    GlobalScope.future { getUser(id) }
+```
+
+### Wrapping Java Callbacks as Coroutines
+---
+Use `suspendCancellableCoroutine` to convert callback-based Java APIs into suspend functions.
+
+```kotlin
+suspend fun fetchLocation(): Location = suspendCancellableCoroutine { cont ->
+    val callback = object : LocationCallback() {
+        override fun onLocationResult(result: LocationResult) {
+            cont.resume(result.lastLocation)
+        }
+
+        override fun onError(error: Exception) {
+            cont.resumeWithException(error)
+        }
+    }
+
+    locationClient.requestLocation(callback)
+
+    cont.invokeOnCancellation {
+        locationClient.removeCallback(callback)
+    }
+}
+```
+
+### Wrapping Callbacks as Flows
+---
+For streaming callbacks, use `callbackFlow`:
+
+```kotlin
+fun locationUpdates(): Flow<Location> = callbackFlow {
+    val callback = object : LocationCallback() {
+        override fun onLocationResult(result: LocationResult) {
+            trySend(result.lastLocation)
+        }
+    }
+    locationClient.requestUpdates(callback)
+    awaitClose { locationClient.removeCallback(callback) }
+}
+```
+
+
+## Migration Strategy
+
+### Recommended Priorities
+---
+1. **Data classes and models** — straightforward conversion, immediate benefits from `equals`/`hashCode`/`copy`.
+2. **Utility classes** — static methods become top-level or extension functions.
+3. **New features** — always write in Kotlin.
+4. **Tests** — convert test classes to Kotlin for readability.
+5. **Activities/Fragments** — convert last; highest risk due to lifecycle complexity.
+
+### File-by-File Approach
+---
+- Convert one file at a time and run tests after each conversion.
+- Start with leaf files (no dependents) and work inward.
+- Keep both `.java` and `.kt` files compiling together during migration; Gradle handles mixed compilation.
+
+### Android Studio Converter Pitfalls
+---
+The built-in "Convert Java File to Kotlin File" tool (`Ctrl+Alt+Shift+K` / `Cmd+Alt+Shift+K`) produces a starting point, but expect to fix:
+
+| Issue | What Happens | Fix |
+|---|---|---|
+| Platform types | Converter guesses `String!` as `String` (non-null) | Audit every type; add `?` where null is possible |
+| Force unwraps | Generates `!!` liberally | Replace with safe calls, defaults, or `require` |
+| Static members | Puts everything in `companion object` without `@JvmStatic` | Add `@JvmStatic` if Java callers remain |
+| Property access | Converts `getFoo()` to `foo` but may break overrides | Check overridden methods carefully |
+| SAM conversions | May leave verbose `object :` syntax | Simplify to lambdas |
+| Nullability | Ignores missing annotations | Add null checks for platform-type values |
+
+Always review the diff after conversion rather than blindly committing.
+
+
+## Mixed Codebase Patterns
+
+### Wrapping Java Builders
+---
+Java builders are verbose in Kotlin. Wrap them with a DSL-style extension:
+
+```kotlin
+// Java builder: AlertDialog.Builder(context).setTitle(...).setMessage(...).create()
+
+inline fun Context.alertDialog(block: AlertDialog.Builder.() -> Unit): AlertDialog =
+    AlertDialog.Builder(this).apply(block).create()
+
+// Usage
+alertDialog {
+    setTitle("Confirm")
+    setMessage("Delete item?")
+    setPositiveButton("OK") { _, _ -> delete() }
+}
+```
+
+### Extension Functions for Java Classes
+---
+Add Kotlin-idiomatic APIs to Java classes you cannot modify:
+
+```kotlin
+fun SharedPreferences.edit(block: SharedPreferences.Editor.() -> Unit) {
+    val editor = edit()
+    editor.block()
+    editor.apply()
+}
+
+// Usage
+prefs.edit {
+    putString("key", "value")
+    putBoolean("onboarded", true)
+}
+```
+
+### Adapting Listeners to Flows
+---
+Convert Java listener patterns into reactive Kotlin Flows:
+
+```kotlin
+fun EditText.textChanges(): Flow<CharSequence> = callbackFlow {
+    val watcher = object : TextWatcher {
+        override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
+        override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
+            trySend(s)
+        }
+        override fun afterTextChanged(s: Editable) {}
+    }
+    addTextChangedListener(watcher)
+    awaitClose { removeTextChangedListener(watcher) }
+}
+
+// Usage in a ViewModel
+editText.textChanges()
+    .debounce(300)
+    .distinctUntilChanged()
+    .collectLatest { query -> search(query.toString()) }
+```
+
+
+## Common Pitfalls
+
+### Platform Type Crashes
+---
+The most frequent interop bug. A Java method returns `null`, Kotlin assumes non-null, and the app crashes with `NullPointerException` — not at the call site, but at first usage.
+
+```kotlin
+// DANGEROUS
+val name: String = javaObject.name // crashes here if null
+
+// SAFE
+val name: String = javaObject.name ?: "Unknown"
+```
+
+### Static Access
+---
+Kotlin has no `static` keyword. Without proper annotations, Java callers face awkward access patterns:
+
+```kotlin
+// Without annotations
+class Constants {
+    companion object {
+        val TAG = "MyApp"            // Java: Constants.Companion.getTAG()
+    }
+}
+
+// With annotations
+class Constants {
+    companion object {
+        @JvmField val TAG = "MyApp"  // Java: Constants.TAG
+        const val MAX = 100           // Java: Constants.MAX (compile-time constant)
+    }
+}
+```
+
+### Checked Exceptions
+---
+Kotlin does not have checked exceptions. Java callers of Kotlin functions that throw will not be warned by the compiler.
+
+```kotlin
+// Kotlin — no checked exception declaration
+fun parse(json: String): Data {
+    throw IOException("bad data")
+}
+
+// Java — compiles without try/catch, crashes at runtime
+Data data = parse(jsonString); // IOException is unchecked from Java's perspective
+```
+
+Fix with `@Throws`:
+```kotlin
+@Throws(IOException::class)
+fun parse(json: String): Data { /* ... */ }
+```
+
+### Property Name Conflicts
+---
+Kotlin generates getters/setters for properties. If a Java subclass already has a method like `getType()`, and you declare a Kotlin property `type`, you get a compilation error due to conflicting JVM signatures.
+
+```kotlin
+// Conflicts with inherited Java method getType()
+// val type: String  // won't compile
+
+// Fix: rename the property or use @JvmName
+@get:JvmName("getItemType")
+val type: String = "default"
+```
+
+### Internal Visibility
+---
+Kotlin `internal` compiles to `public` on the JVM with a mangled name. Java code can still call internal members (with ugly names). Do not rely on `internal` for security at the interop boundary.
+
+### Companion Object Overhead
+---
+Each `companion object` creates a separate class (`MyClass$Companion`). In performance-critical paths, prefer top-level functions and `const val` over companion objects.

--- a/registry/skills/google-app-development/references/meta-quest-patterns.md
+++ b/registry/skills/google-app-development/references/meta-quest-patterns.md
@@ -1,0 +1,696 @@
+# Meta Quest Patterns Reference
+
+Adapting Android APK apps to run on Meta Quest headsets.
+
+>[toc]
+
+
+## Overview
+
+Meta Quest headsets run a modified Android OS (based on AOSP). Standard Android APKs can run on Quest in a "2D panel" mode, but delivering a proper experience requires adapting for VR/MR interaction models.
+
+Key differences from standard Android:
+- **No touchscreen** — input comes from controllers, hand tracking, or gaze.
+- **No Google Play Services** — no GMS, no Google Sign-In, no Google Maps, no Firebase Cloud Messaging via GMS.
+- **Stereo rendering** — the system renders two eye buffers; performance budgets are tighter.
+- **Fixed display** — no portrait/landscape switching; the headset has a fixed resolution and refresh rate.
+- **Different distribution** — apps ship through Meta Quest Store, App Lab, or sideloading, not Google Play.
+- **Spatial context** — apps can use passthrough, spatial anchors, and scene understanding for mixed reality.
+
+A standard Android APK will run in a flat 2D panel inside the Quest environment without modification. To unlock VR/MR features, you integrate the Meta XR SDK and declare VR intent categories.
+
+
+## Project Setup
+
+### Meta XR SDK
+---
+Meta provides the Meta XR SDK (formerly Oculus SDK) as Android AAR libraries. For pure Android (non-Unity, non-Unreal) apps, use the **Meta Spatial SDK** or the **Platform SDK** depending on your needs.
+
+Add the Meta Maven repository and dependencies in your module-level `build.gradle.kts`:
+
+```kotlin
+// settings.gradle.kts
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        maven { url = uri("https://maven.oculus.com/repository/maven-releases/") }
+    }
+}
+```
+
+```kotlin
+// app/build.gradle.kts
+android {
+    defaultConfig {
+        minSdk = 29 // Quest 2 minimum; Quest 3 supports 29+
+        targetSdk = 32
+    }
+
+    buildTypes {
+        // Quest-specific build variant
+        create("quest") {
+            initWith(getByName("release"))
+            buildConfigField("boolean", "IS_QUEST_BUILD", "true")
+            manifestPlaceholders["vrCategory"] = "com.oculus.intent.category.VR"
+        }
+    }
+}
+
+dependencies {
+    implementation("com.meta.spatial:spatial-sdk:0.5.0")
+    implementation("com.meta.platform:platform-sdk:67.0.0")
+}
+```
+
+### Manifest Configuration
+
+Declare VR intent category and Quest-specific metadata in `AndroidManifest.xml`:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Required for Quest store submission -->
+    <uses-feature android:name="android.hardware.vr.headtracking"
+        android:required="true"
+        android:version="1" />
+
+    <!-- Declare supported controllers -->
+    <uses-feature android:name="oculus.software.handtracking"
+        android:required="false" />
+
+    <application
+        android:allowBackup="false"
+        android:label="@string/app_name">
+
+        <!-- Mark app as VR app -->
+        <meta-data
+            android:name="com.oculus.vr.focusaware"
+            android:value="true" />
+
+        <!-- Supported Quest devices -->
+        <meta-data
+            android:name="com.oculus.supportedDevices"
+            android:value="quest2|questpro|quest3" />
+
+        <activity
+            android:name=".MainActivity"
+            android:configChanges="density|keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|uiMode"
+            android:screenOrientation="landscape"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+                <!-- VR category: required for native VR mode -->
+                <category android:name="com.oculus.intent.category.VR" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>
+```
+
+Without `com.oculus.intent.category.VR`, the app runs in 2D panel mode (a flat window in the Quest home environment). Adding this category launches the app in immersive VR mode.
+
+### Build Variants Strategy
+
+For apps that target both phones and Quest, use build variants:
+
+```kotlin
+// app/build.gradle.kts
+android {
+    flavorDimensions += "platform"
+    productFlavors {
+        create("mobile") {
+            dimension = "platform"
+            buildConfigField("boolean", "IS_QUEST", "false")
+        }
+        create("quest") {
+            dimension = "platform"
+            buildConfigField("boolean", "IS_QUEST", "true")
+            minSdk = 29
+        }
+    }
+}
+```
+
+This lets you conditionally include Quest-specific code and dependencies while sharing the core business logic.
+
+
+## Authentication and Entitlement
+
+### Meta Platform SDK
+---
+Quest does not have Google Play Services. Authentication uses Meta accounts, and entitlement verification uses the Meta Platform SDK.
+
+#### Entitlement Check
+
+Every Quest app distributed through the Meta Quest Store must verify the user is entitled to run it. This prevents piracy and validates the purchase.
+
+```kotlin
+import com.oculus.platform.Platform
+import com.oculus.platform.models.Entitlements
+
+class QuestAuthManager(private val activity: Activity) {
+
+    private val appId = "YOUR_META_APP_ID" // from Meta Developer Dashboard
+
+    fun initialize() {
+        // Initialize Platform SDK — must be called before any other Platform calls
+        Platform.initializeAndroidAsync(activity, appId)
+            .setOnCompleteListener { message ->
+                if (message.isError) {
+                    Log.e("QuestAuth", "Platform init failed: ${message.error}")
+                    handleEntitlementFailure()
+                    return@setOnCompleteListener
+                }
+                checkEntitlement()
+            }
+    }
+
+    private fun checkEntitlement() {
+        Entitlements.isViewerEntitled()
+            .setOnCompleteListener { message ->
+                if (message.isError) {
+                    Log.e("QuestAuth", "User is NOT entitled")
+                    handleEntitlementFailure()
+                } else {
+                    Log.i("QuestAuth", "User is entitled, proceeding")
+                    onEntitlementVerified()
+                }
+            }
+    }
+
+    private fun handleEntitlementFailure() {
+        // Required: quit the app if entitlement check fails
+        // Meta rejects apps that continue running without entitlement
+        activity.finish()
+    }
+
+    private fun onEntitlementVerified() {
+        // Proceed with app logic
+    }
+}
+```
+
+#### Differences from Google Play Auth
+
+| Aspect | Google Play | Meta Quest |
+|--------|-------------|------------|
+| Account system | Google Account | Meta Account |
+| Auth library | Google Sign-In / Credential Manager | Meta Platform SDK |
+| Entitlement check | Google Play Licensing | `Entitlements.isViewerEntitled()` |
+| In-app purchases | Google Play Billing | Meta Platform IAP SDK |
+| User identity | Google ID token | Oculus User ID |
+
+If your app uses Firebase Auth with Google Sign-In on mobile, you need an alternative auth flow for Quest — typically a device code flow, email/password, or a companion app approach where the user authenticates on their phone and links the session.
+
+
+## Spatial UI
+
+### Adapting 2D Layouts for VR
+---
+When running in 2D panel mode, standard Android Views and Jetpack Compose UI render on a flat panel in VR space. This works but has limitations:
+
+- **Text readability** — use minimum 24sp font size; small text is hard to read in VR.
+- **Touch targets** — make interactive elements at least 56dp; precision is lower with controller raycasting.
+- **Contrast** — use high-contrast colors; VR displays have different characteristics than phone screens.
+- **Layout width** — panels have a fixed width in VR space; avoid layouts that assume phone-width screens.
+
+#### Panel-Based UI
+
+For native VR mode, Meta Spatial SDK supports panel-based UI where Android Views/Compose are rendered onto panels positioned in 3D space:
+
+```kotlin
+import com.meta.spatial.core.Panel
+import com.meta.spatial.core.PanelConfig
+
+class MainPanelActivity : PanelActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Create a panel with specific dimensions (in meters)
+        val panelConfig = PanelConfig(
+            width = 1.5f,  // 1.5 meters wide
+            height = 1.0f, // 1 meter tall
+            dpi = 320,
+            layoutResource = R.layout.activity_main
+        )
+
+        createPanel(panelConfig)
+    }
+}
+```
+
+#### Jetpack Compose on Quest
+
+Jetpack Compose works on Quest in 2D panel mode since Quest runs Android. For native VR panels, Compose support depends on the Meta Spatial SDK version — check current documentation. The general approach:
+
+```kotlin
+// Compose UI rendered onto a VR panel
+@Composable
+fun QuestDashboard() {
+    MaterialTheme(
+        colorScheme = darkColorScheme() // Dark themes work better in VR
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(32.dp) // Extra padding for VR readability
+        ) {
+            Text(
+                text = "Dashboard",
+                style = MaterialTheme.typography.headlineLarge,
+                fontSize = 28.sp // Larger fonts for VR
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            // Use large, well-spaced interactive elements
+            Button(
+                onClick = { /* action */ },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(64.dp)
+            ) {
+                Text("Action", fontSize = 20.sp)
+            }
+        }
+    }
+}
+```
+
+#### Recommended UI Patterns for VR
+
+- Place primary panels at a comfortable distance (1.5–3 meters from the user).
+- Avoid UI elements at the periphery of the field of view.
+- Use curved panels for wide layouts to maintain readability at edges.
+- Provide visual feedback on hover (controller raycast) before click.
+- Avoid rapid panel transitions; use crossfades instead of slide animations.
+
+
+## Input and Interaction
+
+### Replacing Touch Events
+---
+Quest input comes from three sources: controllers, hand tracking, and gaze. The Meta Interaction SDK abstracts these into a unified interaction model.
+
+#### Controller Input
+
+Controllers provide button presses, trigger pulls, thumbstick input, and 6DoF pose:
+
+```kotlin
+import com.meta.spatial.core.Input
+import com.meta.spatial.core.InputAction
+
+class InputHandler {
+
+    fun processInput(input: Input) {
+        // Trigger press (equivalent to tap/click)
+        if (input.isActionPressed(InputAction.TRIGGER)) {
+            onSelect()
+        }
+
+        // Grip button (often used for grab interactions)
+        if (input.isActionPressed(InputAction.GRIP)) {
+            onGrab()
+        }
+
+        // Thumbstick for scrolling (replaces swipe gestures)
+        val thumbstick = input.getThumbstickValue()
+        if (thumbstick.y != 0f) {
+            onScroll(thumbstick.y)
+        }
+
+        // Menu button
+        if (input.isActionPressed(InputAction.MENU)) {
+            onMenuToggle()
+        }
+    }
+}
+```
+
+#### Hand Tracking
+
+Hand tracking replaces touch input with pinch and poke gestures:
+
+```kotlin
+// Manifest: declare hand tracking support
+// <uses-feature android:name="oculus.software.handtracking" android:required="false" />
+
+class HandTrackingHandler {
+
+    fun onPinchDetected(hand: Hand) {
+        // Pinch = select/click equivalent
+        // The system provides a raycast from the pinch point
+        performAction(hand.pinchRayOrigin, hand.pinchRayDirection)
+    }
+
+    fun onPokeDetected(hand: Hand, target: Panel) {
+        // Direct touch on a nearby panel
+        // Poke maps to View touch events automatically for 2D panels
+        target.dispatchTouchEvent(hand.pokePosition)
+    }
+}
+```
+
+#### Mapping Touch Events to VR Input
+
+| Touch Event | Quest Equivalent |
+|-------------|-----------------|
+| `onClick` | Controller trigger press / hand pinch |
+| `onLongClick` | Sustained trigger hold / sustained pinch |
+| `onScroll` / `onFling` | Thumbstick Y-axis / hand swipe |
+| `onSwipe` (horizontal) | Thumbstick X-axis |
+| `pinch-to-zoom` | Two-controller distance change |
+| `onDrag` | Grip hold + move controller |
+
+For 2D panel apps, the system automatically maps controller raycast + trigger to touch events, so `OnClickListener` and similar still work. Hand tracking poke gestures also map to touch events on nearby panels.
+
+
+## Rendering and Performance
+
+### Frame Rate and Performance Budgets
+---
+Quest headsets require consistent frame rates to avoid discomfort:
+
+| Device | Supported Refresh Rates | Frame Budget |
+|--------|------------------------|--------------|
+| Quest 2 | 72Hz, 90Hz, 120Hz | 13.9ms / 11.1ms / 8.3ms |
+| Quest Pro | 72Hz, 90Hz | 13.9ms / 11.1ms |
+| Quest 3 | 72Hz, 90Hz, 120Hz | 13.9ms / 11.1ms / 8.3ms |
+
+Dropped frames cause judder and motion sickness. For adapted Android apps, 72Hz is the safest target.
+
+#### Fixed Foveated Rendering (FFR)
+
+FFR reduces GPU workload by rendering peripheral areas at lower resolution. Enable it to stay within frame budgets:
+
+```kotlin
+import com.meta.spatial.core.Renderer
+
+class RenderConfig {
+
+    fun configureRendering(renderer: Renderer) {
+        // Set refresh rate
+        renderer.setRefreshRate(72f) // Start conservative
+
+        // Enable fixed foveated rendering
+        // Levels: OFF, LOW, MEDIUM, HIGH, HIGH_TOP
+        renderer.setFoveationLevel(FoveationLevel.HIGH)
+
+        // Quest 3 supports dynamic foveation tied to eye tracking
+        if (renderer.supportsDynamicFoveation()) {
+            renderer.setDynamicFoveation(true)
+        }
+    }
+}
+```
+
+#### GPU and Battery Optimization
+
+- **Minimize overdraw** — flat UI panels have less concern here, but complex 3D scenes do.
+- **Use texture compression** — ASTC is the preferred format on Quest (Adreno GPU).
+- **Reduce draw calls** — batch where possible; Quest GPUs are mobile-class (Snapdragon XR2).
+- **Thermal throttling** — Quest throttles CPU/GPU when hot; design for sustained performance, not peak. Test with extended play sessions (30+ minutes).
+- **Battery** — Quest 2 has roughly 2–3 hours of battery. Avoid unnecessary background work; release resources when the headset enters standby.
+
+```kotlin
+// Respond to focus changes (headset on/off, guardian boundary)
+override fun onVisibilityChanged(visible: Boolean) {
+    if (!visible) {
+        // User removed headset or hit guardian boundary
+        pauseRendering()
+        reduceBackgroundWork()
+    } else {
+        resumeRendering()
+    }
+}
+```
+
+
+## Passthrough and Mixed Reality
+
+### Passthrough API
+---
+Quest 2 supports grayscale passthrough; Quest 3 and Quest Pro support full-color passthrough. This lets you overlay your app on the real world.
+
+```kotlin
+import com.meta.spatial.core.Passthrough
+
+class MixedRealityManager {
+
+    fun enablePassthrough(passthrough: Passthrough) {
+        // Enable full passthrough (replaces VR background with camera feed)
+        passthrough.setStyle(PassthroughStyle.FULL)
+        passthrough.setEnabled(true)
+
+        // Or use selective passthrough with a passthrough window
+        passthrough.setStyle(PassthroughStyle.WINDOW)
+    }
+}
+```
+
+### Scene Understanding
+
+Quest 3 provides scene understanding — the headset scans the room and identifies walls, floors, ceiling, furniture:
+
+```kotlin
+import com.meta.spatial.core.Scene
+
+class SceneManager {
+
+    fun queryRoom(scene: Scene) {
+        scene.requestSceneCapture { result ->
+            if (result.isSuccess) {
+                val anchors = result.anchors
+                for (anchor in anchors) {
+                    when (anchor.semanticLabel) {
+                        "FLOOR" -> placeContentOnFloor(anchor)
+                        "WALL" -> attachPanelToWall(anchor)
+                        "DESK" -> placeObjectOnDesk(anchor)
+                        "CEILING" -> ignoreCeiling(anchor)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun placeContentOnFloor(anchor: SceneAnchor) {
+        // Position a 2D panel or 3D object at the anchor's pose
+        val panel = createInfoPanel()
+        panel.setPosition(anchor.pose.position)
+        panel.setRotation(anchor.pose.rotation)
+    }
+}
+```
+
+### Spatial Anchors
+
+Spatial anchors persist content placement across sessions:
+
+```kotlin
+import com.meta.spatial.core.SpatialAnchor
+
+class AnchorManager {
+
+    fun createPersistentAnchor(pose: Pose): SpatialAnchor {
+        val anchor = SpatialAnchor.create(pose)
+        // Save anchor UUID for next session
+        anchor.persist { uuid ->
+            preferences.edit().putString("saved_anchor", uuid.toString()).apply()
+        }
+        return anchor
+    }
+
+    fun restoreAnchor() {
+        val uuid = preferences.getString("saved_anchor", null) ?: return
+        SpatialAnchor.load(UUID.fromString(uuid)) { anchor ->
+            if (anchor != null) {
+                attachContentToAnchor(anchor)
+            }
+        }
+    }
+}
+```
+
+
+## Distribution
+
+### Meta Quest Store vs App Lab vs Sideloading
+---
+
+| Channel | Review Process | Discoverability | Requirements |
+|---------|---------------|-----------------|--------------|
+| Quest Store | Full Meta review | Listed in store, searchable | Concept approval required before submission |
+| App Lab | Lighter review | Direct link only, not browsable in store | Must meet technical requirements |
+| Sideloading | None | Manual install via adb | Developer mode enabled on headset |
+
+#### Submission Requirements
+
+- **Entitlement check** — mandatory for Store and App Lab.
+- **APK format** — Quest Store accepts APKs (not AABs, unlike Google Play).
+- **Target API level** — must meet Meta's minimum (currently API 29+).
+- **VR comfort rating** — apps must self-declare a comfort rating (comfortable, moderate, intense).
+- **Performance** — must maintain target frame rate without sustained dropped frames.
+- **Privacy policy** — required; must describe data collection.
+- **Content guidelines** — Meta has its own content policies, separate from Google Play's.
+
+#### APK vs AAB
+
+Google Play requires Android App Bundles (AAB). Meta Quest Store accepts APKs directly. If you build both:
+
+```kotlin
+// app/build.gradle.kts
+android {
+    // For Quest builds, produce APK
+    // For mobile builds, Android Studio generates AAB by default for Play
+    buildTypes {
+        getByName("release") {
+            // Both variants use the same signing config
+            signingConfig = signingConfigs.getByName("release")
+        }
+    }
+}
+```
+
+Build the Quest APK:
+```bash
+./gradlew assembleQuestRelease  # Produces APK for Quest
+./gradlew bundleMobileRelease   # Produces AAB for Google Play
+```
+
+
+## Testing
+
+### Development Setup
+---
+
+#### Meta Quest Developer Hub (MQDH)
+
+MQDH is a desktop application for managing Quest devices during development. It provides:
+- Device management and status monitoring
+- APK installation and management
+- Performance overlay and real-time metrics
+- Screen casting for demos and debugging
+- Log viewer
+
+#### ADB Connection
+
+```bash
+# USB connection (recommended for initial setup)
+adb devices
+# Should show Quest serial number
+
+# Enable Wi-Fi ADB (after USB connection established)
+adb tcpip 5555
+adb connect <quest-ip-address>:5555
+
+# Install APK
+adb install -r app-quest-release.apk
+
+# View logs filtered to your app
+adb logcat -s "YourAppTag"
+
+# Launch app
+adb shell am start -n com.yourpackage/.MainActivity
+```
+
+#### Quest Link
+
+Quest Link (USB or Air Link) lets you run the Quest as a PC VR headset. For native Android app development, it is not directly useful — use direct APK deployment via adb instead. Quest Link is relevant if you are using a PC-based game engine (Unity/Unreal) for development.
+
+#### Performance Profiling
+
+```bash
+# Enable OVR Metrics Tool overlay (shows FPS, GPU/CPU utilization, thermals)
+adb shell setprop debug.oculus.gpuLevel 3
+adb shell setprop debug.oculus.cpuLevel 3
+
+# Capture a GPU trace
+adb shell am broadcast -a com.oculus.ossystem.PERF_CAPTURE_START
+# ... run your scenario ...
+adb shell am broadcast -a com.oculus.ossystem.PERF_CAPTURE_STOP
+
+# Use Android GPU Inspector (AGI) for detailed GPU analysis
+# Quest devices are supported since they use Qualcomm Adreno GPUs
+```
+
+Use **OVR Metrics Tool** (installable from MQDH) to see a real-time overlay with:
+- FPS and frame timing
+- CPU/GPU utilization levels
+- Thermal state
+- Memory usage
+
+
+## Common Pitfalls
+
+### APIs Not Available on Quest
+---
+
+| Android API/Service | Available on Quest? | Alternative |
+|---------------------|-------------------|-------------|
+| Google Play Services | No | Meta Platform SDK |
+| Google Maps | No | Custom map rendering or WebView-based |
+| Google Sign-In | No | Meta account or custom auth |
+| Firebase Cloud Messaging (GMS) | No | Polling, WebSockets, or Meta notifications |
+| Firebase Analytics (GMS) | No | Meta analytics or custom solution |
+| Camera/CameraX | Limited | Passthrough API for MR; no direct camera access |
+| Telephony / SMS | No | N/A |
+| NFC | No | N/A |
+| Bluetooth (limited) | Partial | Controller pairing only; no general BT access |
+| Location Services | No | N/A |
+| Biometric (fingerprint/face) | No | Meta account entitlement |
+
+### 2D App Mode vs Native VR
+
+- Without `com.oculus.intent.category.VR` in the manifest, your app runs as a 2D panel — a floating window in the Quest home. This is the easiest path but limits the experience.
+- 2D panel apps still receive controller input mapped to touch events, but cannot access hand tracking, passthrough, spatial anchors, or scene understanding.
+- You can ship a 2D panel app as a first step and add VR features incrementally.
+
+### Permission Model Differences
+
+- Quest uses standard Android runtime permissions, but some permissions behave differently or are unavailable (camera, location, phone).
+- Passthrough requires `com.oculus.permission.USE_SCENE` (declared in manifest, granted at runtime).
+- Hand tracking does not require a runtime permission — it is a manifest-declared feature.
+- Storage permissions follow standard Android scoped storage rules (API 29+).
+
+### Orientation and Display
+
+- Quest always renders in landscape. Setting `android:screenOrientation="portrait"` in the manifest will not produce a portrait display — it will either be ignored or cause layout issues.
+- The display resolution is fixed per device (Quest 2: 1832x1920 per eye; Quest 3: 2064x2208 per eye). Do not assume standard phone resolutions.
+- `DisplayMetrics` and `Configuration` may report unexpected values. Do not rely on these for layout decisions — use responsive layouts with `ConstraintLayout` or Compose.
+- `WindowManager` reports the panel size, not the full headset resolution.
+
+### Missing Google Play Services — Practical Workarounds
+
+```kotlin
+// Check at startup whether GMS is available
+fun isGmsAvailable(context: Context): Boolean {
+    return try {
+        val result = GoogleApiAvailability.getInstance()
+            .isGooglePlayServicesAvailable(context)
+        result == ConnectionResult.SUCCESS
+    } catch (e: Exception) {
+        false // Not available on Quest
+    }
+}
+
+// Branch your initialization based on platform
+fun initializeApp(context: Context) {
+    if (BuildConfig.IS_QUEST) {
+        // Use Meta Platform SDK for auth, analytics, etc.
+        initializeMetaPlatform(context)
+    } else {
+        // Standard Google Play Services path
+        initializeGoogleServices(context)
+    }
+}
+```
+
+### Key Takeaways
+
+- Always feature-detect rather than assume GMS availability.
+- Use build variants to separate Quest and mobile code paths cleanly.
+- Start with 2D panel mode for a quick port; add VR features iteratively.
+- Test thermal behavior with extended sessions — Quest throttles aggressively.
+- Entitlement checks are mandatory for store distribution and must block app usage on failure.
+- Use large, high-contrast UI elements — VR readability is lower than phone screens.

--- a/registry/skills/google-app-development/references/project-structure.md
+++ b/registry/skills/google-app-development/references/project-structure.md
@@ -1,0 +1,1031 @@
+# Android Project Structure Reference
+
+Covers Android-specific project organization, Gradle configuration, build variants, and CI/CD. For generic Kotlin/Gradle project structure (single-module layout, version catalog basics, compiler options, testing setup), see the `kotlin-development` skill's `references/project-structure.md`.
+
+Targets **AGP 8.x+** and **Kotlin 2.x**.
+
+## Multi-Module Architecture
+
+### Module types
+
+| Module | Purpose | Example |
+|---|---|---|
+| `:app` | Application shell — `MainActivity`, navigation graph, DI wiring | `app/` |
+| `:feature:<name>` | Single feature — screen(s), ViewModel, UI state | `:feature:auth`, `:feature:home` |
+| `:core:ui` | Shared composables, theme, design system | `:core:ui` |
+| `:core:network` | HTTP client, API definitions, interceptors | `:core:network` |
+| `:core:data` | Repositories, data sources, caching | `:core:data` |
+| `:core:database` | Room database, DAOs, migrations | `:core:database` |
+| `:core:domain` | Use cases, domain models (pure Kotlin, no Android deps) | `:core:domain` |
+| `:core:common` | Shared utilities, extensions (use sparingly) | `:core:common` |
+| `:core:testing` | Shared test utilities, fakes, test rules | `:core:testing` |
+
+### Typical directory layout
+
+```
+my-app/
+├── app/
+│   ├── build.gradle.kts
+│   └── src/main/kotlin/com/example/app/
+│       ├── MainActivity.kt
+│       ├── MainApplication.kt
+│       └── navigation/AppNavGraph.kt
+├── feature/
+│   ├── auth/
+│   │   ├── build.gradle.kts
+│   │   └── src/main/kotlin/com/example/feature/auth/
+│   │       ├── AuthScreen.kt
+│   │       ├── AuthViewModel.kt
+│   │       └── AuthUiState.kt
+│   └── home/
+│       └── ...
+├── core/
+│   ├── ui/
+│   ├── network/
+│   ├── data/
+│   ├── database/
+│   ├── domain/
+│   └── common/
+├── build-logic/
+│   └── convention/
+│       ├── build.gradle.kts
+│       └── src/main/kotlin/
+├── gradle/
+│   └── libs.versions.toml
+├── build.gradle.kts
+├── settings.gradle.kts
+└── gradle.properties
+```
+
+### Dependency graph rules
+
+```
+app --> feature:* --> core:domain
+                  --> core:ui
+                  --> core:data --> core:network
+                               --> core:database
+                  --> core:common
+```
+
+- **`:app`** depends on all `:feature:*` modules.
+- **`:feature:*`** modules depend on `:core:*` but never on each other.
+- **`:core:domain`** is pure Kotlin — no Android framework dependencies.
+- **`:core:data`** depends on `:core:network` and `:core:database`, exposes repository interfaces.
+- Keep the graph **acyclic**. If two features need to communicate, use navigation arguments or a shared `:core:` module.
+
+### API/impl split
+
+For larger projects, split core modules into API and implementation:
+
+```
+core/
+├── network-api/       # Interfaces, models — lightweight
+│   └── build.gradle.kts   (kotlin("jvm") or Android library)
+├── network-impl/      # Retrofit/Ktor implementation
+│   └── build.gradle.kts   (depends on :core:network-api)
+```
+
+Feature modules depend on `-api` modules only. The `:app` module wires `-impl` via DI. This reduces rebuild scope and enforces clear contracts.
+
+### When to create a new module
+
+| Signal | Action |
+|---|---|
+| Component is a self-contained logical unit (player, auth, networking, analytics) | Extract to its own module — even with a single consumer. Benefits: incremental compilation (unchanged module is not recompiled), enforced access boundaries (`internal` scoped to module), isolated testability, ready for reuse without refactoring. |
+| Code is used by 2+ feature modules | Extract to `:core:<name>` |
+| Feature has its own team or release cycle | Own `:feature:<name>` module |
+| Build time is growing — large module causes frequent recompilation | Split into smaller modules with narrower dependencies |
+| You need different `minSdk` or dependencies for a subset of code | Separate module with its own `build.gradle.kts` |
+
+### When NOT to create a module
+
+- **Tiny scope** — a single utility function or extension doesn't justify a module. Put it in `:core:common`.
+- **No clear boundary** — if you can't define a clean public API for the module, it's not ready to be extracted.
+- **Over-splitting** — each module adds Gradle configuration overhead and sync time. A well-organized project with 10-15 modules is better than 50+ micro-modules with 2 files each.
+
+```kotlin
+// feature/auth/build.gradle.kts
+dependencies {
+    implementation(project(":core:network-api"))
+    // NOT :core:network-impl
+}
+
+// app/build.gradle.kts
+dependencies {
+    implementation(project(":core:network-impl"))
+}
+```
+
+
+## Gradle Setup
+
+### `build.gradle.kts` android block
+
+```kotlin
+// app/build.gradle.kts
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.hilt.android)
+    alias(libs.plugins.ksp)
+}
+
+android {
+    namespace = "com.example.myapp"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "com.example.myapp"
+        minSdk = 26
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+        buildConfig = true
+    }
+}
+```
+
+### Library module
+
+```kotlin
+// core/network/build.gradle.kts
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+}
+
+android {
+    namespace = "com.example.core.network"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+```
+
+### SDK version guidelines
+
+| Property | Recommendation | Notes |
+|---|---|---|
+| `compileSdk` | Latest stable (35) | Access newest APIs at compile time |
+| `targetSdk` | Latest stable (35) | Opt into latest platform behavior, required for Play Store |
+| `minSdk` | 26+ (Android 8.0) | Covers 95%+ of active devices; 24 if broader reach needed |
+| `jvmTarget` | `"17"` | AGP 8.x requires JDK 17 minimum |
+
+### Compose compiler (Kotlin 2.x)
+
+Starting with Kotlin 2.0, the Compose compiler is a Kotlin compiler plugin — no separate version tracking needed:
+
+```kotlin
+// build.gradle.kts
+plugins {
+    alias(libs.plugins.kotlin.compose) // org.jetbrains.kotlin.plugin.compose
+}
+
+// Optional: configure compiler reports for recomposition debugging
+composeCompiler {
+    reportsDestination = layout.buildDirectory.dir("compose_reports")
+    metricsDestination = layout.buildDirectory.dir("compose_metrics")
+    stabilityConfigurationFile = rootProject.layout.projectDirectory.file("stability_config.conf")
+}
+```
+
+### `settings.gradle.kts`
+
+```kotlin
+pluginManagement {
+    includeBuild("build-logic")
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "MyApp"
+
+include(":app")
+include(":feature:auth")
+include(":feature:home")
+include(":core:ui")
+include(":core:network")
+include(":core:data")
+include(":core:database")
+include(":core:domain")
+include(":core:common")
+```
+
+### `gradle.properties`
+
+```properties
+# Performance
+org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+
+# Android
+android.useAndroidX=true
+android.nonTransitiveRClass=true
+```
+
+
+## Version Catalog
+
+### `gradle/libs.versions.toml`
+
+```toml
+[versions]
+agp = "8.7.3"
+kotlin = "2.1.0"
+ksp = "2.1.0-1.0.29"
+
+# AndroidX
+core-ktx = "1.15.0"
+lifecycle = "2.8.7"
+activity-compose = "1.9.3"
+navigation-compose = "2.8.5"
+compose-bom = "2024.12.01"
+room = "2.6.1"
+hilt = "2.53.1"
+hilt-navigation-compose = "1.2.0"
+datastore = "1.1.1"
+
+# Networking
+retrofit = "2.11.0"
+okhttp = "4.12.0"
+ktor = "3.0.3"
+serialization = "1.7.3"
+
+# Image loading
+coil = "3.0.4"
+
+# Testing
+junit = "4.13.2"
+junit5 = "5.11.4"
+truth = "1.4.4"
+mockk = "1.13.13"
+turbine = "1.2.0"
+coroutines = "1.9.0"
+espresso = "3.6.1"
+test-runner = "1.6.2"
+
+[libraries]
+# AndroidX Core
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
+
+# Compose (BOM-managed)
+compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
+compose-ui = { module = "androidx.compose.ui:ui" }
+compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+compose-material3 = { module = "androidx.compose.material3:material3" }
+compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+
+# Room
+room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
+room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
+
+# Hilt
+hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
+hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
+
+# Networking
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+retrofit-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
+okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
+
+# Image loading
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
+
+# DataStore
+datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
+
+# Testing
+junit = { module = "junit:junit", version.ref = "junit" }
+junit5 = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit5" }
+truth = { module = "com.google.truth:truth", version.ref = "truth" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+test-runner = { module = "androidx.test:runner", version.ref = "test-runner" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+room = { id = "androidx.room", version.ref = "room" }
+```
+
+### BOM management
+
+The Compose BOM controls versions for all `androidx.compose` artifacts. Declare it once, omit versions on individual Compose libraries:
+
+```kotlin
+dependencies {
+    val composeBom = platform(libs.compose.bom)
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation(libs.compose.ui)
+    implementation(libs.compose.material3)
+    implementation(libs.compose.ui.tooling.preview)
+    debugImplementation(libs.compose.ui.tooling)
+}
+```
+
+Never pin individual Compose library versions when using the BOM — it causes version conflicts.
+
+
+## Convention Plugins
+
+Convention plugins centralize shared Gradle configuration. Place them in a `build-logic` included build.
+
+### Structure
+
+```
+build-logic/
+└── convention/
+    ├── build.gradle.kts
+    └── src/main/kotlin/
+        ├── AndroidApplicationConventionPlugin.kt
+        ├── AndroidLibraryConventionPlugin.kt
+        ├── AndroidComposeConventionPlugin.kt
+        └── AndroidHiltConventionPlugin.kt
+```
+
+### `build-logic/convention/build.gradle.kts`
+
+```kotlin
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    compileOnly(libs.android.gradlePlugin)
+    compileOnly(libs.kotlin.gradlePlugin)
+    compileOnly(libs.compose.gradlePlugin)
+    compileOnly(libs.ksp.gradlePlugin)
+}
+```
+
+Add to `libs.versions.toml`:
+
+```toml
+[libraries]
+android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+compose-gradlePlugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
+ksp-gradlePlugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+```
+
+### Example: Android library convention plugin
+
+```kotlin
+// AndroidLibraryConventionPlugin.kt
+import com.android.build.gradle.LibraryExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+class AndroidLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply("com.android.library")
+            pluginManager.apply("org.jetbrains.kotlin.android")
+
+            extensions.configure<LibraryExtension> {
+                compileSdk = 35
+
+                defaultConfig {
+                    minSdk = 26
+                    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+                }
+
+                compileOptions {
+                    sourceCompatibility = JavaVersion.VERSION_17
+                    targetCompatibility = JavaVersion.VERSION_17
+                }
+            }
+        }
+    }
+}
+```
+
+Register in `build-logic/convention/build.gradle.kts`:
+
+```kotlin
+gradlePlugin {
+    plugins {
+        register("androidLibrary") {
+            id = "myapp.android.library"
+            implementationClass = "AndroidLibraryConventionPlugin"
+        }
+        register("androidApplication") {
+            id = "myapp.android.application"
+            implementationClass = "AndroidApplicationConventionPlugin"
+        }
+        register("androidCompose") {
+            id = "myapp.android.compose"
+            implementationClass = "AndroidComposeConventionPlugin"
+        }
+        register("androidHilt") {
+            id = "myapp.android.hilt"
+            implementationClass = "AndroidHiltConventionPlugin"
+        }
+    }
+}
+```
+
+### Usage in feature modules
+
+```kotlin
+// feature/auth/build.gradle.kts
+plugins {
+    id("myapp.android.library")
+    id("myapp.android.compose")
+    id("myapp.android.hilt")
+}
+
+android {
+    namespace = "com.example.feature.auth"
+}
+
+dependencies {
+    implementation(project(":core:domain"))
+    implementation(project(":core:ui"))
+}
+```
+
+This replaces 30+ lines of boilerplate per module with 3 plugin applications.
+
+
+## Build Variants
+
+### Build types
+
+```kotlin
+android {
+    buildTypes {
+        debug {
+            isDebuggable = true
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
+        }
+        release {
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+        }
+        create("staging") {
+            initWith(getByName("release"))
+            applicationIdSuffix = ".staging"
+            versionNameSuffix = "-staging"
+            isMinifyEnabled = false
+            signingConfig = signingConfigs.getByName("debug")
+        }
+    }
+}
+```
+
+### Product flavors
+
+```kotlin
+android {
+    flavorDimensions += listOf("environment", "store")
+
+    productFlavors {
+        create("dev") {
+            dimension = "environment"
+            buildConfigField("String", "API_BASE_URL", "\"https://api-dev.example.com\"")
+        }
+        create("prod") {
+            dimension = "environment"
+            buildConfigField("String", "API_BASE_URL", "\"https://api.example.com\"")
+        }
+        create("googlePlay") {
+            dimension = "store"
+        }
+        create("huawei") {
+            dimension = "store"
+        }
+    }
+}
+```
+
+Resulting variants: `devGooglePlayDebug`, `devGooglePlayRelease`, `prodHuaweiRelease`, etc.
+
+### Flavor-specific source sets
+
+```
+app/src/
+├── main/           # Shared code
+├── debug/          # Debug-only code/resources
+├── release/        # Release-only code/resources
+├── dev/            # Dev flavor code
+├── prod/           # Prod flavor code
+├── googlePlay/     # Google Play flavor code
+└── huawei/         # Huawei flavor code
+```
+
+### Build config fields and res values
+
+```kotlin
+defaultConfig {
+    buildConfigField("Boolean", "ENABLE_LOGGING", "false")
+    resValue("string", "app_name", "My App")
+}
+
+buildTypes {
+    debug {
+        buildConfigField("Boolean", "ENABLE_LOGGING", "true")
+        resValue("string", "app_name", "My App (Debug)")
+    }
+}
+```
+
+
+## Signing Configurations
+
+### Debug signing
+
+Debug builds use a default keystore automatically. For team-consistent debug signing:
+
+```kotlin
+android {
+    signingConfigs {
+        getByName("debug") {
+            storeFile = file("debug.keystore")
+            storePassword = "android"
+            keyAlias = "androiddebugkey"
+            keyPassword = "android"
+        }
+    }
+}
+```
+
+### Release signing
+
+Never hardcode release credentials. Load from environment variables or a local properties file:
+
+```kotlin
+android {
+    signingConfigs {
+        create("release") {
+            val keystorePropertiesFile = rootProject.file("keystore.properties")
+            if (keystorePropertiesFile.exists()) {
+                val props = java.util.Properties().apply {
+                    load(keystorePropertiesFile.inputStream())
+                }
+                storeFile = file(props["storeFile"] as String)
+                storePassword = props["storePassword"] as String
+                keyAlias = props["keyAlias"] as String
+                keyPassword = props["keyPassword"] as String
+            }
+        }
+    }
+
+    buildTypes {
+        release {
+            signingConfig = signingConfigs.getByName("release")
+        }
+    }
+}
+```
+
+`keystore.properties` (git-ignored):
+
+```properties
+storeFile=release.keystore
+storePassword=your_store_password_here
+keyAlias=your_key_alias_here
+keyPassword=your_key_password_here
+```
+
+For CI, use environment variables:
+
+```kotlin
+create("release") {
+    storeFile = file(System.getenv("KEYSTORE_PATH") ?: "release.keystore")
+    storePassword = System.getenv("KEYSTORE_PASSWORD") ?: ""
+    keyAlias = System.getenv("KEY_ALIAS") ?: ""
+    keyPassword = System.getenv("KEY_PASSWORD") ?: ""
+}
+```
+
+
+## ProGuard / R8
+
+AGP 8.x uses R8 by default (drop-in replacement for ProGuard with the same rule format).
+
+### `proguard-rules.pro` (app module)
+
+```proguard
+# Keep application entry points
+-keep class com.example.myapp.MainApplication { *; }
+
+# Kotlin serialization
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.**
+-keepclassmembers class kotlinx.serialization.json.** { *** Companion; }
+-keepclasseswithmembers class com.example.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# Retrofit
+-keepattributes Signature, Exceptions
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# Room
+-keep class * extends androidx.room.RoomDatabase
+-keep @androidx.room.Entity class *
+
+# Hilt
+-keep class dagger.hilt.** { *; }
+-keep class * extends dagger.hilt.android.internal.managers.ViewComponentManager$FragmentContextWrapper { *; }
+
+# Compose — R8 full mode compatibility
+-dontwarn androidx.compose.**
+```
+
+### Consumer ProGuard rules (library modules)
+
+Library modules ship rules to consumers via `consumerProguardFiles`:
+
+```kotlin
+// core/network/build.gradle.kts
+android {
+    defaultConfig {
+        consumerProguardFiles("consumer-rules.pro")
+    }
+}
+```
+
+```proguard
+# consumer-rules.pro — applied automatically to any app depending on this library
+-keep class com.example.core.network.model.** { *; }
+```
+
+### R8 full mode
+
+AGP 8.x enables R8 full mode by default. Key differences from compatibility mode:
+- More aggressive optimizations and tree shaking.
+- Default rules are stricter — classes are removed unless explicitly kept.
+- Add `-keep` rules for anything accessed via reflection.
+
+### Debugging R8 issues
+
+```bash
+# Generate mapping file for crash deobfuscation
+./gradlew assembleRelease
+# Output: app/build/outputs/mapping/release/mapping.txt
+
+# Check which rules apply
+./gradlew :app:printConfigurationRelease
+```
+
+Upload `mapping.txt` to Play Console and Firebase Crashlytics for readable stack traces.
+
+
+## CI/CD
+
+### Common Gradle commands
+
+```bash
+# Build debug APK
+./gradlew assembleDebug
+
+# Build release APK
+./gradlew assembleRelease
+
+# Build release AAB (for Play Store)
+./gradlew bundleRelease
+
+# Run unit tests
+./gradlew testDebugUnitTest
+
+# Run instrumented tests
+./gradlew connectedDebugAndroidTest
+
+# Lint check
+./gradlew lintDebug
+
+# Full check (lint + tests)
+./gradlew check
+
+# Clean build
+./gradlew clean assembleRelease
+
+# List all tasks
+./gradlew tasks --group=build
+
+# Dependency tree
+./gradlew :app:dependencies --configuration releaseRuntimeClasspath
+```
+
+### APK vs AAB
+
+| Format | Use case |
+|---|---|
+| APK (`.apk`) | Direct install, testing, Firebase App Distribution, sideloading |
+| AAB (`.aab`) | Play Store upload (required since 2021), Google generates optimized APKs per device |
+
+### Firebase App Distribution
+
+```bash
+# Install Firebase CLI
+npm install -g firebase-tools
+
+# Distribute via Gradle plugin
+# build.gradle.kts
+plugins {
+    id("com.google.firebase.appdistribution")
+}
+
+android {
+    buildTypes {
+        debug {
+            firebaseAppDistribution {
+                appId = "1:123456789:android:abcdef"
+                groups = "qa-team"
+                releaseNotes = "Build from CI — ${System.getenv("CI_COMMIT_SHA") ?: "local"}"
+            }
+        }
+    }
+}
+```
+
+```bash
+# Upload from CI
+./gradlew assembleDebug appDistributionUploadDebug
+```
+
+### Play Store deployment
+
+```bash
+# Using Gradle Play Publisher plugin (triple-t)
+# build.gradle.kts
+plugins {
+    id("com.github.triplet.play") version "3.11.0"
+}
+
+play {
+    serviceAccountCredentials.set(file("play-service-account.json"))
+    track.set("internal")  # internal -> alpha -> beta -> production
+    defaultToAppBundles.set(true)
+}
+```
+
+```bash
+# Publish to internal track
+./gradlew publishBundle
+
+# Promote from internal to production
+./gradlew promoteArtifact --from-track internal --to-track production
+```
+
+### CI pipeline example (GitHub Actions)
+
+```yaml
+# .github/workflows/android.yml
+name: Android CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@v4
+      - run: ./gradlew check
+      - run: ./gradlew assembleRelease
+        env:
+          KEYSTORE_PATH: ${{ secrets.KEYSTORE_PATH }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-apk
+          path: app/build/outputs/apk/release/*.apk
+```
+
+
+## Asset and Resource Management
+
+### Resource directory structure
+
+```
+app/src/main/res/
+├── drawable/              # Vector drawables, XML shapes
+├── drawable-night/        # Dark mode overrides
+├── mipmap-mdpi/           # Launcher icons (48x48)
+├── mipmap-hdpi/           # Launcher icons (72x72)
+├── mipmap-xhdpi/          # Launcher icons (96x96)
+├── mipmap-xxhdpi/         # Launcher icons (144x144)
+├── mipmap-xxxhdpi/        # Launcher icons (192x192)
+├── values/
+│   ├── strings.xml
+│   ├── colors.xml
+│   ├── dimens.xml
+│   ├── themes.xml
+│   └── arrays.xml
+├── values-night/          # Dark theme colors/styles
+├── values-es/             # Spanish translations
+├── values-sw600dp/        # Tablet dimensions
+├── values-land/           # Landscape overrides
+├── font/                  # Custom fonts (.ttf, .otf)
+├── raw/                   # Raw files (audio, JSON)
+├── xml/                   # XML configs (network security, backup rules)
+└── anim/                  # View animations (XML)
+```
+
+### Common resource qualifiers
+
+| Qualifier | Example | Purpose |
+|---|---|---|
+| `-night` | `values-night/colors.xml` | Dark theme |
+| `-<lang>` | `values-es/strings.xml` | Localization |
+| `-sw<N>dp` | `values-sw600dp/dimens.xml` | Smallest width (tablets) |
+| `-land` | `layout-land/` | Landscape orientation |
+| `-v<N>` | `values-v31/themes.xml` | API level gating |
+| `-<dpi>` | `drawable-xxhdpi/` | Screen density |
+
+### Vector drawables
+
+Prefer vector drawables over raster images for icons and simple graphics:
+
+```xml
+<!-- res/drawable/ic_search.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/icon_tint"
+        android:pathData="M15.5,14h-0.79l-0.28,-0.27 ..." />
+</vector>
+```
+
+In Compose, load with `painterResource(R.drawable.ic_search)`.
+
+### Accessing resources in Compose
+
+```kotlin
+// Strings
+Text(text = stringResource(R.string.welcome_message, userName))
+
+// Dimensions
+val padding = dimensionResource(R.dimen.screen_padding)
+
+// Drawables
+Icon(painter = painterResource(R.drawable.ic_search), contentDescription = "Search")
+
+// Colors (prefer MaterialTheme.colorScheme over direct resource colors)
+val color = colorResource(R.color.brand_primary)
+```
+
+
+## Dependencies
+
+### Common Android dependency sets
+
+```kotlin
+// build.gradle.kts — typical app module dependencies
+dependencies {
+    // Compose (BOM-managed)
+    val composeBom = platform(libs.compose.bom)
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+    implementation(libs.compose.ui)
+    implementation(libs.compose.ui.graphics)
+    implementation(libs.compose.material3)
+    implementation(libs.compose.ui.tooling.preview)
+    debugImplementation(libs.compose.ui.tooling)
+
+    // AndroidX
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.navigation.compose)
+
+    // Hilt
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+    implementation(libs.hilt.navigation.compose)
+
+    // Networking (Retrofit)
+    implementation(libs.retrofit)
+    implementation(libs.retrofit.serialization)
+    implementation(libs.okhttp.logging)
+    implementation(libs.serialization.json)
+
+    // OR Networking (Ktor)
+    // implementation(libs.ktor.client.core)
+    // implementation(libs.ktor.client.okhttp)
+    // implementation(libs.ktor.client.content.negotiation)
+    // implementation(libs.ktor.serialization.json)
+
+    // Room
+    implementation(libs.room.runtime)
+    implementation(libs.room.ktx)
+    ksp(libs.room.compiler)
+
+    // Image loading
+    implementation(libs.coil.compose)
+    implementation(libs.coil.network.okhttp)
+
+    // DataStore
+    implementation(libs.datastore.preferences)
+
+    // Testing
+    testImplementation(libs.junit)
+    testImplementation(libs.truth)
+    testImplementation(libs.mockk)
+    testImplementation(libs.turbine)
+    testImplementation(libs.coroutines.test)
+    androidTestImplementation(libs.espresso.core)
+    androidTestImplementation(libs.test.runner)
+    androidTestImplementation(libs.compose.ui.test.junit4)
+    debugImplementation(libs.compose.ui.test.manifest)
+}
+```
+
+### Choosing between alternatives
+
+| Category | Option A | Option B | Recommendation |
+|---|---|---|---|
+| HTTP client | Retrofit + OkHttp | Ktor Client | Retrofit for Android-only; Ktor for KMP projects |
+| Serialization | kotlinx-serialization | Gson/Moshi | kotlinx-serialization (Kotlin-native, multiplatform) |
+| Image loading | Coil 3 | Glide | Coil (Kotlin-first, Compose-native, lighter) |
+| DI | Hilt | Koin | Hilt for apps (compile-time safety); Koin for KMP or simplicity |
+| Local DB | Room | SQLDelight | Room for Android-only; SQLDelight for KMP |
+| Key-value storage | DataStore | SharedPreferences | DataStore (async, type-safe, coroutines) |
+| Testing assertions | Truth | kotlin.test assertions | Truth for Android; kotlin.test for multiplatform |
+| Mocking | MockK | Mockito-Kotlin | MockK (Kotlin-native, better coroutine support) |
+| Flow testing | Turbine | Manual collection | Turbine (concise API for testing Flow emissions) |

--- a/registry/skills/google-app-development/references/tablet-patterns.md
+++ b/registry/skills/google-app-development/references/tablet-patterns.md
@@ -1,0 +1,791 @@
+# Tablet and Foldable Patterns Reference
+
+>[toc]
+
+
+## WindowSizeClass
+
+### Breakpoints and Classification
+---
+
+`WindowSizeClass` is the foundation for building adaptive UIs in Compose. It classifies the current window into discrete size buckets so layouts can respond to meaningful thresholds rather than raw pixel values.
+
+#### Setup
+
+Add the dependency:
+
+```kotlin
+implementation("androidx.compose.material3.adaptive:adaptive:1.1.0")
+```
+
+#### Calculating the Size Class
+
+```kotlin
+@Composable
+fun MyApp() {
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+
+    when (windowSizeClass.windowWidthSizeClass) {
+        WindowWidthSizeClass.COMPACT  -> CompactLayout()
+        WindowWidthSizeClass.MEDIUM   -> MediumLayout()
+        WindowWidthSizeClass.EXPANDED -> ExpandedLayout()
+    }
+}
+```
+
+#### Width Breakpoints
+
+| Class | Breakpoint | Typical Devices |
+|-------|-----------|-----------------|
+| `COMPACT` | < 600dp | Phones in portrait |
+| `MEDIUM` | 600dp - 839dp | Foldables unfolded, small tablets |
+| `EXPANDED` | >= 840dp | Tablets, desktops, landscape foldables |
+
+#### Height Breakpoints
+
+| Class | Breakpoint | Typical Devices |
+|-------|-----------|-----------------|
+| `COMPACT` | < 480dp | Phones in landscape |
+| `MEDIUM` | 480dp - 899dp | Tablets in landscape |
+| `EXPANDED` | >= 900dp | Tablets in portrait, desktops |
+
+**Key point**: Always branch on `windowWidthSizeClass` for primary layout decisions. Use `windowHeightSizeClass` as a secondary signal (e.g., to hide a bottom bar in landscape).
+
+
+## Adaptive Layouts
+
+### ListDetailPaneScaffold
+---
+
+`ListDetailPaneScaffold` implements the canonical list-detail pattern with automatic pane management based on window size.
+
+#### Dependency
+
+```kotlin
+implementation("androidx.compose.material3.adaptive:adaptive-layout:1.1.0")
+implementation("androidx.compose.material3.adaptive:adaptive-navigation:1.1.0")
+```
+
+#### Basic Usage
+
+```kotlin
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+@Composable
+fun ListDetailScreen() {
+    val navigator = rememberListDetailPaneScaffoldNavigator<String>()
+
+    BackHandler(navigator.canNavigateBack()) {
+        navigator.navigateBack()
+    }
+
+    ListDetailPaneScaffold(
+        directive = navigator.scaffoldDirective,
+        value = navigator.scaffoldValue,
+        listPane = {
+            AnimatedPane {
+                ItemList(
+                    onItemClick = { itemId ->
+                        navigator.navigateTo(
+                            pane = ListDetailPaneScaffoldRole.Detail,
+                            content = itemId
+                        )
+                    }
+                )
+            }
+        },
+        detailPane = {
+            AnimatedPane {
+                navigator.currentDestination?.content?.let { itemId ->
+                    ItemDetail(itemId = itemId)
+                }
+            }
+        }
+    )
+}
+```
+
+**Behavior by window size**:
+- **Compact**: Single pane; navigating to detail replaces the list with a back gesture to return.
+- **Medium/Expanded**: Side-by-side panes; list remains visible when detail is shown.
+
+#### Three-Pane (Extra Pane)
+
+```kotlin
+ListDetailPaneScaffold(
+    directive = navigator.scaffoldDirective,
+    value = navigator.scaffoldValue,
+    listPane = { /* ... */ },
+    detailPane = { /* ... */ },
+    extraPane = {
+        AnimatedPane {
+            // Tertiary content (e.g., comments, metadata)
+        }
+    }
+)
+```
+
+### NavigationSuiteScaffold
+---
+
+`NavigationSuiteScaffold` automatically switches between bottom navigation, navigation rail, and navigation drawer based on window size.
+
+#### Dependency
+
+```kotlin
+implementation("androidx.compose.material3:material3-adaptive-navigation-suite:1.4.0")
+```
+
+#### Usage
+
+```kotlin
+@Composable
+fun AppScaffold(currentDestination: Destination) {
+    NavigationSuiteScaffold(
+        navigationSuiteItems = {
+            Destination.entries.forEach { destination ->
+                item(
+                    icon = { Icon(destination.icon, contentDescription = destination.label) },
+                    label = { Text(destination.label) },
+                    selected = destination == currentDestination,
+                    onClick = { /* navigate */ }
+                )
+            }
+        }
+    ) {
+        // Screen content
+        CurrentScreen(currentDestination)
+    }
+}
+```
+
+**Automatic layout selection**:
+
+| Window Width | Navigation Component |
+|-------------|---------------------|
+| Compact | Bottom navigation bar |
+| Medium | Navigation rail (start edge) |
+| Expanded | Persistent navigation drawer |
+
+#### Overriding the Layout Type
+
+```kotlin
+NavigationSuiteScaffold(
+    layoutType = if (isTopLevelDest) {
+        NavigationSuiteType.NavigationBar
+    } else {
+        NavigationSuiteType.None
+    },
+    navigationSuiteItems = { /* ... */ }
+) { /* ... */ }
+```
+
+
+## Multi-Window
+
+### Split-Screen and Freeform Windows
+---
+
+Android supports multi-window modes: split-screen (two apps side-by-side) and freeform (resizable desktop-style windows). Compose apps that use `WindowSizeClass` adapt automatically, but there are additional considerations.
+
+#### Lifecycle Behavior
+
+In multi-window, all visible activities are in `STARTED` state but only the focused one is `RESUMED`. Use `Lifecycle.State.STARTED` (not `RESUMED`) to gate operations that should run while visible:
+
+```kotlin
+val lifecycleOwner = LocalLifecycleOwner.current
+val isAtLeastStarted by lifecycleOwner.lifecycle
+    .currentStateFlow
+    .collectAsState()
+
+if (isAtLeastStarted) {
+    // Continue video playback, sensor updates, etc.
+}
+```
+
+#### Configuration Changes
+
+When entering or exiting multi-window, the system triggers a configuration change. Compose handles recomposition automatically if you derive layout from `WindowSizeClass`. Avoid caching layout decisions in `ViewModel` -- always read from the current window info.
+
+#### Drag and Drop Between Windows
+
+```kotlin
+Modifier.dragAndDropTarget(
+    shouldStartDragAndDrop = { event ->
+        event.mimeTypes().any { it == ClipDescription.MIMETYPE_TEXT_PLAIN }
+    },
+    target = remember {
+        object : DragAndDropTarget {
+            override fun onDrop(event: DragAndDropEvent): Boolean {
+                val text = event.toAndroidDragEvent()
+                    .clipData.getItemAt(0).text
+                // Handle dropped text
+                return true
+            }
+        }
+    }
+)
+```
+
+#### Manifest Declarations
+
+For activities that support multi-window properly:
+
+```xml
+<activity
+    android:name=".MainActivity"
+    android:resizeableActivity="true"
+    android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation" />
+```
+
+Setting `resizeableActivity="false"` does **not** prevent multi-window on large screens (API 31+). It only enters size-compatibility mode.
+
+
+## Foldable Devices
+
+### WindowInfoTracker, Fold Postures, and Hinge Detection
+---
+
+Jetpack `WindowManager` provides fold-aware APIs to detect hinge position and fold state.
+
+#### Dependency
+
+```kotlin
+implementation("androidx.window:window:1.4.0")
+implementation("androidx.window:window-core:1.4.0")
+```
+
+#### Observing Fold State in Compose
+
+```kotlin
+@Composable
+fun FoldAwareScreen() {
+    val context = LocalContext.current
+    val activity = context as Activity
+
+    val layoutInfo by WindowInfoTracker.getOrCreate(activity)
+        .windowLayoutInfo(activity)
+        .collectAsState(initial = null)
+
+    val foldingFeature = layoutInfo?.displayFeatures
+        ?.filterIsInstance<FoldingFeature>()
+        ?.firstOrNull()
+
+    when {
+        foldingFeature == null -> {
+            // Flat or non-foldable device
+            StandardLayout()
+        }
+        foldingFeature.state == FoldingFeature.State.HALF_OPENED -> {
+            // Tabletop or book posture
+            if (foldingFeature.orientation == FoldingFeature.Orientation.HORIZONTAL) {
+                TabletopLayout(foldingFeature)
+            } else {
+                BookLayout(foldingFeature)
+            }
+        }
+        foldingFeature.state == FoldingFeature.State.FLAT -> {
+            // Fully unfolded -- treat as tablet
+            ExpandedLayout()
+        }
+    }
+}
+```
+
+#### Fold Postures
+
+| Posture | Fold State | Orientation | Use Case |
+|---------|-----------|-------------|----------|
+| **Tabletop** | HALF_OPENED | HORIZONTAL | Video on top, controls on bottom |
+| **Book** | HALF_OPENED | VERTICAL | Two-pane reading, side-by-side compare |
+| **Flat** | FLAT | Any | Standard tablet layout |
+
+#### Calculating Hinge Position
+
+```kotlin
+@Composable
+fun HingeAwareLayout(foldingFeature: FoldingFeature) {
+    val density = LocalDensity.current
+    val hingeBounds = foldingFeature.bounds
+
+    // Convert hinge bounds to Dp
+    val hingePosition = with(density) {
+        if (foldingFeature.orientation == FoldingFeature.Orientation.VERTICAL) {
+            hingeBounds.left.toDp()
+        } else {
+            hingeBounds.top.toDp()
+        }
+    }
+    val hingeSize = with(density) {
+        if (foldingFeature.orientation == FoldingFeature.Orientation.VERTICAL) {
+            hingeBounds.width().toDp()
+        } else {
+            hingeBounds.height().toDp()
+        }
+    }
+
+    // Place content on either side of the hinge, avoiding overlap
+    if (foldingFeature.orientation == FoldingFeature.Orientation.VERTICAL) {
+        Row {
+            Box(Modifier.width(hingePosition)) { LeftPane() }
+            Spacer(Modifier.width(hingeSize))
+            Box(Modifier.weight(1f)) { RightPane() }
+        }
+    }
+}
+```
+
+#### Occlusion vs. Separation
+
+```kotlin
+if (foldingFeature.isSeparating) {
+    // Content on opposite sides of the fold may not be visible simultaneously.
+    // Add spacing or avoid placing interactive elements across the hinge.
+}
+
+if (foldingFeature.occlusionType == FoldingFeature.OcclusionType.FULL) {
+    // Physical hinge obscures content -- never draw across it.
+}
+```
+
+
+## Large Screen Navigation
+
+### List-Detail Pattern and Two-Pane Layouts
+---
+
+#### Canonical Layout Recommendations
+
+Google recommends three canonical layouts for large screens:
+
+| Layout | When to Use | Implementation |
+|--------|------------|----------------|
+| **List-Detail** | Browse + inspect | `ListDetailPaneScaffold` |
+| **Supporting Panel** | Primary content + reference | `SupportingPaneScaffold` |
+| **Feed** | Scrollable homogeneous content | Adaptive grid with `LazyVerticalGrid` |
+
+#### SupportingPaneScaffold
+
+```kotlin
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+@Composable
+fun SupportingPaneScreen() {
+    val navigator = rememberSupportingPaneScaffoldNavigator()
+
+    SupportingPaneScaffold(
+        directive = navigator.scaffoldDirective,
+        value = navigator.scaffoldValue,
+        mainPane = {
+            AnimatedPane {
+                MainContent(
+                    onShowSupporting = {
+                        navigator.navigateTo(SupportingPaneScaffoldRole.Supporting)
+                    }
+                )
+            }
+        },
+        supportingPane = {
+            AnimatedPane {
+                SupportingContent()
+            }
+        }
+    )
+}
+```
+
+#### Adaptive Grid for Feed Layouts
+
+```kotlin
+@Composable
+fun AdaptiveFeed(items: List<FeedItem>) {
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    val columns = when (windowSizeClass.windowWidthSizeClass) {
+        WindowWidthSizeClass.COMPACT  -> 1
+        WindowWidthSizeClass.MEDIUM   -> 2
+        WindowWidthSizeClass.EXPANDED -> 3
+        else -> 1
+    }
+
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(columns),
+        contentPadding = PaddingValues(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        items(items) { item ->
+            FeedCard(item)
+        }
+    }
+}
+```
+
+#### Navigation Patterns by Screen Size
+
+| Width Class | Primary Nav | Secondary Nav |
+|------------|------------|---------------|
+| Compact | Bottom bar | Top app bar |
+| Medium | Navigation rail | Top app bar |
+| Expanded | Persistent drawer | Contextual toolbar |
+
+Use `NavigationSuiteScaffold` (see Adaptive Layouts above) to handle this automatically.
+
+
+## Input Support
+
+### Keyboard Shortcuts, Mouse Hover, and Stylus
+---
+
+Large screen devices frequently use keyboard, mouse, trackpad, and stylus input. Supporting these inputs properly is critical for a polished experience.
+
+#### Keyboard Shortcuts
+
+```kotlin
+@Composable
+fun ShortcutAwareScreen() {
+    var showSearch by remember { mutableStateOf(false) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .onPreviewKeyEvent { event ->
+                if (event.type == KeyEventType.KeyDown &&
+                    event.isCtrlPressed &&
+                    event.key == Key.F
+                ) {
+                    showSearch = true
+                    true
+                } else {
+                    false
+                }
+            }
+    ) {
+        // Screen content
+    }
+}
+```
+
+#### Common Shortcut Conventions
+
+| Shortcut | Action |
+|----------|--------|
+| Ctrl+C / Ctrl+V | Copy / Paste |
+| Ctrl+Z / Ctrl+Shift+Z | Undo / Redo |
+| Ctrl+F | Find / Search |
+| Ctrl+S | Save |
+| Ctrl+A | Select all |
+| Tab / Shift+Tab | Focus navigation |
+| Escape | Dismiss / Back |
+
+#### Mouse Hover and Right-Click
+
+```kotlin
+@Composable
+fun HoverAwareCard(item: Item) {
+    var isHovered by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = Modifier
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) {
+                        val event = awaitPointerEvent()
+                        when (event.type) {
+                            PointerEventType.Enter -> isHovered = true
+                            PointerEventType.Exit -> isHovered = false
+                        }
+                    }
+                }
+            },
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = if (isHovered) 8.dp else 2.dp
+        )
+    ) {
+        // Card content
+    }
+}
+```
+
+#### Context Menu (Right-Click)
+
+```kotlin
+@Composable
+fun ContextMenuExample(text: String) {
+    var showMenu by remember { mutableStateOf(false) }
+    var menuOffset by remember { mutableStateOf(Offset.Zero) }
+
+    Box(
+        modifier = Modifier
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) {
+                        val event = awaitPointerEvent()
+                        if (event.type == PointerEventType.Press &&
+                            event.button == PointerButton.Secondary
+                        ) {
+                            menuOffset = event.changes.first().position
+                            showMenu = true
+                        }
+                    }
+                }
+            }
+    ) {
+        Text(text)
+        DropdownMenu(
+            expanded = showMenu,
+            onDismissRequest = { showMenu = false },
+            offset = DpOffset(menuOffset.x.dp, menuOffset.y.dp)
+        ) {
+            DropdownMenuItem(
+                text = { Text("Copy") },
+                onClick = { /* copy action */ }
+            )
+            DropdownMenuItem(
+                text = { Text("Share") },
+                onClick = { /* share action */ }
+            )
+        }
+    }
+}
+```
+
+#### Stylus Support
+
+```kotlin
+@Composable
+fun StylusCanvas() {
+    val paths = remember { mutableStateListOf<Path>() }
+    val currentPath = remember { mutableStateOf<Path?>(null) }
+
+    Canvas(
+        modifier = Modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) {
+                        val event = awaitPointerEvent()
+                        val change = event.changes.first()
+
+                        // Detect stylus via input type
+                        val isStylusInput = change.type == PointerType.Stylus
+
+                        when (event.type) {
+                            PointerEventType.Press -> {
+                                currentPath.value = Path().apply {
+                                    moveTo(change.position.x, change.position.y)
+                                }
+                            }
+                            PointerEventType.Move -> {
+                                currentPath.value?.lineTo(
+                                    change.position.x,
+                                    change.position.y
+                                )
+                            }
+                            PointerEventType.Release -> {
+                                currentPath.value?.let { paths.add(it) }
+                                currentPath.value = null
+                            }
+                        }
+
+                        // Use pressure for stroke width (stylus-specific)
+                        val pressure = change.pressure
+                        change.consume()
+                    }
+                }
+            }
+    ) {
+        paths.forEach { path ->
+            drawPath(path, Color.Black, style = Stroke(width = 4f))
+        }
+        currentPath.value?.let { path ->
+            drawPath(path, Color.Black, style = Stroke(width = 4f))
+        }
+    }
+}
+```
+
+**Stylus considerations**:
+- Read `pressure` for variable stroke width.
+- Read `tilt` for brush angle effects.
+- Distinguish `PointerType.Stylus` from `PointerType.Touch` to support palm rejection.
+
+
+## Desktop Windowing
+
+### Chrome OS, Desktop Mode, and Minimum Sizes
+---
+
+On Chrome OS and Android desktop windowing mode (introduced with large screen devices), apps run in resizable windows similar to traditional desktop operating systems.
+
+#### Minimum Window Size
+
+Declare minimum dimensions in the manifest to prevent layouts from breaking at very small sizes:
+
+```xml
+<activity
+    android:name=".MainActivity"
+    android:minWidth="400dp"
+    android:minHeight="300dp"
+    android:resizeableActivity="true" />
+```
+
+#### Handling Window Resize Gracefully
+
+Compose apps that derive layout from `WindowSizeClass` handle resizing automatically. Avoid fixed-size layouts. Instead:
+
+```kotlin
+@Composable
+fun ResponsiveContent() {
+    BoxWithConstraints {
+        when {
+            maxWidth < 600.dp -> CompactContent()
+            maxWidth < 840.dp -> MediumContent()
+            else -> ExpandedContent()
+        }
+    }
+}
+```
+
+#### Chrome OS Specifics
+
+- **Keyboard and trackpad are always present**: Always support keyboard navigation and hover states.
+- **Window management**: Users expect standard windowing controls (minimize, maximize, close). These are handled by the system; no app code is needed.
+- **Free-form resizing**: The window can be any arbitrary size. Test with unusual aspect ratios (very wide, very tall).
+- **Multi-display**: Chrome OS supports external monitors. Use `WindowMetricsCalculator` to get the correct display metrics for the current window, not the default display.
+
+#### Detecting Desktop Windowing Mode
+
+```kotlin
+val windowMetrics = WindowMetricsCalculator
+    .getOrCreate()
+    .computeCurrentWindowMetrics(activity)
+
+val currentBounds = windowMetrics.bounds
+val screenBounds = WindowMetricsCalculator
+    .getOrCreate()
+    .computeMaximumWindowMetrics(activity)
+    .bounds
+
+val isWindowed = currentBounds != screenBounds
+```
+
+
+## Testing Large Screens
+
+### Device Config Overrides and Foldable Emulators
+---
+
+#### Emulator Profiles for Large Screens
+
+Use these AVD profiles in Android Studio for testing:
+
+| Profile | Resolution | Size Class |
+|---------|-----------|-----------|
+| Pixel Tablet | 2560 x 1600 | Expanded |
+| Pixel Fold | 2208 x 1840 (inner) | Expanded |
+| Medium Phone | 1080 x 2400 | Compact |
+| 7" Tablet | 1200 x 1920 | Medium |
+| 10" Tablet | 1600 x 2560 | Expanded |
+| Desktop (Chrome OS) | Freeform | Variable |
+
+#### Foldable Emulator Configuration
+
+Android Studio provides foldable emulator profiles with virtual hinge controls:
+
+1. Create an AVD using the **7.6" Fold-in** or **8" Fold-out** hardware profile.
+2. In the running emulator, use **Extended Controls > Virtual sensors > Hinge angle** to simulate fold states.
+3. Test at key angles: 0 (closed), 90 (half-opened/tabletop), 180 (flat).
+
+#### Compose UI Testing with Overridden Window Size
+
+```kotlin
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+@Test
+fun listDetailLayout_expandedWidth_showsBothPanes() {
+    composeTestRule.setContent {
+        // Override the adaptive info for testing
+        CompositionLocalProvider(
+            LocalWindowAdaptiveInfo provides WindowAdaptiveInfo(
+                windowSizeClass = WindowSizeClass(
+                    windowWidthSizeClass = WindowWidthSizeClass.EXPANDED,
+                    windowHeightSizeClass = WindowHeightSizeClass.MEDIUM
+                ),
+                windowPosture = Posture()
+            )
+        ) {
+            ListDetailScreen()
+        }
+    }
+
+    // Both panes should be visible simultaneously
+    composeTestRule.onNodeWithTag("list_pane").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("detail_pane").assertIsDisplayed()
+}
+
+@Test
+fun listDetailLayout_compactWidth_showsOnlyList() {
+    composeTestRule.setContent {
+        CompositionLocalProvider(
+            LocalWindowAdaptiveInfo provides WindowAdaptiveInfo(
+                windowSizeClass = WindowSizeClass(
+                    windowWidthSizeClass = WindowWidthSizeClass.COMPACT,
+                    windowHeightSizeClass = WindowHeightSizeClass.MEDIUM
+                ),
+                windowPosture = Posture()
+            )
+        ) {
+            ListDetailScreen()
+        }
+    }
+
+    composeTestRule.onNodeWithTag("list_pane").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("detail_pane").assertDoesNotExist()
+}
+```
+
+#### Testing Foldable Postures
+
+```kotlin
+@Test
+fun layout_tabletopPosture_splitContent() {
+    val hingeFeature = FoldingFeature(
+        activity = composeTestRule.activity,
+        state = FoldingFeature.State.HALF_OPENED,
+        orientation = FoldingFeature.Orientation.HORIZONTAL,
+        size = 0 // Zero-width hinge
+    )
+
+    composeTestRule.setContent {
+        CompositionLocalProvider(
+            LocalWindowAdaptiveInfo provides WindowAdaptiveInfo(
+                windowSizeClass = WindowSizeClass(
+                    windowWidthSizeClass = WindowWidthSizeClass.MEDIUM,
+                    windowHeightSizeClass = WindowHeightSizeClass.MEDIUM
+                ),
+                windowPosture = Posture(
+                    isTabletop = true,
+                    hingeList = listOf(hingeFeature)
+                )
+            )
+        ) {
+            FoldAwareScreen()
+        }
+    }
+
+    composeTestRule.onNodeWithTag("top_content").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("bottom_content").assertIsDisplayed()
+}
+```
+
+#### Testing Checklist for Large Screens
+
+- [ ] App renders correctly at Compact, Medium, and Expanded widths
+- [ ] List-detail shows side-by-side on Expanded, single-pane on Compact
+- [ ] Navigation switches between bottom bar, rail, and drawer appropriately
+- [ ] Content does not overlap the hinge area on foldables
+- [ ] Tabletop posture positions content correctly above and below fold
+- [ ] Keyboard shortcuts work (Ctrl+key combinations)
+- [ ] Mouse hover states are visible
+- [ ] Right-click context menus function
+- [ ] App handles multi-window resize without crashes
+- [ ] Drag and drop between windows works for applicable content types
+- [ ] Minimum window size is enforced and layout does not break
+- [ ] Configuration changes (rotation, fold/unfold) preserve state

--- a/registry/skills/google-app-development/references/tv-patterns.md
+++ b/registry/skills/google-app-development/references/tv-patterns.md
@@ -1,0 +1,570 @@
+# TV Patterns Reference (Google TV / Android TV)
+
+>[toc]
+
+
+## Compose for TV
+
+Jetpack Compose for TV (library group `androidx.tv`) provides purpose-built composables that understand focus-driven interaction and the 10-foot UI paradigm. Target **androidx.tv:tv-material:1.0+** and **androidx.tv:tv-foundation:1.0+** with Material 3 theming.
+
+### Core Composables
+---
+
+#### TvLazyColumn / TvLazyRow
+Focus-aware replacements for standard `LazyColumn` / `LazyRow`. They handle focus restoration, scroll-to-focused-item behavior, and D-pad navigation out of the box.
+
+```kotlin
+TvLazyRow(
+    pivotOffsets = PivotOffsets(parentFraction = 0.0f, childFraction = 0.0f),
+    contentPadding = PaddingValues(horizontal = 48.dp),
+    horizontalArrangement = Arrangement.spacedBy(16.dp)
+) {
+    items(catalog) { item ->
+        TvCard(item)
+    }
+}
+```
+
+- Use `pivotOffsets` to control where the focused item aligns on screen.
+- Wrap rows inside a `TvLazyColumn` to build a full browse grid.
+
+#### ImmersiveList
+Displays a large background image or video that updates as the user moves focus across a horizontal row of items.
+
+```kotlin
+ImmersiveList(
+    background = { index, listHasFocus ->
+        AnimatedContent(targetState = index) { idx ->
+            ImmersiveListBackgroundImage(items[idx].backgroundUri)
+        }
+    }
+) {
+    TvLazyRow { items(items) { item -> FocusableCard(item) } }
+}
+```
+
+- The `background` lambda receives the currently focused index and whether the list has focus, enabling animated transitions.
+
+#### Carousel
+Auto-advances through hero content; pauses on user interaction.
+
+```kotlin
+Carousel(
+    itemCount = featured.size,
+    autoScrollDurationMillis = 5_000L,
+    modifier = Modifier
+        .fillMaxWidth()
+        .height(376.dp)
+) { index ->
+    CarouselSlide(featured[index])
+}
+```
+
+- Responds to left/right D-pad for manual navigation.
+- Pair with `ImmersiveList` for a full home-screen experience.
+
+#### TvCard / WideCardContainer
+Material 3 card surfaces designed for TV focus states (border glow, scaling).
+
+```kotlin
+CompactCard(
+    onClick = { navigateToDetail(item) },
+    image = { AsyncImage(model = item.posterUrl, contentDescription = null) },
+    title = { Text(item.title) },
+    modifier = Modifier.size(width = 196.dp, height = 120.dp),
+    scale = CardDefaults.scale(focusedScale = 1.05f)
+)
+```
+
+Card variants: `Card`, `CompactCard`, `WideCardContainer`, `ClassicCard`. Each accepts `scale`, `border`, `glow`, and `shape` customization through `CardDefaults`.
+
+
+## Focus Management
+
+TV has no touch; the focus system is the primary interaction model.
+
+### FocusRequester
+---
+Programmatically request focus on a specific composable.
+
+```kotlin
+val focusRequester = remember { FocusRequester() }
+
+Button(
+    onClick = { /* ... */ },
+    modifier = Modifier.focusRequester(focusRequester)
+) { Text("Play") }
+
+LaunchedEffect(Unit) {
+    focusRequester.requestFocus()
+}
+```
+
+### focusRestorer()
+---
+Remembers which child last held focus inside a `TvLazyRow` / `TvLazyColumn` so that returning to the row restores focus to the same item rather than resetting to the first.
+
+```kotlin
+TvLazyRow(
+    modifier = Modifier.focusRestorer()
+) {
+    items(catalog) { item -> FocusableCard(item) }
+}
+```
+
+- Apply `focusRestorer()` on every scrollable container to avoid disorienting jumps.
+- Accepts an optional `FocusRequester` lambda for a fallback target when the previously-focused item is gone.
+
+### D-Pad Navigation Ordering
+---
+Control focus traversal explicitly when the default spatial algorithm is insufficient:
+
+```kotlin
+val (left, right) = remember { FocusRequester.createRefs() }
+
+Row {
+    Button(
+        modifier = Modifier
+            .focusRequester(left)
+            .focusProperties { this.right = right }
+    ) { Text("A") }
+
+    Button(
+        modifier = Modifier
+            .focusRequester(right)
+            .focusProperties { this.left = left }
+    ) { Text("B") }
+}
+```
+
+### Focus Indication
+---
+Use `Modifier.onFocusChanged {}` or the built-in `IndicationNodeFactory` from `tv-material` to show visual highlights. Material 3 TV components handle this automatically through `border`, `glow`, and `scale` parameters.
+
+
+## Leanback (Legacy)
+
+The `androidx.leanback` library was the original TV UI toolkit built on Fragments and RecyclerView.
+
+### BrowseSupportFragment
+---
+Provided the classic rows-of-cards TV interface with a sidebar of categories.
+
+```kotlin
+class MainFragment : BrowseSupportFragment() {
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        title = "My TV App"
+        adapter = ArrayObjectAdapter(ListRowPresenter()).apply {
+            add(ListRow(HeaderItem("Action"), actionAdapter))
+            add(ListRow(HeaderItem("Comedy"), comedyAdapter))
+        }
+    }
+}
+```
+
+### Migration to Compose for TV
+---
+Leanback is in maintenance mode. Migration path:
+
+| Leanback Component | Compose for TV Replacement |
+|---|---|
+| `BrowseSupportFragment` | `TvLazyColumn` + `TvLazyRow` with `ImmersiveList` |
+| `DetailsSupportFragment` | Custom Compose detail screen |
+| `SearchSupportFragment` | Custom search with `TextField` + results list |
+| `PlaybackSupportFragment` | Media3 `PlayerView` + custom Compose overlay |
+| `GuidedStepSupportFragment` | Compose dialogs / step-by-step UI |
+| `ListRow` / `Presenter` | `TvLazyRow` + card composables |
+
+Migration tips:
+- Migrate screen-by-screen; Leanback fragments and Compose screens can coexist via `NavHostFragment` + Compose destinations.
+- Replace `Presenter` / `ObjectAdapter` patterns with standard Compose state and `items()` lambdas.
+- Remove the `leanback` dependency only after all fragments are migrated.
+
+
+## Remote / D-Pad Navigation
+
+### D-Pad Events
+---
+Intercept hardware key events with `Modifier.onKeyEvent` or `Modifier.onPreviewKeyEvent`:
+
+```kotlin
+Modifier.onKeyEvent { event ->
+    when {
+        event.key == Key.DirectionCenter && event.type == KeyEventType.KeyUp -> {
+            onSelect()
+            true
+        }
+        event.key == Key.DirectionRight && event.type == KeyEventType.KeyDown -> {
+            onMoveRight()
+            true
+        }
+        else -> false
+    }
+}
+```
+
+### KeyEvent Constants
+---
+| Remote Button | `Key` constant |
+|---|---|
+| D-Pad Up | `Key.DirectionUp` |
+| D-Pad Down | `Key.DirectionDown` |
+| D-Pad Left | `Key.DirectionLeft` |
+| D-Pad Right | `Key.DirectionRight` |
+| D-Pad Center / Select | `Key.DirectionCenter` |
+| Back | `Key.Back` |
+| Media Play/Pause | `Key.MediaPlayPause` |
+| Media Rewind | `Key.MediaRewind` |
+| Media Fast Forward | `Key.MediaFastForward` |
+
+### Back Button Handling
+---
+Use `BackHandler` from `androidx.activity.compose`:
+
+```kotlin
+BackHandler(enabled = isOverlayVisible) {
+    dismissOverlay()
+}
+```
+
+- Do not intercept `Back` on top-level destinations; the system should exit the app.
+- Inside detail/player screens, use `BackHandler` to return to browse.
+- The system enforces that users can always exit; apps that block `Back` indefinitely are rejected in review.
+
+
+## Media Playback
+
+### Media3 / ExoPlayer
+---
+`androidx.media3` (the successor to standalone ExoPlayer) is the recommended playback stack.
+
+```kotlin
+@Composable
+fun VideoPlayer(mediaItem: MediaItem) {
+    val context = LocalContext.current
+    val player = remember {
+        ExoPlayer.Builder(context).build().apply {
+            setMediaItem(mediaItem)
+            prepare()
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { player.release() }
+    }
+
+    AndroidView(
+        factory = { ctx -> PlayerView(ctx).apply { this.player = player } },
+        modifier = Modifier.fillMaxSize()
+    )
+}
+```
+
+### MediaSession
+---
+Required for media key routing and system integration (Now Playing card, Google Assistant "pause" commands).
+
+```kotlin
+class PlaybackService : MediaSessionService() {
+    private var mediaSession: MediaSession? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        val player = ExoPlayer.Builder(this).build()
+        mediaSession = MediaSession.Builder(this, player).build()
+    }
+
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo) = mediaSession
+
+    override fun onDestroy() {
+        mediaSession?.run { player.release(); release() }
+        super.onDestroy()
+    }
+}
+```
+
+### Background Playback
+---
+- Use `MediaSessionService` so playback continues when the user presses Home.
+- Bind a foreground notification for audio-only playback.
+- For video, pause when the app loses focus unless PiP is active.
+
+### Picture-in-Picture (PiP)
+---
+```kotlin
+// In Activity
+override fun onUserLeaveHint() {
+    if (isPlaying) {
+        enterPictureInPictureMode(
+            PictureInPictureParams.Builder()
+                .setAspectRatio(Rational(16, 9))
+                .setAutoEnterEnabled(true)   // API 31+
+                .build()
+        )
+    }
+}
+```
+
+- Declare `android:supportsPictureInPicture="true"` and `android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation"` on the Activity.
+- On API 31+ (Android 12), use `setAutoEnterEnabled(true)` for seamless PiP on Home press.
+- Hide non-essential UI in `onPictureInPictureModeChanged`.
+
+
+## Layout for TV
+
+### 1080p Baseline
+---
+- Design at **1920 x 1080 dp**. Most TV apps render at 1080p; the system scales to 4K displays.
+- Use `dp` consistently. Avoid `px`.
+- Minimum touch-target equivalent for focus: **48 dp** (but prefer larger cards for readability at 10 feet).
+
+### Overscan / Safe Area
+---
+Legacy TVs may crop edges. Apply padding to keep content within safe bounds:
+
+```kotlin
+Modifier.padding(
+    horizontal = 48.dp,   // 5% of 960
+    vertical = 27.dp      // 5% of 540
+)
+```
+
+Modern Google TV devices do not overscan, but the 48 dp horizontal margin remains a best practice for visual comfort.
+
+### Focus Scaling
+---
+Material 3 TV cards scale up on focus (typically 1.05x-1.1x). Reserve space so that scaled cards do not clip:
+
+```kotlin
+CompactCard(
+    scale = CardDefaults.scale(focusedScale = 1.05f),
+    modifier = Modifier.padding(8.dp)   // breathing room for scale
+)
+```
+
+### 10-Foot UI Guidelines
+---
+- **Typography**: minimum body text size ~14 sp; titles 20-24 sp; headlines 32+ sp.
+- **Contrast**: WCAG AA minimum; prefer higher contrast given variable TV calibration.
+- **Color**: avoid pure white backgrounds (harsh on large screens). Use dark themes by default.
+- **Animation**: keep transitions smooth (60 fps) and purposeful. Avoid rapid or small animations that are invisible at distance.
+- **Information density**: fewer items visible at once compared to mobile; prioritize hero content and linear browsing.
+
+
+## Content Discovery
+
+### Google TV Home Channels
+---
+Apps can publish rows of content to the Google TV home screen via the `TvProvider` API (`android.media.tv`).
+
+```kotlin
+val channelUri = context.contentResolver.insert(
+    TvContractCompat.Channels.CONTENT_URI,
+    ContentValues().apply {
+        put(TvContractCompat.Channels.COLUMN_DISPLAY_NAME, "Trending")
+        put(TvContractCompat.Channels.COLUMN_APP_LINK_INTENT_URI, deepLinkUri)
+        put(TvContractCompat.Channels.COLUMN_TYPE, TvContractCompat.Channels.TYPE_PREVIEW)
+    }
+)
+```
+
+- Channels must be approved by the user (system shows an "Add to home" prompt).
+- Keep channel content fresh; stale rows are deprioritized.
+
+### Watch Next
+---
+Add programs to the system "Continue Watching" row:
+
+```kotlin
+val values = ContentValues().apply {
+    put(TvContractCompat.WatchNextPrograms.COLUMN_TITLE, "Episode 5")
+    put(TvContractCompat.WatchNextPrograms.COLUMN_WATCH_NEXT_TYPE,
+        TvContractCompat.WatchNextPrograms.WATCH_NEXT_TYPE_CONTINUE)
+    put(TvContractCompat.WatchNextPrograms.COLUMN_LAST_PLAYBACK_POSITION_MILLIS, positionMs)
+    put(TvContractCompat.WatchNextPrograms.COLUMN_DURATION_MILLIS, durationMs)
+    put(TvContractCompat.WatchNextPrograms.COLUMN_INTENT_URI, deepLinkUri)
+}
+context.contentResolver.insert(
+    TvContractCompat.WatchNextPrograms.CONTENT_URI, values
+)
+```
+
+Watch Next types: `WATCH_NEXT_TYPE_CONTINUE`, `WATCH_NEXT_TYPE_NEXT`, `WATCH_NEXT_TYPE_NEW`, `WATCH_NEXT_TYPE_WATCHLIST`.
+
+### Recommendations
+---
+- The legacy `NotificationCompat` recommendation API is deprecated.
+- Use **Engage SDK** (`com.google.android.engage`) for richer content clusters that surface across Google TV surfaces including Search, "For You", and entity pages.
+
+
+## Search
+
+### Voice Search Integration
+---
+Handle the system-level voice search intent:
+
+```xml
+<activity android:name=".SearchActivity">
+    <intent-filter>
+        <action android:name="android.intent.action.SEARCH" />
+    </intent-filter>
+    <meta-data
+        android:name="android.app.searchable"
+        android:resource="@xml/searchable" />
+</activity>
+```
+
+Extract the query in the Activity:
+
+```kotlin
+val query = intent.getStringExtra(SearchManager.QUERY)
+```
+
+For deeper Google TV integration, provide a content provider that returns results matching `SearchManager` columns so the system can display your content inline in global search results.
+
+### In-App Search with Suggestions
+---
+```kotlin
+@Composable
+fun TvSearchScreen(viewModel: SearchViewModel) {
+    var query by remember { mutableStateOf("") }
+    val suggestions by viewModel.suggestions.collectAsStateWithLifecycle()
+
+    Column(modifier = Modifier.padding(48.dp)) {
+        TextField(
+            value = query,
+            onValueChange = {
+                query = it
+                viewModel.onQueryChanged(it)
+            },
+            placeholder = { Text("Search movies, shows...") }
+        )
+
+        TvLazyColumn {
+            items(suggestions) { suggestion ->
+                ListItem(
+                    selected = false,
+                    onClick = { viewModel.select(suggestion) }
+                ) { Text(suggestion.title) }
+            }
+        }
+    }
+}
+```
+
+- Prefer voice-initiated search on TV; typing with a remote is slow.
+- Debounce search queries (300-500 ms) to reduce network calls.
+
+
+## Input Methods
+
+### Limited Text Input
+---
+On-screen keyboards with D-pad are cumbersome. Minimize text entry:
+
+- Pre-populate fields where possible.
+- Offer selection lists instead of free-text fields.
+- Support the **companion app** or **phone remote** keyboard for unavoidable text entry.
+
+### Voice Input
+---
+Trigger the system speech recognizer:
+
+```kotlin
+val speechIntent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+    putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+}
+speechLauncher.launch(speechIntent)
+```
+
+- Always provide a D-pad fallback; not all remotes have a microphone.
+- Show a microphone icon near search fields to indicate voice availability.
+
+### QR Code Pairing / Second-Screen Sign-In
+---
+Avoid forcing users to type credentials on TV. Use device-code or QR-code flows:
+
+1. App displays a short URL and a user code (or a QR code).
+2. User scans on their phone and completes OAuth on mobile.
+3. TV app polls or listens via WebSocket for the auth token.
+
+Google Identity Services supports the **OAuth 2.0 Device Authorization Grant** (RFC 8628), which is the recommended pattern for TV sign-in.
+
+```kotlin
+// Pseudocode: device code flow
+val deviceCodeResponse = authClient.requestDeviceCode(clientId, scopes)
+showQrCode(deviceCodeResponse.verificationUri)
+showUserCode(deviceCodeResponse.userCode)
+
+// Poll for token
+val tokenResponse = authClient.pollForToken(
+    deviceCode = deviceCodeResponse.deviceCode,
+    interval = deviceCodeResponse.interval
+)
+```
+
+
+## Google TV vs Android TV
+
+### Overview
+---
+| Aspect | Android TV (AOSP) | Google TV |
+|---|---|---|
+| **Base OS** | Android (TV profile) | Android TV + Google TV UI layer |
+| **Launcher** | OEM or basic Android TV home | Google TV home with personalized recommendations |
+| **Content Discovery** | Basic channel rows | AI-driven "For You", "Live", "Library" tabs |
+| **Minimum API** | API 21 (Lollipop) | API 31+ on newer devices; varies by OEM |
+| **Play Store** | Google Play for TV | Google Play for TV (same store) |
+| **Assistant** | Google Assistant built-in | Google Assistant with deeper media integration |
+| **Engage SDK** | Not available | Available for richer content surfacing |
+
+### Key Differences
+---
+- **Google TV is a superset**: every Google TV device is an Android TV device, but not vice versa. Apps targeting `android.software.leanback` run on both.
+- **Discovery surface**: Google TV prioritizes Engage SDK clusters and Watch Next for home-screen placement. Android TV (non-Google TV) relies on the legacy channel API.
+- **Profile & personalization**: Google TV supports multiple user profiles and personalized recommendations.
+- **Cast built-in**: Google TV devices include Chromecast built-in; consider supporting `CastReceiverContext` for cast-to-TV flows.
+
+### Requirements for Google TV
+---
+- Declare `android.software.leanback` as a **used** feature (not required, to allow mobile+TV builds):
+  ```xml
+  <uses-feature android:name="android.software.leanback" android:required="false" />
+  ```
+- Declare that touch is **not** required:
+  ```xml
+  <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+  ```
+- Provide a **leanback launcher** banner (320 x 180 dp) for the app icon on the TV home screen.
+- Meet **TV app quality guidelines**: no touch-dependent flows, all UI navigable by D-pad, no portrait-only layouts.
+- For Google TV-specific features (Engage SDK, Watch Next), follow the [Engage SDK integration guide](https://developer.android.com/training/tv/discovery/engage).
+
+### Build Configuration
+---
+```kotlin
+// build.gradle.kts
+android {
+    defaultConfig {
+        minSdk = 21           // broadest Android TV reach
+        targetSdk = 35        // latest stable
+    }
+}
+
+dependencies {
+    // Compose for TV (Material 3)
+    implementation("androidx.tv:tv-foundation:1.0.0")
+    implementation("androidx.tv:tv-material:1.0.0")
+
+    // Media3
+    implementation("androidx.media3:media3-exoplayer:1.5.1")
+    implementation("androidx.media3:media3-session:1.5.1")
+    implementation("androidx.media3:media3-ui:1.5.1")
+
+    // Engage SDK (Google TV discovery)
+    implementation("com.google.android.engage:engage-core:1.5.5")
+
+    // TV Provider (channels / Watch Next)
+    implementation("androidx.tvprovider:tvprovider:1.0.0")
+}
+```

--- a/registry/skills/google-app-development/references/view-interop.md
+++ b/registry/skills/google-app-development/references/view-interop.md
@@ -1,0 +1,383 @@
+# View Interop Reference
+
+Target: Compose BOM `2025.05.00+` (Compose UI 1.8+, Navigation 2.9+)
+
+---
+
+## AndroidView
+
+`AndroidView` hosts a classic Android `View` inside a Compose layout.
+
+```kotlin
+@Composable
+fun LegacyChartWrapper(data: List<Float>) {
+    AndroidView(
+        // factory runs once — create the View here
+        factory = { context ->
+            LineChartView(context).apply {
+                layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
+            }
+        },
+        // update runs on every recomposition where inputs change
+        update = { chart ->
+            chart.setData(data)
+            chart.invalidate()
+        },
+        // onRelease runs when the composable leaves composition (Compose 1.6+)
+        onRelease = { chart ->
+            chart.cleanup()
+        },
+        modifier = Modifier.fillMaxWidth().height(200.dp)
+    )
+}
+```
+
+### Key Parameters
+---
+| Parameter | Purpose |
+|-----------|---------|
+| `factory: (Context) -> T` | One-time View creation. Receives `ComponentActivity` context by default. |
+| `update: (T) -> Unit` | Called on initial composition and whenever recomposition occurs with changed state. Keep idempotent. |
+| `onReset: (T) -> Unit` | Called when the node is reused in a `ReusableContent` scope (Compose 1.6+). |
+| `onRelease: (T) -> Unit` | Called when the `AndroidView` permanently leaves composition. Use for teardown. |
+| `modifier` | Standard Compose modifier; sizing is respected by the underlying `ViewGroup`. |
+
+### Important Notes
+- `factory` receives the nearest `LocalContext.current`. If you need a themed context, wrap with `ContextThemeWrapper`.
+- Avoid capturing mutable Compose state directly inside `factory` — use `update` for reactive bindings.
+- The View is added to a `ComposeView`-internal `ViewGroup`; do not call `removeView` manually.
+
+
+## AndroidViewBinding
+
+Wraps a `ViewBinding`-inflated layout, useful when you have existing XML layouts.
+
+```kotlin
+@Composable
+fun PlayerScreen(uri: Uri) {
+    AndroidViewBinding(PlayerLayoutBinding::inflate) {
+        // 'this' is the binding instance — runs like update
+        playerView.player = ExoPlayer.Builder(playerView.context).build().apply {
+            setMediaItem(MediaItem.fromUri(uri))
+            prepare()
+        }
+    }
+}
+```
+
+- Requires `viewBinding` build feature enabled in the module's `build.gradle.kts`.
+- The trailing lambda behaves like `update` — it re-runs on recomposition.
+- Fragment inflation via `FragmentContainerView` inside the binding is supported but requires `FragmentActivity`.
+
+
+## ComposeView
+
+Embeds Compose content inside an Activity, Fragment, or any `ViewGroup`.
+
+### In an Activity
+```kotlin
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {  // shorthand — creates a ComposeView internally
+            AppTheme { MainScreen() }
+        }
+    }
+}
+```
+
+### In a Fragment
+```kotlin
+class ProfileFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(
+                ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+            )
+            setContent {
+                AppTheme { ProfileScreen() }
+            }
+        }
+    }
+}
+```
+
+### ViewCompositionStrategy
+---
+Controls when the Composition is disposed.
+
+| Strategy | Disposes when | Use case |
+|----------|---------------|----------|
+| `DisposeOnDetachedFromWindow` | View detaches from window (default) | Simple Activity usage |
+| `DisposeOnDetachedFromWindowOrReleasedFromPool` | Detach or RecyclerView pool release | ComposeView inside RecyclerView items |
+| `DisposeOnViewTreeLifecycleDestroyed` | Fragment view lifecycle `ON_DESTROY` | Fragments (prevents leaks on back-stack) |
+| `DisposeOnLifecycleDestroyed(lifecycle)` | Specific lifecycle destroyed | Dialogs, custom lifecycle owners |
+
+Use `DisposeOnViewTreeLifecycleDestroyed` in Fragments. The default strategy causes recomposition issues when Fragments go on the back-stack without destroying their view.
+
+
+## AbstractComposeView
+
+Create a reusable Compose-backed View that can be used in XML layouts.
+
+```kotlin
+class StarRatingView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : AbstractComposeView(context, attrs) {
+
+    var rating by mutableIntStateOf(0)
+
+    @Composable
+    override fun Content() {
+        AppTheme {
+            StarRatingBar(
+                rating = rating,
+                onRatingChanged = { rating = it }
+            )
+        }
+    }
+}
+```
+
+```xml
+<com.example.ui.StarRatingView
+    android:id="@+id/starRating"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+- Expose mutable state as public properties; `AbstractComposeView` triggers recomposition automatically when Compose `State` objects change.
+- Override `measurePolicy` only if you need custom intrinsic measurement.
+- Set the composition strategy via `setViewCompositionStrategy()` if used inside Fragments.
+
+
+## Navigation Interop
+
+### Mixing Fragment Navigation and Compose Navigation
+---
+
+#### Option A: Fragment NavHost with Compose Destinations
+Keep the existing `NavHostFragment` and use `ComposeView` inside Fragment destinations. Best when migrating incrementally.
+
+```kotlin
+// Fragment destination that hosts Compose
+class SettingsFragment : Fragment() {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, state: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                AppTheme { SettingsScreen(onBack = { findNavController().popBackStack() }) }
+            }
+        }
+    }
+}
+```
+
+#### Option B: Compose NavHost with Fragment Destinations
+Use `composable()` for new screens and `fragment<MyFragment>(route)` for legacy screens (requires `navigation-fragment-compose` artifact).
+
+```kotlin
+// build.gradle.kts
+implementation("androidx.navigation:navigation-fragment-compose:2.9.0")
+
+// In Compose
+NavHost(navController, startDestination = "home") {
+    composable("home") { HomeScreen() }
+    fragment<LegacyDetailFragment>("detail/{id}") {
+        argument("id") { type = NavType.StringType }
+    }
+}
+```
+
+#### Option C: Full Compose Navigation
+Replace the Fragment `NavHost` entirely. Preferred for greenfield or fully migrated apps.
+
+### Shared Navigation Tips
+- Pass a single `NavController` or a navigation callback lambda; avoid creating multiple NavControllers.
+- Deep links and back-stack behavior work across both systems when using the `navigation-fragment-compose` bridge.
+- Test navigation transitions manually — animation interop between Fragment transitions and Compose animations may require tuning.
+
+
+## When to Use Views
+
+### Decision Guide
+---
+
+| Component | Recommendation | Reason |
+|-----------|---------------|--------|
+| **Google Maps** (`MapView`) | Use `AndroidView` or the `maps-compose` library | Compose wrapper is mature (`com.google.maps.android:maps-compose`). Prefer the library. |
+| **WebView** | Use `AndroidView` | No Compose equivalent. Wrap with `update` for URL changes. Handle `onRelease` for `destroy()`. |
+| **AdView** (AdMob) | Use `AndroidView` | SDK is View-based. Follow Google's `AndroidView` guide for ad lifecycle. |
+| **ExoPlayer / Media3** `PlayerView` | Use `AndroidView` or `AndroidViewBinding` | Media3 provides experimental Compose components, but `PlayerView` is still more stable. |
+| **CameraX PreviewView** | Use `AndroidView` | Bind `ProcessCameraProvider` in `factory`, unbind in `onRelease`. |
+| **Custom drawing with Canvas** | Prefer Compose `Canvas` | Compose Canvas covers most use cases. Fall back to View Canvas only for `SurfaceView`/`TextureView`. |
+| **PDF rendering** | Use `AndroidView` with `PdfRenderer` | No Compose equivalent. |
+
+### General Rule
+Use `AndroidView` when:
+- The component has no Compose equivalent.
+- A well-tested View-based SDK wraps complex native behavior (maps, ads, video).
+- Performance-critical rendering relies on `SurfaceView` or `TextureView`.
+
+Prefer Compose when:
+- You can replicate the behavior with Compose primitives.
+- The View is purely layout/UI with no native binding (buttons, text fields, lists).
+
+
+## Migration Strategy
+
+### Screen-by-Screen (Recommended)
+---
+1. **Pick a leaf screen** (no child Fragments, minimal shared state).
+2. Wrap the Activity/Fragment content with `ComposeView` and `setContent`.
+3. Replace the XML layout with Compose equivalents, keeping the Fragment shell.
+4. Once all content is Compose, convert the Fragment to a Compose `NavHost` destination.
+5. Repeat for adjacent screens, working inward toward the host Activity.
+
+### Shared ViewModels
+---
+ViewModels bridge View and Compose worlds seamlessly.
+
+```kotlin
+// ViewModel shared between Fragment host and Compose content
+class OrderViewModel : ViewModel() {
+    val items = MutableStateFlow<List<OrderItem>>(emptyList())
+}
+
+// In Fragment
+val viewModel: OrderViewModel by viewModels()
+
+// In ComposeView inside the same Fragment
+setContent {
+    val vm: OrderViewModel = viewModel()   // resolves the same instance
+    val items by vm.items.collectAsStateWithLifecycle()
+    OrderList(items)
+}
+```
+
+- `viewModel()` and `hiltViewModel()` inside `ComposeView` resolve against the Fragment's `ViewModelStoreOwner` by default.
+- `collectAsStateWithLifecycle()` (from `lifecycle-runtime-compose`) is preferred over `collectAsState()` — it respects lifecycle and avoids updates when the UI is not visible.
+
+### Bottom-Up Approach
+---
+1. **Start with leaf components**: buttons, cards, list items. Wrap them in `AbstractComposeView` so they can be used in XML.
+2. **Replace RecyclerView adapters**: migrate item ViewHolders to Compose items (see RecyclerView Interop below).
+3. **Replace layouts**: swap `ConstraintLayout`/`LinearLayout` XML with Compose equivalents inside `ComposeView`.
+4. **Replace navigation**: migrate from Fragment-based to Compose-based `NavHost`.
+5. **Remove Fragment shells**: once a screen is fully Compose, eliminate the Fragment.
+
+
+## RecyclerView Interop
+
+### LazyColumn vs RecyclerView
+---
+| Aspect | `LazyColumn` / `LazyRow` | `RecyclerView` |
+|--------|--------------------------|----------------|
+| View recycling | Automatic (composition-based) | Explicit `ViewHolder` pattern |
+| Item types | Composable lambdas | `ViewType` + `ViewHolder` |
+| Performance (large lists) | Good; use `key` for stable identity | Excellent with `DiffUtil` |
+| Nested scrolling | Built-in | Requires `NestedScrollView` config |
+| Item animations | `animateItem()` modifier (Compose 1.7+) | `ItemAnimator` |
+
+For most new development, prefer `LazyColumn`. Use `RecyclerView` only for very large, heterogeneous lists where you observe measurable performance differences.
+
+### Compose Items Inside RecyclerView
+---
+When migrating incrementally, you can use `ComposeView` inside a `RecyclerView.ViewHolder`.
+
+```kotlin
+class ComposeItemViewHolder(
+    val composeView: ComposeView
+) : RecyclerView.ViewHolder(composeView) {
+    init {
+        composeView.setViewCompositionStrategy(
+            ViewCompositionStrategy.DisposeOnDetachedFromWindowOrReleasedFromPool
+        )
+    }
+}
+
+// In Adapter
+override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ComposeItemViewHolder {
+    return ComposeItemViewHolder(ComposeView(parent.context))
+}
+
+override fun onBindViewHolder(holder: ComposeItemViewHolder, position: Int) {
+    holder.composeView.setContent {
+        AppTheme { ItemCard(items[position]) }
+    }
+}
+```
+
+- Always use `DisposeOnDetachedFromWindowOrReleasedFromPool` to prevent leaks when items are recycled.
+- Calling `setContent` in `onBindViewHolder` is safe — Compose handles recomposition efficiently.
+- Consider migrating the entire `RecyclerView` to `LazyColumn` once all item types are Compose.
+
+
+## Common Pitfalls
+
+### Memory Leaks
+---
+- **Fragment back-stack**: Using the default `DisposeOnDetachedFromWindow` in Fragments causes the Composition to live beyond `onDestroyView`. Always use `DisposeOnViewTreeLifecycleDestroyed`.
+- **AndroidView cleanup**: Resources allocated in `factory` (players, camera providers, database cursors) must be released in `onRelease`. Forgetting this is the most common source of leaks.
+- **Coroutine scopes**: Avoid launching coroutines in `factory` or `update`. Use `LaunchedEffect` or `DisposableEffect` in the enclosing composable instead.
+
+### Theme Bridging
+---
+- Compose `MaterialTheme` and View `Theme.Material3` are independent. Use `MdcTheme` or `Mdc3Theme` from `com.google.android.material:compose-theme-adapter-3` to bridge XML theme attributes into Compose.
+- Alternatively, define a shared design token layer and apply it to both systems.
+- Watch for color mismatches: View `?attr/colorPrimary` and Compose `MaterialTheme.colorScheme.primary` may differ if not synchronized.
+
+```kotlin
+// Bridge the XML theme into Compose
+Mdc3Theme {
+    // MaterialTheme values now match the Activity's XML theme
+    MyComposeScreen()
+}
+```
+
+### Keyboard (IME) Handling
+---
+- `AndroidView` text fields manage their own `InputMethodManager` — Compose's `FocusRequester` does not control them.
+- When mixing Compose `TextField` and View `EditText`, test focus transitions carefully. Use `LocalFocusManager` for Compose and `View.requestFocus()` for Views — they do not interoperate automatically.
+- Use `WindowCompat.setDecorFitsSystemWindows(window, false)` and `imePadding()` modifier for consistent keyboard inset behavior.
+
+### Focus and Accessibility
+---
+- Focus traversal between Compose and View elements can break if `nextFocusDown` / `nextFocusUp` XML attributes conflict with Compose's focus order.
+- Content descriptions set via `Modifier.semantics { contentDescription = "..." }` in Compose do not propagate to sibling Views. Ensure both systems declare accessibility metadata independently.
+- Test with TalkBack whenever mixing Compose and View hierarchies — traversal order is a frequent source of bugs.
+
+### Lifecycle Awareness
+---
+- `AndroidView` does not forward `onPause` / `onResume` to the hosted View. If the View relies on lifecycle callbacks (e.g., `MapView.onResume()`), observe the lifecycle manually:
+
+```kotlin
+AndroidView(
+    factory = { context ->
+        MapView(context).also { it.onCreate(null) }
+    },
+    update = { }
+)
+
+val lifecycle = LocalLifecycleOwner.current.lifecycle
+DisposableEffect(lifecycle) {
+    val observer = LifecycleEventObserver { _, event ->
+        when (event) {
+            Lifecycle.Event.ON_RESUME -> mapView.onResume()
+            Lifecycle.Event.ON_PAUSE -> mapView.onPause()
+            Lifecycle.Event.ON_DESTROY -> mapView.onDestroy()
+            else -> {}
+        }
+    }
+    lifecycle.addObserver(observer)
+    onDispose { lifecycle.removeObserver(observer) }
+}
+```
+
+### State Synchronization
+---
+- Two-way state binding between a View property and Compose `MutableState` can cause infinite update loops. Use flags or `snapshotFlow` with `distinctUntilChanged` to break cycles.
+- Prefer unidirectional data flow: Compose state as source of truth, pushed to Views via `update`.

--- a/registry/skills/google-app-development/references/wear-os-patterns.md
+++ b/registry/skills/google-app-development/references/wear-os-patterns.md
@@ -1,0 +1,568 @@
+# Wear OS Patterns Reference
+
+>[toc]
+
+Target: **Wear OS 4+** / latest **Compose for Wear OS** (Horologist + Wear Compose Foundation & Material3).
+
+
+## Compose for Wear OS
+
+Wear OS uses a dedicated Compose toolkit (`androidx.wear.compose`) that accounts for round displays, limited screen real estate, and wrist-based interaction.
+
+### Core Navigation — `SwipeDismissableNavHost`
+---
+All Wear OS Compose apps should use `SwipeDismissableNavHost` instead of the standard `NavHost`. It provides a built-in swipe-to-dismiss gesture that matches the platform back-navigation pattern.
+
+```kotlin
+val navController = rememberSwipeDismissableNavController()
+
+SwipeDismissableNavHost(
+    navController = navController,
+    startDestination = "home"
+) {
+    composable("home") { HomeScreen(navController) }
+    composable("detail/{id}") { backStackEntry ->
+        DetailScreen(backStackEntry.arguments?.getString("id"))
+    }
+}
+```
+
+- Each destination automatically supports swipe-to-dismiss to go back.
+- Avoid deeply nested navigation; prefer flat hierarchies (2-3 levels max).
+
+### `ScalingLazyColumn`
+---
+The primary scrollable list component for Wear OS. It applies scaling and transparency effects to items near the edges of the round screen so content feels natural on a circular viewport.
+
+```kotlin
+val listState = rememberScalingLazyListState()
+
+ScalingLazyColumn(
+    state = listState,
+    modifier = Modifier.fillMaxSize(),
+    anchorType = ScalingLazyListAnchorType.ItemCenter
+) {
+    item { ListHeader { Text("Settings") } }
+    items(options) { option ->
+        Chip(
+            onClick = { /* handle */ },
+            label = { Text(option.title) },
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+```
+
+- Always pair with `PositionIndicator(scalingLazyListState = listState)` to show the scroll position on the side.
+- Use `ScalingLazyListAnchorType.ItemCenter` for most content screens.
+
+### `TimeText`
+---
+Displays the current time at the top of the screen (curved on round devices). It should be present on most screens so the user always sees the time.
+
+```kotlin
+Scaffold(
+    timeText = { TimeText() },
+    positionIndicator = { PositionIndicator(listState) },
+    vignette = { Vignette(vignettePosition = VignettePosition.TopAndBottom) }
+) {
+    // Screen content
+}
+```
+
+- `TimeText` automatically adapts to round vs. square screens.
+- Custom leading/trailing content can be added via `startCurvedContent` and `endCurvedContent` parameters.
+
+### Round vs. Square Screens
+---
+- Use `LocalConfiguration.current.isScreenRound` to detect screen shape when custom layouts are needed.
+- Prefer Wear Compose components (`Scaffold`, `ScalingLazyColumn`, `CurvedLayout`) which handle shape differences automatically.
+- For edge-aware padding on round screens, use `rememberResponsiveColumnPadding()` from the Horologist library.
+
+
+## Tiles
+
+Tiles are lightweight, glanceable surfaces accessible by swiping left/right from the watch face. They are **not** Compose UI — they use a layout-based rendering system for performance.
+
+### `TileService`
+---
+Extend `TileService` to provide tile content. The system calls `onTileRequest()` to get layout and `onTileResourcesRequest()` to get images/resources.
+
+```kotlin
+class MyTileService : TileService() {
+
+    override fun onTileRequest(requestParams: RequestBuilders.TileRequest) =
+        Futures.immediateFuture(
+            Tile.Builder()
+                .setResourcesVersion("1")
+                .setTileTimeline(
+                    Timeline.fromLayoutElement(tileLayout())
+                )
+                .setFreshnessIntervalMillis(15 * 60 * 1000) // 15 min refresh
+                .build()
+        )
+
+    override fun onTileResourcesRequest(requestParams: ResourcesRequest) =
+        Futures.immediateFuture(
+            Resources.Builder().setVersion("1").build()
+        )
+}
+```
+
+Register in `AndroidManifest.xml`:
+
+```xml
+<service
+    android:name=".MyTileService"
+    android:exported="true"
+    android:permission="com.google.android.wearable.permission.BIND_TILE_PROVIDER">
+    <intent-filter>
+        <action android:name="androidx.wear.tiles.action.BIND_TILE_PROVIDER" />
+    </intent-filter>
+</service>
+```
+
+### Layout and Renderer
+---
+Tile layouts use `LayoutElementBuilders` (Box, Row, Column, Text, Image, Spacer, Arc). These are **not** Compose composables — they are serializable layout descriptions rendered by the system.
+
+### Compose for Tiles (Recommended)
+---
+The `androidx.wear.protolayout.material3` library and the Tiles Material3 renderer let you build tile layouts with a Compose-like DSL while still producing protolayout elements under the hood.
+
+```kotlin
+// Using protolayout-material3 components
+private fun tileLayout(): LayoutElement =
+    PrimaryLayout.Builder(deviceParameters)
+        .setContent(
+            Text.Builder(this, "Steps: 8,432")
+                .setTypography(Typography.TITLE3)
+                .build()
+        )
+        .build()
+```
+
+- Keep tile content minimal — one or two pieces of information.
+- Use `setFreshnessIntervalMillis` to control how often the system refreshes the tile.
+- Tiles support click actions via `Clickable` that can launch activities or trigger tile updates.
+
+
+## Complications
+
+Complications are small data elements displayed on watch faces (step count, weather, battery, etc.). You supply data through a `ComplicationDataSourceService`.
+
+### `ComplicationDataSourceService`
+---
+
+```kotlin
+class StepsComplicationService : ComplicationDataSourceService() {
+
+    override fun onComplicationRequest(
+        request: ComplicationRequest,
+        listener: ComplicationRequestListener
+    ) {
+        val data = ShortTextComplicationData.Builder(
+            text = PlainComplicationText.Builder("8,432").build(),
+            contentDescription = PlainComplicationText.Builder("Steps today").build()
+        )
+            .setTapAction(openAppPendingIntent())
+            .build()
+
+        listener.onComplicationData(data)
+    }
+
+    override fun getPreviewData(type: ComplicationType): ComplicationData =
+        ShortTextComplicationData.Builder(
+            text = PlainComplicationText.Builder("--").build(),
+            contentDescription = PlainComplicationText.Builder("Steps").build()
+        ).build()
+}
+```
+
+Register with supported types:
+
+```xml
+<service
+    android:name=".StepsComplicationService"
+    android:exported="true"
+    android:permission="com.google.android.wearable.permission.BIND_COMPLICATION_PROVIDER">
+    <intent-filter>
+        <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST" />
+    </intent-filter>
+    <meta-data
+        android:name="android.support.wearable.complications.SUPPORTED_TYPES"
+        android:value="SHORT_TEXT,RANGED_VALUE" />
+    <meta-data
+        android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS"
+        android:value="600" />
+</service>
+```
+
+### Complication Types
+---
+| Type | Description | Example |
+|------|-------------|---------|
+| `SHORT_TEXT` | Icon + short text | "72F" |
+| `LONG_TEXT` | Longer text string | "Sunny, 72F, Low 58F" |
+| `RANGED_VALUE` | Progress/gauge value | Step progress ring |
+| `MONOCHROMATIC_IMAGE` | Single-color icon | Battery icon |
+| `SMALL_IMAGE` | Small photo/icon | Contact photo |
+| `PHOTO_IMAGE` | Full photo | Album art |
+| `NO_DATA` | Placeholder / empty state | "--" |
+
+- Provide `getPreviewData()` so the watch face editor can show a preview.
+- Use `ComplicationDataTimeline` to schedule future data updates without waking the service.
+
+
+## Health Services
+
+The `androidx.health.services.client` library provides access to on-device sensors with built-in batching and power management.
+
+### `ExerciseClient`
+---
+For active workout tracking with continuous sensor updates.
+
+```kotlin
+val healthServicesClient = HealthServices.getClient(context)
+val exerciseClient = healthServicesClient.exerciseClient
+
+// Check capabilities
+val capabilities = exerciseClient.getCapabilitiesAsync().await()
+val runCapabilities = capabilities.getExerciseTypeCapabilities(ExerciseType.RUNNING)
+
+// Configure and start
+val config = ExerciseConfig.builder(ExerciseType.RUNNING)
+    .setDataTypes(setOf(DataType.HEART_RATE_BPM, DataType.DISTANCE_TOTAL, DataType.SPEED))
+    .setIsAutoPauseAndResumeEnabled(true)
+    .build()
+
+exerciseClient.setUpdateCallback(exerciseUpdateCallback)
+exerciseClient.startExerciseAsync(config).await()
+```
+
+- Only one exercise can be active at a time across the entire device.
+- Always call `exerciseClient.endExerciseAsync()` in `onDestroy` or when the user stops.
+- Use a `ForegroundService` with an ongoing notification during workouts.
+
+### `PassiveMonitoringClient`
+---
+For background health data collection (e.g., daily steps, resting heart rate) without an active workout.
+
+```kotlin
+val passiveClient = healthServicesClient.passiveMonitoringClient
+
+val passiveConfig = PassiveListenerConfig.builder()
+    .setDataTypes(setOf(DataType.STEPS_DAILY, DataType.HEART_RATE_BPM))
+    .setHealthEventTypes(setOf(HealthEvent.Type.FALL_DETECTED))
+    .build()
+
+passiveClient.setPassiveListenerServiceAsync(
+    MyPassiveListenerService::class.java,
+    passiveConfig
+).await()
+```
+
+- Data is delivered in batches to reduce power consumption.
+- Use a `PassiveListenerService` to receive data even when the app is not running.
+
+### `MeasureClient`
+---
+For one-shot or short-duration measurements (e.g., check current heart rate before starting an exercise).
+
+```kotlin
+val measureClient = healthServicesClient.measureClient
+
+val heartRateAvailable = measureClient
+    .getCapabilitiesAsync()
+    .await()
+    .supportedDataTypesMeasure
+    .contains(DataType.HEART_RATE_BPM)
+
+if (heartRateAvailable) {
+    measureClient.registerMeasureCallback(DataType.HEART_RATE_BPM, measureCallback)
+}
+
+// Unregister when done
+measureClient.unregisterMeasureCallbackAsync(DataType.HEART_RATE_BPM, measureCallback)
+```
+
+- Always check capabilities before registering — not all sensors are present on all devices.
+- Unregister callbacks promptly to save battery.
+
+
+## Watch Face
+
+### Watch Face Format (WFF)
+---
+Wear OS 4+ uses the **Watch Face Format**, a declarative XML-based format that replaces the legacy `CanvasWatchFaceService`. Watch faces are bundled as APKs containing XML configuration rather than custom drawing code.
+
+```xml
+<!-- res/raw/watchface.xml -->
+<WatchFace width="450" height="450">
+    <Scene>
+        <AnalogClock>
+            <HourHand resource="@drawable/hour_hand" />
+            <MinuteHand resource="@drawable/minute_hand" />
+            <SecondHand resource="@drawable/second_hand" />
+        </AnalogClock>
+    </Scene>
+</WatchFace>
+```
+
+- WFF watch faces run in a system process — no custom code executes, which improves battery life and reliability.
+- Use the **Watch Face Studio** tool (from Samsung/Google) for visual design.
+
+### Complication Slots
+---
+Define slots in the watch face XML so users can add their preferred complications.
+
+```xml
+<ComplicationSlot
+    slotId="1"
+    name="Top"
+    supportedTypes="SHORT_TEXT|RANGED_VALUE|MONOCHROMATIC_IMAGE"
+    x="225" y="100"
+    width="80" height="80" />
+```
+
+- Provide sensible default data sources for each slot.
+- Support multiple complication types per slot for flexibility.
+
+### Ambient Mode
+---
+When the watch enters ambient mode, the display switches to a low-power state.
+
+- **Reduce color**: use white/gray on black; avoid large bright areas.
+- **Remove animations**: no moving elements or frequent updates.
+- **Burn-in protection**: shift content by a few pixels periodically on OLED screens. WFF handles this automatically via the `BurnInProtection` element.
+- **Update cadence**: once per minute in ambient mode (system-enforced).
+
+
+## Rotary Input
+
+Most Wear OS devices have a rotating side button (crown) or bezel. Compose for Wear OS provides built-in support.
+
+### `rotaryScrollable()`
+---
+
+```kotlin
+val listState = rememberScalingLazyListState()
+val focusRequester = rememberActiveFocusRequester()
+
+ScalingLazyColumn(
+    state = listState,
+    modifier = Modifier
+        .fillMaxSize()
+        .rotaryScrollable(
+            behavior = RotaryScrollableDefaults.behavior(listState),
+            focusRequester = focusRequester
+        )
+) {
+    // items
+}
+```
+
+- Use `rememberActiveFocusRequester()` to automatically request focus when the composable is displayed.
+- `rotaryScrollable` supports both smooth scrolling (crown) and snap/fling (bezel) automatically based on device hardware.
+- For custom rotary handling (e.g., volume control), use `onRotaryScrollEvent` directly on a modifier.
+
+```kotlin
+Modifier.onRotaryScrollEvent { event ->
+    volume += event.verticalScrollPixels / 100f
+    true
+}
+```
+
+
+## Data Layer
+
+The Wearable Data Layer API enables communication between a phone app and a watch app.
+
+### `DataClient`
+---
+Syncs key-value data items between devices. Changes are propagated automatically when devices are connected.
+
+```kotlin
+val dataClient = Wearable.getDataClient(context)
+
+// Send data
+val putDataRequest = PutDataMapRequest.create("/user/profile").apply {
+    dataMap.putString("name", "Andrii")
+    dataMap.putInt("steps", 8432)
+    dataMap.putLong("timestamp", System.currentTimeMillis()) // force update
+}.asPutDataRequest().setUrgent()
+
+dataClient.putDataItem(putDataRequest).await()
+
+// Listen for changes
+dataClient.addListener { dataEvents ->
+    dataEvents.forEach { event ->
+        if (event.type == DataEvent.TYPE_CHANGED) {
+            val dataMap = DataMapItem.fromDataItem(event.dataItem).dataMap
+            // process updated data
+        }
+    }
+}
+```
+
+- Data items are limited to **100 KB**. Use `Asset` for larger payloads (images, files).
+- Include a timestamp or counter to force propagation — identical data is not re-synced.
+
+### `MessageClient`
+---
+For fire-and-forget messages. No guarantee of delivery if the other device is unreachable.
+
+```kotlin
+val messageClient = Wearable.getMessageClient(context)
+
+// Find connected node
+val nodes = Wearable.getNodeClient(context).connectedNodes.await()
+val phoneNodeId = nodes.firstOrNull()?.id ?: return
+
+// Send message
+messageClient.sendMessage(phoneNodeId, "/action/start-tracking", byteArrayOf()).await()
+
+// Receive on the other side
+class MyMessageListenerService : WearableListenerService() {
+    override fun onMessageReceived(messageEvent: MessageEvent) {
+        when (messageEvent.path) {
+            "/action/start-tracking" -> { /* handle */ }
+        }
+    }
+}
+```
+
+- Messages are best for triggering actions (RPC-style), not for syncing state.
+- Register `WearableListenerService` in the manifest to receive messages when the app is not running.
+
+### Phone-Watch Sync Best Practices
+---
+- Use `DataClient` for state that must survive disconnection and be available on reconnection.
+- Use `MessageClient` for transient commands or requests.
+- Always check `CapabilityClient` to verify the companion app is installed on the other device.
+- Minimize sync frequency; batch updates where possible to reduce battery drain.
+
+
+## Standalone vs Companion
+
+### Architecture Models
+---
+
+| Model | Description | Use Case |
+|-------|-------------|----------|
+| **Standalone** | Watch app works independently; no phone app required | Fitness tracker, music player with local storage |
+| **Companion** | Watch app requires a paired phone app | Remote control, notification mirroring |
+| **Hybrid** | Core features work standalone; enhanced features need phone | Messaging app (standalone read, companion for full sync) |
+
+- Google Play requires declaring `<uses-feature android:name="android.hardware.type.watch" />` for Wear OS apps.
+- Standalone apps must declare `meta-data android:name="com.google.android.wearable.standalone" android:value="true"` in the manifest.
+
+### Detecting Connectivity
+---
+
+```kotlin
+val capabilityClient = Wearable.getCapabilityClient(context)
+
+// Check if phone app is installed
+val capabilityInfo = capabilityClient
+    .getCapability("companion_app_phone", CapabilityClient.FILTER_REACHABLE)
+    .await()
+
+val phoneNodeId = capabilityInfo.nodes.firstOrNull()?.id
+
+if (phoneNodeId != null) {
+    // Phone app is reachable — enable companion features
+} else {
+    // Running standalone — use local-only mode
+}
+
+// Listen for capability changes
+capabilityClient.addListener({ info ->
+    // Update UI based on phone connectivity
+}, "companion_app_phone")
+```
+
+- Define capabilities in `res/values/wear.xml` on each device so `CapabilityClient` can discover them.
+- Design for offline-first: assume the phone may be unreachable and degrade gracefully.
+
+
+## Notifications
+
+### Bridged vs Local Notifications
+---
+
+| Type | Origin | Behavior |
+|------|--------|----------|
+| **Bridged** | Phone app | Automatically forwarded to watch by the system |
+| **Local** | Watch app | Created directly on the watch |
+
+- Bridged notifications appear automatically — no watch-side code needed.
+- To prevent bridging a specific notification, set `.setLocalOnly(true)` on the phone side.
+
+### Wearable-Specific Actions
+---
+
+```kotlin
+val replyAction = NotificationCompat.Action.Builder(
+    R.drawable.ic_reply,
+    "Reply",
+    replyPendingIntent
+)
+    .addRemoteInput(
+        RemoteInput.Builder("reply_key")
+            .setLabel("Reply")
+            .build()
+    )
+    .build()
+
+val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+    .setSmallIcon(R.drawable.ic_message)
+    .setContentTitle("New Message")
+    .setContentText("Hey, are you coming?")
+    .addAction(replyAction)
+    .extend(
+        NotificationCompat.WearableExtender()
+            .addAction(replyAction)
+    )
+    .build()
+```
+
+- Use `RemoteInput` to allow voice or keyboard replies directly from the watch.
+- Keep notification content concise — long text is hard to read on small screens.
+- Use `BigTextStyle` or `InboxStyle` sparingly; they expand but still have limited viewport.
+- Wearable actions added via `WearableExtender` appear as swipeable action buttons below the notification.
+
+
+## Limitations
+
+### Battery
+---
+- Wear OS devices have batteries typically between **300-600 mAh**. Every sensor read, network call, and screen wake has measurable impact.
+- Use `PassiveMonitoringClient` over `ExerciseClient` for background data.
+- Avoid wake locks; prefer `WorkManager` with appropriate constraints.
+- Batch network requests; prefer syncing via `DataClient` over direct HTTP calls.
+- Set `setFreshnessIntervalMillis` on tiles to the longest acceptable interval.
+
+### Memory
+---
+- Typical Wear OS devices have **1-2 GB RAM** with limited per-app allocation.
+- Avoid loading large bitmaps; use downsampled/vector images.
+- Keep the composable tree shallow — deep nesting increases memory and measure/layout cost.
+- Use `remember` and `derivedStateOf` judiciously to minimize recomposition.
+- Profile with Android Studio's Memory Profiler connected to the watch/emulator.
+
+### Screen Sizes
+---
+- Wear OS screens range from roughly **192 x 192 dp** to **228 x 228 dp**.
+- Round screens have ~22% less usable area in corners compared to a bounding square.
+- Always test on both round and square form factors.
+- Avoid placing interactive elements near screen edges on round devices — they may be clipped or hard to tap.
+- Minimum touch target size: **48 dp** (same as mobile, but even more critical on wrist).
+
+### General Constraints
+---
+- **No multi-window**: only one app visible at a time.
+- **Limited background execution**: the system aggressively kills background processes. Use `ForegroundService` for ongoing tasks (workouts, music).
+- **Network**: prefer Bluetooth-proxied connections through the phone; direct Wi-Fi/LTE drains battery significantly.
+- **Storage**: internal storage is limited (8-32 GB shared with system). Avoid caching large files.
+- **Input**: no keyboard for most interactions — design for voice, tap, and rotary input as primary modalities.


### PR DESCRIPTION
## Summary                                                                                                                                                                                                             
  - Adds the `google-app-development` skill to the registry — a comprehensive Jetpack Compose / Kotlin guide for building apps across Google and AOSP-based platforms
  - Covers Android phone, tablet, foldable, Wear OS, Google TV, Android Auto, Android Automotive OS, Meta Quest, Amazon Fire TV, and Fire Tablets                                                                        
  - Designed to work alongside the `kotlin-development` skill for language fundamentals                                                                                                                                
                                                                                                                                                                                                                       
  ## Skill Contents (15 files, ~10K lines)
  - **SKILL.md** — main skill definition: Compose-first rules, MVI architecture, code style, naming conventions, DI, testable design, platform matrix
  - **references/compose-patterns.md** — state management, recomposition, navigation, side effects, lists, theming, animations
  - **references/android-lifecycle.md** — Activity/Fragment lifecycle, ViewModel, SavedStateHandle, process death, deep links
  - **references/concurrency.md** — viewModelScope, lifecycleScope, repeatOnLifecycle, WorkManager, foreground services, AlarmManager, testing
  - **references/project-structure.md** — multi-module architecture, Gradle setup, version catalog, convention plugins, build variants, CI/CD
  - **references/view-interop.md** — AndroidView, ComposeView, migration strategy, RecyclerView interop
  - **references/java-interop.md** — platform types, JVM annotations, SAM conversions, coroutine bridges, migration strategy
  - **references/tablet-patterns.md** — WindowSizeClass, adaptive layouts, foldable postures, input support, desktop windowing
  - **references/wear-os-patterns.md** — Compose for Wear, Tiles, complications, Health Services
  - **references/tv-patterns.md** — Compose for TV, focus/D-pad navigation, Leanback migration
  - **references/android-auto-patterns.md** — Car App Library, templates, phone projection
  - **references/android-automotive-patterns.md** — AAOS, car hardware APIs, VHAL, multi-user
  - **references/meta-quest-patterns.md** — VR adaptation, spatial UI, entitlement, passthrough
  - **references/fire-tv-patterns.md** — Amazon IAP, ADM, Alexa integration, missing GMS
  - **references/fire-tablet-patterns.md** — Show Mode, device tiers, Kids Edition

  ## Test plan
  - [x] SKILL.md follows registry conventions (frontmatter: name, description, version)
  - [x] All 14 reference files listed in SKILL.md exist on disk
  - [x] No orphaned files in references/ directory
  - [x] Code examples use modern Kotlin 2.x and Jetpack Compose
  - [x] Cross-reference to `kotlin-development` skill is valid
  - [x] Platform-specific references cover all 9 advertised platforms

  🤖 Generated with [Claude Code](https://claude.com/claude-code)