### PR TITLE
Bump CLI version to 0.1.2

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@provectusinc/awos-recruitment",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@provectusinc/awos-recruitment",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "tar": "^7.0.0",
         "yaml": "^2.0.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provectusinc/awos-recruitment",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "bin": "dist/index.js",
   "files": [


### PR DESCRIPTION
## Summary
- Bumps `@provectusinc/awos-recruitment` CLI package version from 0.1.1 to 0.1.2 after npm publish

## Test plan
- [ ] Verify `npx @provectusinc/awos-recruitment@0.1.2` installs and runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)