### PR TITLE
Add kms:Decrypt permission to ECS execution role for SSM SecureString

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -44,6 +44,10 @@ data "aws_iam_policy_document" "ssm_read" {
     actions   = ["ssm:GetParameters"]
     resources = ["arn:aws:ssm:${var.aws_region}:*:parameter/${var.project_name}/prod/*"]
   }
+  statement {
+    actions   = ["kms:Decrypt"]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_role_policy" "ecs_execution_ssm" {


### PR DESCRIPTION
The ECS execution role could not decrypt SecureString SSM parameters (e.g. the PostHog API key), preventing secret injection into containers.