### PR TITLE
Feature/apple skill additional refs

### DIFF
--- a/registry/skills/apple-app-development/SKILL.md
+++ b/registry/skills/apple-app-development/SKILL.md
@@ -22,6 +22,7 @@ For Swift language fundamentals (type system, optionals, error handling, concurr
 - **`references/concurrency.md`** — `@MainActor` for UI, `.task` modifier, `@Observable` lifecycle, Combine interop in SwiftUI context
 - **`references/uikit-interop.md`** — `UIViewRepresentable`, `UIViewControllerRepresentable`, hosting SwiftUI in UIKit, migration strategies
 - **`references/project-structure.md`** — Xcode project organization, SPM packages, multi-module architecture, build configurations, targets, schemes
+- **`references/persistence.md`** — Core Data (NSPersistentContainer, contexts, migrations, batch ops, CloudKit) and SwiftData (@Model, @Query, ModelActor, VersionedSchema, #Unique, #Index)
 - **`references/app-lifecycle.md`** — App/Scene lifecycle, background tasks, push notifications, deep links, Universal Links
 - **`references/ipados-patterns.md`** — Multitasking (Split View, Slide Over, Stage Manager), pointer/keyboard support, drag & drop, Mac Catalyst
 - **`references/macos-patterns.md`** — AppKit interop, menus, toolbar, windows, settings/preferences, sandboxing

--- a/registry/skills/apple-app-development/SKILL.md
+++ b/registry/skills/apple-app-development/SKILL.md
@@ -24,6 +24,7 @@ For Swift language fundamentals (type system, optionals, error handling, concurr
 - **`references/project-structure.md`** — Xcode project organization, SPM packages, multi-module architecture, build configurations, targets, schemes
 - **`references/persistence.md`** — Core Data (NSPersistentContainer, contexts, migrations, batch ops, CloudKit) and SwiftData (@Model, @Query, ModelActor, VersionedSchema, #Unique, #Index)
 - **`references/networking.md`** — URLSession (async/await, uploads, downloads, background sessions, WebSocket, auth challenges, caching), Alamofire (interceptors, retry, certificate pinning, multipart)
+- **`references/storekit.md`** — StoreKit 2 (Product, Transaction, subscriptions, entitlements, verification), StoreKit SwiftUI views (SubscriptionStoreView, StoreView), testing, refunds
 - **`references/media-playback.md`** — AVPlayer, AVKit (VideoPlayer, AVPlayerViewController), AVAudioSession, Picture-in-Picture, AirPlay, offline HLS downloads, Now Playing, remote controls
 - **`references/app-lifecycle.md`** — App/Scene lifecycle, background tasks, push notifications, deep links, Universal Links
 - **`references/ipados-patterns.md`** — Multitasking (Split View, Slide Over, Stage Manager), pointer/keyboard support, drag & drop, Mac Catalyst

--- a/registry/skills/apple-app-development/SKILL.md
+++ b/registry/skills/apple-app-development/SKILL.md
@@ -23,6 +23,8 @@ For Swift language fundamentals (type system, optionals, error handling, concurr
 - **`references/uikit-interop.md`** — `UIViewRepresentable`, `UIViewControllerRepresentable`, hosting SwiftUI in UIKit, migration strategies
 - **`references/project-structure.md`** — Xcode project organization, SPM packages, multi-module architecture, build configurations, targets, schemes
 - **`references/persistence.md`** — Core Data (NSPersistentContainer, contexts, migrations, batch ops, CloudKit) and SwiftData (@Model, @Query, ModelActor, VersionedSchema, #Unique, #Index)
+- **`references/networking.md`** — URLSession (async/await, uploads, downloads, background sessions, WebSocket, auth challenges, caching), Alamofire (interceptors, retry, certificate pinning, multipart)
+- **`references/media-playback.md`** — AVPlayer, AVKit (VideoPlayer, AVPlayerViewController), AVAudioSession, Picture-in-Picture, AirPlay, offline HLS downloads, Now Playing, remote controls
 - **`references/app-lifecycle.md`** — App/Scene lifecycle, background tasks, push notifications, deep links, Universal Links
 - **`references/ipados-patterns.md`** — Multitasking (Split View, Slide Over, Stage Manager), pointer/keyboard support, drag & drop, Mac Catalyst
 - **`references/macos-patterns.md`** — AppKit interop, menus, toolbar, windows, settings/preferences, sandboxing

--- a/registry/skills/apple-app-development/references/media-playback.md
+++ b/registry/skills/apple-app-development/references/media-playback.md
@@ -36,7 +36,7 @@ struct PlayerView: View {
                 Spacer()
                 Text("Live")
                     .font(.caption)
-                    .padding(6)
+                    .padding(.horizontal, 8) // Adjust per your design tokens
                     .background(.ultraThinMaterial)
                     .clipShape(Capsule())
                     .padding()
@@ -67,7 +67,7 @@ struct FullscreenPlayerView: UIViewControllerRepresentable {
         controller.canStartPictureInPictureAutomaticallyFromInline = true
 
         // Set metadata for display
-        let item = player.currentItem!
+        guard let item = player.currentItem else { return controller }
         item.externalMetadata = makeMetadata()
 
         return controller
@@ -252,7 +252,7 @@ When `VideoPlayer` and `AVPlayerViewController` don't fit your design, render vi
 class CustomPlayerView: UIView {
     override class var layerClass: AnyClass { AVPlayerLayer.self }
 
-    var playerLayer: AVPlayerLayer { layer as! AVPlayerLayer }
+    var playerLayer: AVPlayerLayer { layer as! AVPlayerLayer } // Safe: layerClass override guarantees type
 
     func configure(with player: AVPlayer) {
         playerLayer.player = player
@@ -455,7 +455,7 @@ let observation = routeDetector.observe(\.multipleRoutesDetected) { detector, _ 
 
 ```swift
 // UIKit — add AVRoutePickerView
-let routePicker = AVRoutePickerView(frame: CGRect(x: 0, y: 0, width: 44, height: 44))
+let routePicker = AVRoutePickerView(frame: CGRect(x: 0, y: 0, width: 44, height: 44)) // Standard tap target per Apple HIG
 routePicker.tintColor = .white
 view.addSubview(routePicker)
 ```

--- a/registry/skills/apple-app-development/references/media-playback.md
+++ b/registry/skills/apple-app-development/references/media-playback.md
@@ -1,0 +1,744 @@
+# Media Playback Reference (AVFoundation & AVKit)
+
+Comprehensive guide to media playback on Apple platforms. Covers AVPlayer, AVKit integration with SwiftUI and UIKit, audio session management, Picture-in-Picture, AirPlay, offline downloads, and performance. For tvOS-specific playback patterns see `tvos-patterns.md`.
+
+## Architecture Overview
+
+| Layer | Framework | Purpose |
+|---|---|---|
+| **UI** | AVKit | `VideoPlayer` (SwiftUI), `AVPlayerViewController` (UIKit) — standard transport controls, PiP, AirPlay |
+| **Playback** | AVFoundation | `AVPlayer`, `AVPlayerItem`, `AVQueuePlayer` — playback engine, time observation, state management |
+| **Rendering** | AVFoundation | `AVPlayerLayer` — Core Animation layer for custom player UI |
+| **Audio** | AVFAudio | `AVAudioSession` — system audio configuration, categories, interruptions, route changes |
+| **Assets** | AVFoundation | `AVAsset`, `AVURLAsset` — media metadata, tracks, duration, loading |
+
+**Rule:** Use AVKit (`VideoPlayer` or `AVPlayerViewController`) for standard playback. Drop to AVFoundation only when you need a fully custom player UI.
+
+
+## AVKit — Standard Playback
+
+### VideoPlayer (SwiftUI)
+---
+
+The simplest way to add video playback. Provides native transport controls across all platforms.
+
+```swift
+import AVKit
+import SwiftUI
+
+struct PlayerView: View {
+    @State private var player = AVPlayer(url: URL(string: "https://example.com/video.m3u8")!)
+
+    var body: some View {
+        VideoPlayer(player: player) {
+            // Optional overlay — positioned above transport controls
+            VStack {
+                Spacer()
+                Text("Live")
+                    .font(.caption)
+                    .padding(6)
+                    .background(.ultraThinMaterial)
+                    .clipShape(Capsule())
+                    .padding()
+            }
+        }
+        .onAppear { player.play() }
+        .onDisappear { player.pause() }
+    }
+}
+```
+
+`VideoPlayer` is suitable for inline playback. For fullscreen with rich metadata, use `AVPlayerViewController`.
+
+### AVPlayerViewController (UIKit / UIViewControllerRepresentable)
+---
+
+Full-featured player with transport bar, subtitle selection, AirPlay, and PiP support.
+
+```swift
+struct FullscreenPlayerView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> AVPlayerViewController {
+        let controller = AVPlayerViewController()
+        let player = AVPlayer(url: url)
+        controller.player = player
+        controller.allowsPictureInPicturePlayback = true
+        controller.canStartPictureInPictureAutomaticallyFromInline = true
+
+        // Set metadata for display
+        let item = player.currentItem!
+        item.externalMetadata = makeMetadata()
+
+        return controller
+    }
+
+    func updateUIViewController(_ controller: AVPlayerViewController, context: Context) {}
+
+    private func makeMetadata() -> [AVMetadataItem] {
+        let title = AVMutableMetadataItem()
+        title.identifier = .commonIdentifierTitle
+        title.value = "Episode Title" as NSString
+
+        let subtitle = AVMutableMetadataItem()
+        subtitle.identifier = .iTunesMetadataTrackSubTitle
+        subtitle.value = "Season 1, Episode 3" as NSString
+
+        return [title, subtitle]
+    }
+}
+```
+
+#### Presenting Fullscreen from SwiftUI
+
+```swift
+struct ContentView: View {
+    @State private var showPlayer = false
+
+    var body: some View {
+        Button("Play Video") { showPlayer = true }
+            .fullScreenCover(isPresented: $showPlayer) {
+                FullscreenPlayerView(url: videoURL)
+                    .ignoresSafeArea()
+            }
+    }
+}
+```
+
+
+## AVFoundation — Playback Engine
+
+### AVPlayer & AVPlayerItem
+---
+
+```swift
+import AVFoundation
+
+// Create player with a URL
+let player = AVPlayer(url: mediaURL)
+
+// Or with an AVPlayerItem for more control
+let asset = AVURLAsset(url: mediaURL)
+let item = AVPlayerItem(asset: asset)
+let player = AVPlayer(playerItem: item)
+```
+
+#### Transport Controls
+
+```swift
+player.play()
+player.pause()
+player.rate = 2.0  // 2x speed
+player.rate = 0.5  // half speed
+
+// Seek to specific time
+let target = CMTime(seconds: 30, preferredTimescale: 600)
+await player.seek(to: target)
+
+// Seek with tolerance (faster — allows nearest keyframe)
+await player.seek(to: target, toleranceBefore: .zero, toleranceAfter: .zero)
+```
+
+#### Observing Playback State
+
+Use `timeControlStatus` instead of `rate` for reliable play/pause detection:
+
+```swift
+// KVO observation
+let observation = player.observe(\.timeControlStatus) { player, _ in
+    switch player.timeControlStatus {
+    case .playing:
+        print("Playing")
+    case .paused:
+        print("Paused")
+    case .waitingToPlayAtSpecifiedRate:
+        print("Buffering — reason: \(player.reasonForWaitingToPlay?.rawValue ?? "unknown")")
+    @unknown default:
+        break
+    }
+}
+```
+
+#### AVPlayerItem Status
+
+```swift
+let statusObservation = item.observe(\.status) { item, _ in
+    switch item.status {
+    case .readyToPlay:
+        // Safe to call play()
+        break
+    case .failed:
+        print("Failed: \(item.error?.localizedDescription ?? "")")
+    case .unknown:
+        break
+    @unknown default:
+        break
+    }
+}
+```
+
+### Time Observation
+---
+
+#### Periodic Time Observer
+
+Track playback progress for UI updates (scrubber, elapsed time):
+
+```swift
+let interval = CMTime(seconds: 0.5, preferredTimescale: 600)
+let observer = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { time in
+    let seconds = CMTimeGetSeconds(time)
+    updateProgressUI(seconds: seconds)
+}
+
+// Remove when done — must store the observer token
+player.removeTimeObserver(observer)
+```
+
+#### Boundary Time Observer
+
+Trigger actions at specific times (chapter markers, ad cue points):
+
+```swift
+let times = [
+    CMTime(seconds: 10, preferredTimescale: 600),
+    CMTime(seconds: 60, preferredTimescale: 600),
+].map { NSValue(time: $0) }
+
+let observer = player.addBoundaryTimeObserver(forTimes: times, queue: .main) {
+    showChapterTitle()
+}
+```
+
+### AVQueuePlayer
+---
+
+Sequential playback of multiple items:
+
+```swift
+let items = urls.map { AVPlayerItem(url: $0) }
+let queuePlayer = AVQueuePlayer(items: items)
+queuePlayer.play()  // Automatically advances to next item
+
+// Insert/remove items dynamically
+queuePlayer.insert(newItem, after: nil)  // Append to end
+queuePlayer.remove(items[0])
+
+// Skip to next
+queuePlayer.advanceToNextItem()
+```
+
+#### AVPlayerLooper
+
+Seamless looping of a single item:
+
+```swift
+let item = AVPlayerItem(url: loopURL)
+let queuePlayer = AVQueuePlayer()
+let looper = AVPlayerLooper(player: queuePlayer, templateItem: item)
+queuePlayer.play()
+
+// Check loop state
+print("Loop count: \(looper.loopCount)")
+```
+
+### Custom Player UI with AVPlayerLayer
+---
+
+When `VideoPlayer` and `AVPlayerViewController` don't fit your design, render video with `AVPlayerLayer`:
+
+```swift
+// UIKit
+class CustomPlayerView: UIView {
+    override class var layerClass: AnyClass { AVPlayerLayer.self }
+
+    var playerLayer: AVPlayerLayer { layer as! AVPlayerLayer }
+
+    func configure(with player: AVPlayer) {
+        playerLayer.player = player
+        playerLayer.videoGravity = .resizeAspect
+    }
+}
+```
+
+```swift
+// SwiftUI wrapper
+struct CustomVideoView: UIViewRepresentable {
+    let player: AVPlayer
+
+    func makeUIView(context: Context) -> CustomPlayerView {
+        let view = CustomPlayerView()
+        view.configure(with: player)
+        return view
+    }
+
+    func updateUIView(_ uiView: CustomPlayerView, context: Context) {}
+}
+```
+
+**Video gravity options:**
+
+| Value | Behavior |
+|---|---|
+| `.resizeAspect` | Fit within bounds, preserve aspect ratio (letterbox) |
+| `.resizeAspectFill` | Fill bounds, preserve aspect ratio (crop) |
+| `.resize` | Stretch to fill (distorts) |
+
+
+## AVAudioSession
+---
+
+Configure how your app interacts with the system audio. **Must be set up before playback begins.**
+
+### Categories
+
+| Category | Behavior | Use Case |
+|---|---|---|
+| `.playback` | Silences other audio, plays with silent switch on | Video/music player |
+| `.ambient` | Mixes with other audio, respects silent switch | Game background music |
+| `.soloAmbient` | Default — silences other audio, respects silent switch | Casual audio |
+| `.playAndRecord` | Input + output simultaneously | Voice/video calls |
+| `.record` | Input only | Audio recording |
+
+### Setup
+
+```swift
+func configureAudioSession() throws {
+    let session = AVAudioSession.sharedInstance()
+    try session.setCategory(.playback, mode: .moviePlayback, options: [])
+    try session.setActive(true)
+}
+```
+
+Common modes: `.default`, `.moviePlayback`, `.spokenAudio`, `.voiceChat`, `.videoChat`.
+
+### Background Audio
+
+To continue playback when the app is backgrounded:
+
+1. Set category to `.playback`
+2. Enable **Audio, AirPlay, and Picture in Picture** in target capabilities → Background Modes
+3. Activate the session before playback
+
+### Interruption Handling
+
+```swift
+NotificationCenter.default.addObserver(
+    forName: AVAudioSession.interruptionNotification,
+    object: AVAudioSession.sharedInstance(),
+    queue: .main
+) { notification in
+    guard let info = notification.userInfo,
+          let typeValue = info[AVAudioSessionInterruptionTypeKey] as? UInt,
+          let type = AVAudioSession.InterruptionType(rawValue: typeValue)
+    else { return }
+
+    switch type {
+    case .began:
+        // Pause UI, save playback position
+        break
+    case .ended:
+        let options = info[AVAudioSessionInterruptionOptionKey] as? UInt ?? 0
+        if AVAudioSession.InterruptionOptions(rawValue: options).contains(.shouldResume) {
+            player.play()
+        }
+    @unknown default:
+        break
+    }
+}
+```
+
+### Route Change Handling
+
+Detect headphone disconnect and pause playback (Apple HIG requirement):
+
+```swift
+NotificationCenter.default.addObserver(
+    forName: AVAudioSession.routeChangeNotification,
+    object: AVAudioSession.sharedInstance(),
+    queue: .main
+) { notification in
+    guard let info = notification.userInfo,
+          let reasonValue = info[AVAudioSessionRouteChangeReasonKey] as? UInt,
+          let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue)
+    else { return }
+
+    if reason == .oldDeviceUnavailable {
+        // Headphones unplugged — pause playback
+        player.pause()
+    }
+}
+```
+
+
+## Picture-in-Picture (PiP)
+---
+
+### With AVPlayerViewController (Simplest)
+
+```swift
+let controller = AVPlayerViewController()
+controller.player = player
+controller.allowsPictureInPicturePlayback = true
+controller.canStartPictureInPictureAutomaticallyFromInline = true
+// PiP works automatically — no additional code needed
+```
+
+### With Custom Player (AVPictureInPictureController)
+
+```swift
+guard AVPictureInPictureController.isPictureInPictureSupported() else { return }
+
+let pipController = AVPictureInPictureController(playerLayer: playerLayer)
+pipController.delegate = self
+
+// Start/stop
+pipController.startPictureInPicture()
+pipController.stopPictureInPicture()
+```
+
+#### Delegate
+
+```swift
+extension PlayerManager: AVPictureInPictureControllerDelegate {
+    func pictureInPictureControllerWillStartPictureInPicture(
+        _ controller: AVPictureInPictureController) {
+        // Prepare UI — hide inline player controls
+    }
+
+    func pictureInPictureControllerDidStopPictureInPicture(
+        _ controller: AVPictureInPictureController) {
+        // Restore UI
+    }
+
+    func pictureInPictureController(
+        _ controller: AVPictureInPictureController,
+        restoreUserInterfaceForPictureInPictureStopWithCompletionHandler handler: @escaping (Bool) -> Void) {
+        // Restore full player UI when user taps to return from PiP
+        showFullscreenPlayer()
+        handler(true)
+    }
+}
+```
+
+### PiP Requirements
+
+- Audio session category `.playback` with Background Modes enabled
+- Device must support PiP (`isPictureInPictureSupported()`)
+- Player must be actively playing content
+
+
+## AirPlay & External Display
+---
+
+### Enabling AirPlay
+
+AirPlay is enabled by default with `AVPlayerViewController` and `VideoPlayer`. For custom players:
+
+```swift
+player.allowsExternalPlayback = true  // Default is true
+player.usesExternalPlaybackWhileExternalScreenIsActive = true
+```
+
+### Route Detection
+
+```swift
+let routeDetector = AVRouteDetector()
+routeDetector.isRouteDetectionEnabled = true
+
+let observation = routeDetector.observe(\.multipleRoutesDetected) { detector, _ in
+    showAirPlayButton = detector.multipleRoutesDetected
+}
+```
+
+### Route Picker (Custom UI)
+
+```swift
+// UIKit — add AVRoutePickerView
+let routePicker = AVRoutePickerView(frame: CGRect(x: 0, y: 0, width: 44, height: 44))
+routePicker.tintColor = .white
+view.addSubview(routePicker)
+```
+
+
+## Offline Downloads (HLS)
+---
+
+Download HTTP Live Streaming content for offline playback using `AVAssetDownloadURLSession`.
+
+### Download Setup
+
+```swift
+let configuration = URLSessionConfiguration.background(
+    withIdentifier: "com.example.app.asset-download"
+)
+let downloadSession = AVAssetDownloadURLSession(
+    configuration: configuration,
+    assetDownloadDelegate: self,
+    delegateQueue: .main
+)
+```
+
+### Starting a Download
+
+```swift
+let asset = AVURLAsset(url: hlsURL)
+guard let task = downloadSession.makeAssetDownloadTask(
+    asset: asset,
+    assetTitle: "Episode 1",
+    assetArtworkData: artworkData,
+    options: [AVAssetDownloadTaskMinimumRequiredMediaBitrateKey: 2_000_000]
+) else { return }
+
+task.resume()
+```
+
+### Aggregate Download (Multiple Variants)
+
+Download specific media selections (subtitles, audio tracks):
+
+```swift
+guard let task = downloadSession.aggregateAssetDownloadTask(
+    with: asset,
+    mediaSelections: [audioSelection, subtitleSelection],
+    assetTitle: "Episode 1",
+    assetArtworkData: artworkData,
+    options: nil
+) else { return }
+
+task.resume()
+```
+
+### Delegate Callbacks
+
+```swift
+extension DownloadManager: AVAssetDownloadDelegate {
+    func urlSession(_ session: URLSession, assetDownloadTask: AVAssetDownloadTask,
+                    didFinishDownloadingTo location: URL) {
+        // Save location for offline playback
+        UserDefaults.standard.set(location.relativePath, forKey: assetDownloadTask.taskDescription!)
+    }
+
+    func urlSession(_ session: URLSession,
+                    assetDownloadTask: AVAssetDownloadTask,
+                    didLoad timeRange: CMTimeRange,
+                    totalTimeRangesLoaded: [NSValue],
+                    timeRangeExpectedToLoad: CMTimeRange) {
+        var percentComplete = 0.0
+        for value in totalTimeRangesLoaded {
+            let loaded = value.timeRangeValue
+            percentComplete += CMTimeGetSeconds(loaded.duration) /
+                               CMTimeGetSeconds(timeRangeExpectedToLoad.duration)
+        }
+        updateDownloadProgress(percentComplete)
+    }
+}
+```
+
+### Playing Downloaded Content
+
+```swift
+// Retrieve saved location
+guard let relativePath = UserDefaults.standard.string(forKey: assetID) else { return }
+let localURL = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(relativePath)
+let asset = AVURLAsset(url: localURL)
+let item = AVPlayerItem(asset: asset)
+player.replaceCurrentItem(with: item)
+player.play()
+```
+
+### Storage Management
+
+```swift
+let manager = AVAssetDownloadStorageManager.shared()
+let policy = AVMutableAssetDownloadStorageManagementPolicy()
+policy.expirationDate = Date().addingTimeInterval(30 * 24 * 60 * 60)  // 30 days
+policy.priority = .important
+
+let localURL = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(relativePath)
+manager.setStorageManagementPolicy(policy, for: localURL)
+```
+
+
+## Media Selection (Subtitles & Audio Tracks)
+---
+
+```swift
+// Discover available options
+guard let asset = player.currentItem?.asset else { return }
+let mediaCharacteristics: [AVMediaCharacteristic] = [.audible, .legible]
+
+for characteristic in mediaCharacteristics {
+    if let group = try? await asset.loadMediaSelectionGroup(for: characteristic) {
+        for option in group.options {
+            print("\(characteristic): \(option.displayName) [\(option.locale?.identifier ?? "")]")
+        }
+    }
+}
+
+// Select a specific subtitle track
+if let subtitleGroup = try? await asset.loadMediaSelectionGroup(for: .legible) {
+    let french = subtitleGroup.options.first { $0.locale?.languageCode == "fr" }
+    if let french {
+        player.currentItem?.select(french, in: subtitleGroup)
+    }
+}
+
+// Set preferred language criteria (automatic selection)
+player.appliesMediaSelectionCriteriaAutomatically = true
+let criteria = AVPlayerMediaSelectionCriteria(
+    preferredLanguages: ["en", "fr"],
+    preferredMediaCharacteristics: [.legible]
+)
+player.setMediaSelectionCriteria(criteria, forMediaCharacteristic: .legible)
+```
+
+
+## Now Playing & Remote Controls
+---
+
+Enable lock screen and Control Center controls for media apps.
+
+### MPNowPlayingInfoCenter
+
+```swift
+import MediaPlayer
+
+func updateNowPlayingInfo(title: String, artist: String, duration: TimeInterval, elapsed: TimeInterval) {
+    var info: [String: Any] = [
+        MPMediaItemPropertyTitle: title,
+        MPMediaItemPropertyArtist: artist,
+        MPMediaItemPropertyPlaybackDuration: duration,
+        MPNowPlayingInfoPropertyElapsedPlaybackTime: elapsed,
+        MPNowPlayingInfoPropertyPlaybackRate: player.rate
+    ]
+
+    if let artwork = loadArtwork() {
+        info[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(
+            boundsSize: artwork.size
+        ) { _ in artwork }
+    }
+
+    MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+}
+```
+
+### MPRemoteCommandCenter
+
+```swift
+func setupRemoteCommands() {
+    let commandCenter = MPRemoteCommandCenter.shared()
+
+    commandCenter.playCommand.addTarget { [weak self] _ in
+        self?.player.play()
+        return .success
+    }
+
+    commandCenter.pauseCommand.addTarget { [weak self] _ in
+        self?.player.pause()
+        return .success
+    }
+
+    commandCenter.skipForwardCommand.preferredIntervals = [15]
+    commandCenter.skipForwardCommand.addTarget { [weak self] event in
+        guard let self, let event = event as? MPSkipIntervalCommandEvent else { return .commandFailed }
+        let target = CMTimeAdd(player.currentTime(), CMTime(seconds: event.interval, preferredTimescale: 600))
+        Task { await self.player.seek(to: target) }
+        return .success
+    }
+
+    commandCenter.skipBackwardCommand.preferredIntervals = [15]
+    commandCenter.skipBackwardCommand.addTarget { [weak self] event in
+        guard let self, let event = event as? MPSkipIntervalCommandEvent else { return .commandFailed }
+        let target = CMTimeSubtract(player.currentTime(), CMTime(seconds: event.interval, preferredTimescale: 600))
+        Task { await self.player.seek(to: target) }
+        return .success
+    }
+}
+```
+
+
+## Asset Loading
+---
+
+Load asset properties asynchronously before playback:
+
+```swift
+let asset = AVURLAsset(url: mediaURL)
+
+// Modern async API (iOS 15+)
+let duration = try await asset.load(.duration)
+let tracks = try await asset.load(.tracks)
+let isPlayable = try await asset.load(.isPlayable)
+
+// Load multiple properties at once
+let (dur, playable) = try await asset.load(.duration, .isPlayable)
+
+// Check if a specific track type exists
+let videoTracks = try await asset.loadTracks(withMediaType: .video)
+let hasVideo = !videoTracks.isEmpty
+```
+
+**Rule:** Always check `isPlayable` before attempting playback. Never access asset properties synchronously — use `load(_:)`.
+
+
+## Performance & Best Practices
+
+### Memory Management
+
+```swift
+// Release player resources when not visible
+func cleanup() {
+    player.pause()
+    player.replaceCurrentItem(with: nil)  // Releases buffers
+}
+```
+
+### Preloading
+
+```swift
+// Preload next item in queue for gapless playback
+let nextItem = AVPlayerItem(url: nextURL)
+nextItem.preferredForwardBufferDuration = 5  // Buffer 5 seconds ahead
+```
+
+### Error Handling
+
+```swift
+// Observe player item failures
+NotificationCenter.default.addObserver(
+    forName: .AVPlayerItemFailedToPlayToEndTime,
+    object: player.currentItem,
+    queue: .main
+) { notification in
+    let error = notification.userInfo?[AVPlayerItemFailedToPlayToEndTimeErrorKey] as? Error
+    handlePlaybackError(error)
+}
+
+// Observe end of playback
+NotificationCenter.default.addObserver(
+    forName: .AVPlayerItemDidPlayToEndTime,
+    object: player.currentItem,
+    queue: .main
+) { _ in
+    showReplayButton()
+    // Or loop: player.seek(to: .zero); player.play()
+}
+```
+
+
+## Common Pitfalls
+
+| Pitfall | Fix |
+|---|---|
+| No audio — silent switch is on | Set audio session category to `.playback` |
+| No background audio | Enable Background Modes capability + `.playback` category |
+| PiP doesn't work | Requires `.playback` audio session + Background Modes + active playback |
+| Video doesn't render in custom player | Ensure `AVPlayerLayer` is properly sized and added to view hierarchy |
+| Playback starts with delay | Use `automaticallyWaitsToMinimizeStalling` and preload with `preferredForwardBufferDuration` |
+| Not pausing on headphone disconnect | Observe `AVAudioSession.routeChangeNotification` and check `.oldDeviceUnavailable` |
+| Time observers not removed | Store observer token and call `removeTimeObserver(_:)` — leaks otherwise |
+| Accessing asset properties synchronously | Use `asset.load(.duration)` — synchronous access is deprecated and can block |
+| App Transport Security blocks HTTP streams | Add exception in Info.plist or use HTTPS |
+| Player item reused after failure | Create a new `AVPlayerItem` — failed items cannot be reused |
+| AirPlay not showing | Check `allowsExternalPlayback` (default true) and ensure route detection is enabled |

--- a/registry/skills/apple-app-development/references/networking.md
+++ b/registry/skills/apple-app-development/references/networking.md
@@ -1,0 +1,813 @@
+# Networking Reference (URLSession & Alamofire)
+
+Comprehensive guide to networking on Apple platforms. URLSession is the foundation — use it by default. Alamofire is an optional convenience layer for complex scenarios (interceptors, retry, certificate pinning). Both can coexist in the same project.
+
+## When to Use Which
+
+| Scenario | Recommendation |
+|---|---|
+| Simple REST API calls | URLSession async/await |
+| One-off data fetches | `URLSession.shared` |
+| Background downloads/uploads | URLSession background session |
+| WebSocket connections | `URLSessionWebSocketTask` |
+| Complex auth token refresh | Alamofire `RequestInterceptor` (or custom URLSession wrapper) |
+| Automatic retry with backoff | Alamofire `RetryPolicy` |
+| Certificate pinning | Alamofire `ServerTrustManager` (simpler) or URLSession delegate (more control) |
+| Multipart form uploads | Alamofire (convenient) or manual URLSession (verbose) |
+| Request/response logging | Alamofire `EventMonitor` |
+
+**Rule:** Start with URLSession. Add Alamofire only when you genuinely need its advanced features. Don't add it for basic GET/POST — that's one line of native code.
+
+
+## URLSession — Foundation
+
+### Simple Data Fetch (async/await)
+---
+
+```swift
+// One-liner with shared session
+let (data, response) = try await URLSession.shared.data(from: url)
+
+// With URLRequest for full control
+var request = URLRequest(url: url)
+request.httpMethod = "POST"
+request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+request.httpBody = try JSONEncoder().encode(payload)
+
+let (data, response) = try await URLSession.shared.data(for: request)
+```
+
+#### Response Validation
+
+URLSession does **not** throw on HTTP error status codes (4xx, 5xx). Always validate:
+
+```swift
+func fetch<T: Decodable>(_ type: T.Type, from url: URL) async throws -> T {
+    let (data, response) = try await URLSession.shared.data(from: url)
+
+    guard let httpResponse = response as? HTTPURLResponse else {
+        throw NetworkError.invalidResponse
+    }
+
+    guard (200...299).contains(httpResponse.statusCode) else {
+        throw NetworkError.httpError(statusCode: httpResponse.statusCode, data: data)
+    }
+
+    return try JSONDecoder().decode(T.self, from: data)
+}
+```
+
+### API Client Pattern
+---
+
+A reusable, protocol-based networking layer:
+
+```swift
+protocol APIClient: Sendable {
+    func request<T: Decodable>(_ endpoint: Endpoint) async throws -> T
+}
+
+struct Endpoint {
+    let path: String
+    let method: HTTPMethod
+    let queryItems: [URLQueryItem]?
+    let body: Encodable?
+    let headers: [String: String]?
+
+    enum HTTPMethod: String {
+        case get = "GET"
+        case post = "POST"
+        case put = "PUT"
+        case patch = "PATCH"
+        case delete = "DELETE"
+    }
+}
+
+final class URLSessionAPIClient: APIClient {
+    private let session: URLSession
+    private let baseURL: URL
+    private let decoder: JSONDecoder
+
+    init(baseURL: URL, session: URLSession = .shared, decoder: JSONDecoder = .init()) {
+        self.baseURL = baseURL
+        self.session = session
+        self.decoder = decoder
+    }
+
+    func request<T: Decodable>(_ endpoint: Endpoint) async throws -> T {
+        let urlRequest = try buildRequest(for: endpoint)
+        let (data, response) = try await session.data(for: urlRequest)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.invalidResponse
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw NetworkError.httpError(
+                statusCode: httpResponse.statusCode,
+                data: data
+            )
+        }
+
+        return try decoder.decode(T.self, from: data)
+    }
+
+    private func buildRequest(for endpoint: Endpoint) throws -> URLRequest {
+        var components = URLComponents(url: baseURL.appendingPathComponent(endpoint.path),
+                                        resolvingAgainstBaseURL: true)!
+        components.queryItems = endpoint.queryItems
+
+        var request = URLRequest(url: components.url!)
+        request.httpMethod = endpoint.method.rawValue
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let body = endpoint.body {
+            request.httpBody = try JSONEncoder().encode(body)
+        }
+
+        endpoint.headers?.forEach { request.setValue($1, forHTTPHeaderField: $0) }
+        return request
+    }
+}
+```
+
+### Session Configuration
+---
+
+```swift
+// Default — disk caching, cookies, credentials
+let defaultConfig = URLSessionConfiguration.default
+
+// Ephemeral — no persistence (private browsing)
+let ephemeralConfig = URLSessionConfiguration.ephemeral
+
+// Background — transfers continue when app is suspended
+let backgroundConfig = URLSessionConfiguration.background(
+    withIdentifier: "com.example.app.background"
+)
+```
+
+#### Common Configuration Options
+
+```swift
+let config = URLSessionConfiguration.default
+config.timeoutIntervalForRequest = 30        // Per-request timeout
+config.timeoutIntervalForResource = 300      // Total resource timeout
+config.waitsForConnectivity = true           // Wait for network instead of failing immediately
+config.allowsCellularAccess = true
+config.allowsExpensiveNetworkAccess = true
+config.allowsConstrainedNetworkAccess = false // Respect Low Data Mode
+config.httpMaximumConnectionsPerHost = 6
+config.requestCachePolicy = .useProtocolCachePolicy
+
+// Default headers for all requests
+config.httpAdditionalHeaders = [
+    "Accept": "application/json",
+    "X-App-Version": Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+]
+
+let session = URLSession(configuration: config)
+```
+
+### Uploads
+---
+
+#### JSON Body
+
+```swift
+var request = URLRequest(url: url)
+request.httpMethod = "POST"
+request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+let payload = CreateUserRequest(name: "Alice", email: "alice@example.com")
+request.httpBody = try JSONEncoder().encode(payload)
+
+let (data, response) = try await URLSession.shared.data(for: request)
+```
+
+#### File Upload
+
+```swift
+let (data, response) = try await URLSession.shared.upload(
+    for: request,
+    fromFile: fileURL
+)
+```
+
+#### Multipart Form Data (Manual)
+
+```swift
+func createMultipartRequest(url: URL, fileData: Data, fileName: String,
+                             mimeType: String, fields: [String: String]) -> URLRequest {
+    let boundary = UUID().uuidString
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("multipart/form-data; boundary=\(boundary)",
+                     forHTTPHeaderField: "Content-Type")
+
+    var body = Data()
+
+    // Text fields
+    for (key, value) in fields {
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n".data(using: .utf8)!)
+        body.append("\(value)\r\n".data(using: .utf8)!)
+    }
+
+    // File
+    body.append("--\(boundary)\r\n".data(using: .utf8)!)
+    body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(fileName)\"\r\n".data(using: .utf8)!)
+    body.append("Content-Type: \(mimeType)\r\n\r\n".data(using: .utf8)!)
+    body.append(fileData)
+    body.append("\r\n".data(using: .utf8)!)
+
+    // Close
+    body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+    request.httpBody = body
+    return request
+}
+```
+
+### Downloads
+---
+
+#### Simple Download
+
+```swift
+let (localURL, response) = try await URLSession.shared.download(from: remoteURL)
+
+// Move from temp location to permanent
+let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+let destination = documentsURL.appendingPathComponent("file.pdf")
+try FileManager.default.moveItem(at: localURL, to: destination)
+```
+
+#### Background Downloads
+
+```swift
+// 1. Create background session (reuse same identifier across app launches)
+let config = URLSessionConfiguration.background(withIdentifier: "com.example.app.download")
+config.isDiscretionary = true           // System optimizes timing (Wi-Fi, charging)
+config.sessionSendsLaunchEvents = true  // Wake app on completion
+
+let backgroundSession = URLSession(configuration: config, delegate: self, delegateQueue: nil)
+
+// 2. Create and start download
+let task = backgroundSession.downloadTask(with: remoteURL)
+task.earliestBeginDate = Date().addingTimeInterval(60 * 60)  // Schedule for later
+task.countOfBytesClientExpectsToReceive = 10 * 1024 * 1024   // Help system plan
+task.resume()
+
+// 3. Handle completion via delegate
+func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
+                didFinishDownloadingTo location: URL) {
+    // Move file from temp location — it's deleted after this method returns
+    let destination = documentsDirectory.appendingPathComponent("downloaded.pdf")
+    try? FileManager.default.moveItem(at: location, to: destination)
+}
+
+// 4. Handle app relaunch (AppDelegate)
+func application(_ application: UIApplication,
+                 handleEventsForBackgroundURLSession identifier: String,
+                 completionHandler: @escaping () -> Void) {
+    backgroundCompletionHandler = completionHandler
+}
+
+func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+    Task { @MainActor in
+        backgroundCompletionHandler?()
+        backgroundCompletionHandler = nil
+    }
+}
+```
+
+**Background session rules:**
+- Must provide a delegate (no async/await or completion handlers)
+- HTTP/HTTPS only
+- Upload tasks must be file-based (not data/stream)
+- Recreate session with same identifier on app relaunch
+- Use single session with multiple tasks, not multiple sessions
+
+#### Resumable Downloads
+
+```swift
+// Cancel and save resume data
+task.cancel { resumeData in
+    self.savedResumeData = resumeData
+}
+
+// Resume later
+if let resumeData = savedResumeData {
+    let task = session.downloadTask(withResumeData: resumeData)
+    task.resume()
+}
+```
+
+### Streaming Bytes
+---
+
+```swift
+let (bytes, response) = try await URLSession.shared.bytes(from: url)
+
+for try await line in bytes.lines {
+    processLine(line)
+}
+```
+
+### WebSocket
+---
+
+```swift
+let task = URLSession.shared.webSocketTask(with: URL(string: "wss://example.com/ws")!)
+task.resume()
+
+// Send
+try await task.send(.string("Hello"))
+try await task.send(.data(binaryData))
+
+// Receive
+let message = try await task.receive()
+switch message {
+case .string(let text):
+    print("Received: \(text)")
+case .data(let data):
+    print("Received \(data.count) bytes")
+@unknown default:
+    break
+}
+
+// Ping
+task.sendPing { error in
+    if let error { print("Ping failed: \(error)") }
+}
+
+// Close
+task.cancel(with: .normalClosure, reason: nil)
+```
+
+### Authentication Challenges
+---
+
+#### Server Trust (SSL/TLS Validation)
+
+```swift
+class NetworkDelegate: NSObject, URLSessionDelegate {
+    func urlSession(_ session: URLSession,
+                    didReceive challenge: URLAuthenticationChallenge
+    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let serverTrust = challenge.protectionSpace.serverTrust
+        else {
+            return (.performDefaultHandling, nil)
+        }
+
+        // Custom certificate validation logic here
+        return (.useCredential, URLCredential(trust: serverTrust))
+    }
+}
+```
+
+#### Basic/Digest Authentication
+
+```swift
+func urlSession(_ session: URLSession, task: URLSessionTask,
+                didReceive challenge: URLAuthenticationChallenge
+) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+    if challenge.previousFailureCount == 0 {
+        let credential = URLCredential(user: username, password: password,
+                                        persistence: .forSession)
+        return (.useCredential, credential)
+    }
+    return (.cancelAuthenticationChallenge, nil)
+}
+```
+
+### Auth Token Injection (URLSession-only approach)
+---
+
+```swift
+actor TokenManager {
+    private var accessToken: String?
+    private var refreshToken: String?
+    private var isRefreshing = false
+
+    func validToken() async throws -> String {
+        if let token = accessToken, !isExpired(token) {
+            return token
+        }
+        return try await refreshAccessToken()
+    }
+
+    private func refreshAccessToken() async throws -> String {
+        guard !isRefreshing else {
+            // Wait for ongoing refresh
+            try await Task.sleep(for: .milliseconds(100))
+            return try await validToken()
+        }
+        isRefreshing = true
+        defer { isRefreshing = false }
+
+        // Perform refresh
+        let newTokens = try await authService.refresh(refreshToken!)
+        accessToken = newTokens.access
+        refreshToken = newTokens.refresh
+        return newTokens.access
+    }
+}
+
+// Usage in API client
+func authorizedRequest(_ endpoint: Endpoint) async throws -> URLRequest {
+    var request = try buildRequest(for: endpoint)
+    let token = try await tokenManager.validToken()
+    request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    return request
+}
+```
+
+### Caching
+---
+
+```swift
+// Configure cache
+let cache = URLCache(
+    memoryCapacity: 50 * 1024 * 1024,   // 50 MB memory
+    diskCapacity: 200 * 1024 * 1024      // 200 MB disk
+)
+config.urlCache = cache
+config.requestCachePolicy = .useProtocolCachePolicy
+
+// Per-request cache policy
+var request = URLRequest(url: url)
+request.cachePolicy = .reloadIgnoringLocalCacheData  // Skip cache
+```
+
+| Policy | Behavior |
+|---|---|
+| `.useProtocolCachePolicy` | Default — follows HTTP cache headers |
+| `.reloadIgnoringLocalCacheData` | Always fetch from network |
+| `.returnCacheDataElseLoad` | Use cache if available, else network |
+| `.returnCacheDataDontLoad` | Cache only — fail if not cached |
+
+### Network Reachability
+---
+
+Use `NWPathMonitor` (Network framework) instead of deprecated `SCNetworkReachability`:
+
+```swift
+import Network
+
+@Observable
+class NetworkMonitor {
+    var isConnected = true
+    var isExpensive = false
+    private let monitor = NWPathMonitor()
+
+    init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            Task { @MainActor in
+                self?.isConnected = path.status == .satisfied
+                self?.isExpensive = path.isExpensive
+            }
+        }
+        monitor.start(queue: DispatchQueue(label: "NetworkMonitor"))
+    }
+
+    deinit {
+        monitor.cancel()
+    }
+}
+```
+
+
+## Alamofire — Convenience Layer
+
+Add Alamofire when you need interceptors, automatic retry, or cleaner certificate pinning. It builds on URLSession — they coexist naturally.
+
+### Setup
+
+```swift
+// Package.swift
+.package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.10.0")
+```
+
+### Basic Requests
+---
+
+```swift
+import Alamofire
+
+// GET with Decodable
+let users: [User] = try await AF.request("https://api.example.com/users")
+    .validate()  // Throws on 4xx/5xx
+    .serializingDecodable([User].self)
+    .value
+
+// POST with JSON body
+let newUser: User = try await AF.request(
+    "https://api.example.com/users",
+    method: .post,
+    parameters: CreateUserRequest(name: "Alice"),
+    encoder: JSONParameterEncoder.default
+)
+.validate()
+.serializingDecodable(User.self)
+.value
+```
+
+### RequestInterceptor (Token Refresh)
+---
+
+The primary reason to adopt Alamofire — automatic token injection and refresh:
+
+```swift
+class AuthInterceptor: RequestInterceptor {
+    private let tokenManager: TokenManager
+
+    init(tokenManager: TokenManager) {
+        self.tokenManager = tokenManager
+    }
+
+    func adapt(_ urlRequest: URLRequest, for session: Session,
+               completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        var request = urlRequest
+        Task {
+            do {
+                let token = try await tokenManager.validToken()
+                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                completion(.success(request))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func retry(_ request: Request, for session: Session, dueTo error: Error,
+               completion: @escaping (RetryResult) -> Void) {
+        guard let response = request.response, response.statusCode == 401,
+              request.retryCount < 1
+        else {
+            completion(.doNotRetry)
+            return
+        }
+
+        Task {
+            do {
+                _ = try await tokenManager.refreshAccessToken()
+                completion(.retry)
+            } catch {
+                completion(.doNotRetryWithError(error))
+            }
+        }
+    }
+}
+
+// Configure session with interceptor
+let session = Session(interceptor: AuthInterceptor(tokenManager: tokenManager))
+```
+
+### Automatic Retry
+---
+
+```swift
+// Built-in retry policy with exponential backoff
+let retryPolicy = RetryPolicy(
+    retryLimit: 3,
+    exponentialBackoffBase: 2,
+    exponentialBackoffScale: 0.5,
+    retryableHTTPMethods: [.get, .put, .delete],
+    retryableHTTPStatusCodes: [408, 500, 502, 503, 504],
+    retryableURLErrorCodes: [
+        .timedOut, .cannotFindHost, .cannotConnectToHost,
+        .networkConnectionLost, .dnsLookupFailed
+    ]
+)
+
+let session = Session(interceptor: retryPolicy)
+```
+
+### Certificate Pinning
+---
+
+```swift
+let evaluators: [String: ServerTrustEvaluating] = [
+    "api.example.com": PinnedCertificatesTrustEvaluator(),         // Pin certificates
+    "cdn.example.com": PublicKeysTrustEvaluator(),                  // Pin public keys
+    "staging.example.com": DisabledTrustEvaluator(),                // Disable (dev only!)
+]
+
+let manager = ServerTrustManager(evaluators: evaluators)
+let session = Session(serverTrustManager: manager)
+```
+
+### Multipart Upload
+---
+
+```swift
+let response = try await AF.upload(
+    multipartFormData: { formData in
+        formData.append(imageData, withName: "avatar",
+                        fileName: "photo.jpg", mimeType: "image/jpeg")
+        formData.append("Alice".data(using: .utf8)!, withName: "name")
+    },
+    to: "https://api.example.com/profile"
+)
+.validate()
+.serializingDecodable(ProfileResponse.self)
+.value
+```
+
+### Download with Progress
+---
+
+```swift
+let destination: DownloadRequest.Destination = { _, _ in
+    let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    return (documentsURL.appendingPathComponent("file.pdf"), [.removePreviousFile, .createIntermediateDirectories])
+}
+
+AF.download("https://example.com/large-file.pdf", to: destination)
+    .downloadProgress { progress in
+        updateProgressUI(progress.fractionCompleted)
+    }
+    .response { response in
+        if let fileURL = response.fileURL {
+            print("Downloaded to: \(fileURL)")
+        }
+    }
+```
+
+### Event Monitor (Logging)
+---
+
+```swift
+let monitor = ClosureEventMonitor()
+monitor.requestDidFinish = { request in
+    print(request.cURLDescription())  // Full cURL command for debugging
+}
+
+let session = Session(eventMonitors: [monitor])
+```
+
+### Coexisting with URLSession
+---
+
+Alamofire's `Session` wraps a `URLSession`. You can use both in the same project:
+
+```swift
+// Alamofire for API calls with auth/retry
+let apiSession = Session(interceptor: authInterceptor)
+
+// URLSession for simple/background tasks
+let backgroundConfig = URLSessionConfiguration.background(withIdentifier: "com.example.bg")
+let backgroundSession = URLSession(configuration: backgroundConfig, delegate: self, delegateQueue: nil)
+```
+
+Common pattern: Alamofire for authenticated API layer, raw URLSession for background downloads, WebSocket, or streaming.
+
+
+## Shared Patterns
+
+### Error Types
+---
+
+```swift
+enum NetworkError: LocalizedError {
+    case invalidResponse
+    case httpError(statusCode: Int, data: Data)
+    case noConnection
+    case timeout
+    case decodingFailed(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse: "Invalid server response"
+        case .httpError(let code, _): "HTTP error \(code)"
+        case .noConnection: "No internet connection"
+        case .timeout: "Request timed out"
+        case .decodingFailed(let error): "Failed to decode response: \(error.localizedDescription)"
+        }
+    }
+
+    init(urlError: URLError) {
+        switch urlError.code {
+        case .notConnectedToInternet, .networkConnectionLost:
+            self = .noConnection
+        case .timedOut:
+            self = .timeout
+        default:
+            self = .invalidResponse
+        }
+    }
+}
+```
+
+### JSON Decoding Configuration
+---
+
+```swift
+let decoder = JSONDecoder()
+decoder.keyDecodingStrategy = .convertFromSnakeCase
+decoder.dateDecodingStrategy = .iso8601
+
+// For custom date formats
+decoder.dateDecodingStrategy = .custom { decoder in
+    let container = try decoder.singleValueContainer()
+    let string = try container.decode(String.self)
+    guard let date = ISO8601DateFormatter().date(from: string) else {
+        throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid date")
+    }
+    return date
+}
+```
+
+### Pagination Pattern
+---
+
+```swift
+struct PagedResponse<T: Decodable>: Decodable {
+    let items: [T]
+    let nextCursor: String?
+    let hasMore: Bool
+}
+
+func fetchAll<T: Decodable>(endpoint: String, type: T.Type) -> AsyncStream<[T]> {
+    AsyncStream { continuation in
+        Task {
+            var cursor: String? = nil
+            repeat {
+                var url = URLComponents(string: baseURL + endpoint)!
+                if let cursor { url.queryItems = [URLQueryItem(name: "cursor", value: cursor)] }
+
+                let (data, _) = try await URLSession.shared.data(from: url.url!)
+                let page = try JSONDecoder().decode(PagedResponse<T>.self, from: data)
+                continuation.yield(page.items)
+                cursor = page.nextCursor
+            } while cursor != nil
+
+            continuation.finish()
+        }
+    }
+}
+```
+
+### Testable Networking
+---
+
+Abstract behind a protocol for testing:
+
+```swift
+protocol HTTPClient: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+// Production
+extension URLSession: HTTPClient {}
+
+// Test
+final class MockHTTPClient: HTTPClient {
+    var stubbedData: Data = Data()
+    var stubbedStatusCode: Int = 200
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: stubbedStatusCode,
+            httpVersion: nil, headerFields: nil
+        )!
+        return (stubbedData, response)
+    }
+}
+
+// API client uses protocol
+final class APIService {
+    private let client: HTTPClient
+
+    init(client: HTTPClient = URLSession.shared) {
+        self.client = client
+    }
+
+    func fetchUsers() async throws -> [User] {
+        let request = URLRequest(url: usersURL)
+        let (data, response) = try await client.data(for: request)
+        // validate and decode...
+    }
+}
+```
+
+
+## Common Pitfalls
+
+| Pitfall | Fix |
+|---|---|
+| Not validating HTTP status codes | URLSession doesn't throw on 4xx/5xx — always check `HTTPURLResponse.statusCode` |
+| Using `URLSession.shared` for everything | Shared session has no delegate and limited configuration. Create custom sessions for auth, caching, background |
+| Blocking main thread with synchronous requests | Always use `async/await` or completion handlers |
+| Not handling `waitsForConnectivity` | Set `config.waitsForConnectivity = true` to avoid immediate failures on poor connectivity |
+| Leaking URLSession | Sessions hold strong references to delegates. Call `finishTasksAndInvalidate()` when done |
+| Ignoring App Transport Security | HTTPS is required by default. Add exceptions in Info.plist only when necessary |
+| Not pausing/resuming downloads properly | Store `resumeData` from `cancel(byProducingResumeData:)`, recreate task with it |
+| Background session with completion handlers | Background sessions require delegates — async/await and completion handlers don't work |
+| Hardcoding base URLs | Use build configuration or Info.plist injection for environment-specific URLs |
+| Not setting `Content-Type` header | POST/PUT requests without `Content-Type: application/json` may be rejected by the server |
+| Certificate pinning in debug builds | Pinning breaks with Charles/Proxyman. Conditionally disable in debug |
+| Ignoring `URLError.cancelled` | Cancelled tasks throw — distinguish cancellation from real errors |

--- a/registry/skills/apple-app-development/references/networking.md
+++ b/registry/skills/apple-app-development/references/networking.md
@@ -113,11 +113,13 @@ final class URLSessionAPIClient: APIClient {
     }
 
     private func buildRequest(for endpoint: Endpoint) throws -> URLRequest {
-        var components = URLComponents(url: baseURL.appendingPathComponent(endpoint.path),
-                                        resolvingAgainstBaseURL: true)!
+        guard var components = URLComponents(url: baseURL.appendingPathComponent(endpoint.path),
+                                              resolvingAgainstBaseURL: true)
+        else { throw NetworkError.invalidResponse }
         components.queryItems = endpoint.queryItems
 
-        var request = URLRequest(url: components.url!)
+        guard let url = components.url else { throw NetworkError.invalidResponse }
+        var request = URLRequest(url: url)
         request.httpMethod = endpoint.method.rawValue
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -409,7 +411,8 @@ actor TokenManager {
         defer { isRefreshing = false }
 
         // Perform refresh
-        let newTokens = try await authService.refresh(refreshToken!)
+        guard let refreshToken else { throw AuthError.noRefreshToken }
+        let newTokens = try await authService.refresh(refreshToken)
         accessToken = newTokens.access
         refreshToken = newTokens.refresh
         return newTokens.access

--- a/registry/skills/apple-app-development/references/persistence.md
+++ b/registry/skills/apple-app-development/references/persistence.md
@@ -107,8 +107,9 @@ let viewContext = container.viewContext
 ```swift
 container.performBackgroundTask { context in
     let request = NSFetchRequest<Task>(entityName: "Task")
-    let tasks = try? context.fetch(request)
-    try? context.save()
+    let tasks = try context.fetch(request)
+    // ... mutate ...
+    try context.save()
 }
 // Creates a new private-queue context each call. Avoid in tight loops — creates many threads.
 ```
@@ -135,7 +136,7 @@ let objectID = backgroundTask.objectID
 
 // On main context
 await MainActor.run {
-    let mainTask = viewContext.object(with: objectID) as! Task
+    let mainTask = viewContext.object(with: objectID) as! Task // Safe: objectID guarantees entity type
 }
 ```
 
@@ -264,7 +265,7 @@ customStage.willMigrateHandler = { migrationManager, currentStage in
 }
 
 let manager = NSStagedMigrationManager([lightweightStage, customStage])
-let description = container.persistentStoreDescriptions.first!
+guard let description = container.persistentStoreDescriptions.first else { return }
 description.setOption(manager, forKey: NSPersistentStoreStagedMigrationManagerOptionKey)
 ```
 
@@ -273,13 +274,15 @@ description.setOption(manager, forKey: NSPersistentStoreStagedMigrationManagerOp
 Required for elaborate changes beyond staged capabilities (splitting entities, complex data transformations):
 
 ```swift
-let mapping = NSMappingModel(from: [Bundle.main],
-                              forSourceModel: sourceModel,
-                              destinationModel: destModel)
+guard let mapping = NSMappingModel(from: [Bundle.main],
+                                    forSourceModel: sourceModel,
+                                    destinationModel: destModel)
+else { fatalError("No mapping model found for \(sourceModel) -> \(destModel)") }
+
 let manager = NSMigrationManager(sourceModel: sourceModel,
                                   destinationModel: destModel)
 try manager.migrateStore(from: sourceURL, type: .sqlite,
-                          mapping: mapping!, to: destURL, type: .sqlite)
+                          mapping: mapping, to: destURL, type: .sqlite)
 ```
 
 **Best practice:** Test each migration step with real data. Use staged migrations when possible — they are simpler and less error-prone than manual.
@@ -294,7 +297,7 @@ Batch operations execute directly at the SQLite level, bypassing the managed obj
 ```swift
 let request = NSBatchInsertRequest(entity: Task.entity(),
                                     managedObjectHandler: { obj in
-    let task = obj as! Task
+    let task = obj as! Task // Safe: entity type matches NSBatchInsertRequest
     task.title = nextItem.title
     task.dueDate = nextItem.dueDate
     return false  // return true when done

--- a/registry/skills/apple-app-development/references/persistence.md
+++ b/registry/skills/apple-app-development/references/persistence.md
@@ -1,0 +1,1128 @@
+# Persistence Reference (Core Data & SwiftData)
+
+Comprehensive guide to data persistence on Apple platforms. Covers Core Data (mature, full-featured) and SwiftData (iOS 17+, Swift-native). Use this reference for stack setup, CRUD, concurrency, migrations, performance, CloudKit sync, and testing.
+
+## When to Use Which
+
+| Criterion | SwiftData | Core Data |
+|---|---|---|
+| **Minimum target** | iOS 17+ | iOS 11+ |
+| **Boilerplate** | Minimal (`@Model` macro) | Significant (`.xcdatamodeld`, codegen) |
+| **SwiftUI integration** | Native (`@Query`, `.modelContainer`) | Workable (`@FetchRequest`) |
+| **UIKit support** | Possible but awkward | First-class (`NSFetchedResultsController`) |
+| **Undo/Redo** | Not built-in | Built-in (`NSUndoManager`) |
+| **Complex predicates** | `#Predicate` (limited composition) | `NSCompoundPredicate` (flexible) |
+| **Batch operations** | Limited | `NSBatchInsertRequest`, etc. |
+| **CloudKit** | Supported (with constraints) | `NSPersistentCloudKitContainer` (mature) |
+| **Performance at scale** | Good, slightly behind | Optimized over 15+ years |
+| **Migrations** | `VersionedSchema` (still maturing) | Lightweight + heavyweight (battle-tested) |
+| **Custom data stores** | iOS 18+ `DataStore` protocol | N/A |
+
+**Guidance:**
+- **New SwiftUI-only projects (iOS 17+):** Start with SwiftData unless you need batch operations, undo/redo, or complex predicate composition.
+- **Existing Core Data apps:** Migrate strategically. SwiftData and Core Data can coexist — they share the same SQLite backing store.
+- **Apps requiring UIKit + advanced features:** Core Data remains the stronger choice.
+- **Widgets/extensions for Core Data apps:** Consider using SwiftData in the extension while the main app stays on Core Data, sharing the same store via App Groups.
+
+
+## Core Data
+
+### Stack Setup
+---
+
+```swift
+import CoreData
+
+final class PersistenceController: Sendable {
+    static let shared = PersistenceController()
+
+    let container: NSPersistentContainer
+
+    init(inMemory: Bool = false) {
+        container = NSPersistentContainer(name: "MyModel")
+
+        if inMemory {
+            container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+        }
+
+        container.loadPersistentStores { _, error in
+            if let error { fatalError("Core Data store failed: \(error.localizedDescription)") }
+        }
+
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+    }
+}
+```
+
+Rules:
+- Use `/dev/null` as the store URL for tests instead of `NSInMemoryStoreType` — it uses a real SQLite engine so cascade deletes and other SQLite-specific behaviors work correctly.
+- Set `automaticallyMergesChangesFromParent = true` on `viewContext` so background saves propagate to the UI.
+- Set a merge policy (typically `NSMergeByPropertyObjectTrumpMergePolicy`) to handle conflicts.
+
+### NSManagedObject Codegen Modes
+---
+
+| Mode | When to use |
+|---|---|
+| **Class Definition** | Simple models, rapid prototyping. Xcode generates both class and properties. |
+| **Category/Extension** | You write the class, Xcode generates a properties extension. Best for adding custom logic. |
+| **Manual/None** | Full control. Required for transient properties, custom accessors. |
+
+For production apps, **Category/Extension** is the most common — add computed properties, validation, and convenience methods while Xcode handles the `@NSManaged` boilerplate.
+
+```swift
+// With Category/Extension codegen, you write this:
+@objc(Task)
+public class Task: NSManagedObject {
+    var isOverdue: Bool {
+        guard let dueDate else { return false }
+        return dueDate < Date.now
+    }
+
+    public override func validateForInsert() throws {
+        try super.validateForInsert()
+        guard let title, !title.isEmpty else {
+            throw ValidationError.missingTitle
+        }
+    }
+}
+// Xcode generates the +CoreDataProperties extension with @NSManaged vars
+```
+
+### Context Concurrency
+---
+
+Core Data offers three context patterns. Critical rule: **never access a managed object or context on the wrong queue**.
+
+#### viewContext (Main Queue)
+
+```swift
+let viewContext = container.viewContext
+// Always tied to main queue. Safe from @MainActor code and SwiftUI views.
+```
+
+#### performBackgroundTask (Ephemeral)
+
+```swift
+container.performBackgroundTask { context in
+    let request = NSFetchRequest<Task>(entityName: "Task")
+    let tasks = try? context.fetch(request)
+    try? context.save()
+}
+// Creates a new private-queue context each call. Avoid in tight loops — creates many threads.
+```
+
+#### newBackgroundContext (Reusable)
+
+```swift
+let backgroundContext = container.newBackgroundContext()
+backgroundContext.automaticallyMergesChangesFromParent = true
+
+backgroundContext.perform {
+    // fetch, mutate, save
+    try? backgroundContext.save()
+}
+```
+
+#### Passing Objects Across Queues
+
+Never pass `NSManagedObject` instances between queues. Use `NSManagedObjectID`:
+
+```swift
+// On background context
+let objectID = backgroundTask.objectID
+
+// On main context
+await MainActor.run {
+    let mainTask = viewContext.object(with: objectID) as! Task
+}
+```
+
+#### Swift 6 Strict Concurrency
+
+Swift 6 flags `NSManagedObject` and `NSManagedObjectContext` as non-`Sendable`. Strategies:
+- Use `@preconcurrency import CoreData` as a transitional measure.
+- Pass only `NSManagedObjectID` (which is `Sendable`) across isolation boundaries.
+- Wrap Core Data access behind an actor that owns a private-queue context.
+
+### Fetch Requests & Predicates
+---
+
+```swift
+let request = NSFetchRequest<Task>(entityName: "Task")
+request.predicate = NSPredicate(format: "isCompleted == %@ AND dueDate < %@",
+                                 NSNumber(value: false), Date.now as NSDate)
+request.sortDescriptors = [
+    NSSortDescriptor(keyPath: \Task.dueDate, ascending: true),
+    NSSortDescriptor(keyPath: \Task.priority, ascending: false)
+]
+request.fetchBatchSize = 20
+request.fetchLimit = 100
+request.relationshipKeyPathsForPrefetching = ["assignee"]
+```
+
+#### NSFetchedResultsController (UIKit)
+
+```swift
+let frc = NSFetchedResultsController(
+    fetchRequest: request,
+    managedObjectContext: viewContext,
+    sectionNameKeyPath: "category",
+    cacheName: "TaskCache"
+)
+frc.delegate = self
+try frc.performFetch()
+
+// Modern delegate — integrates with diffable data sources
+func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>,
+                didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {
+    let snapshot = snapshot as NSDiffableDataSourceSnapshot<String, NSManagedObjectID>
+    dataSource.apply(snapshot, animatingDifferences: true)
+}
+```
+
+### Relationships
+---
+
+| Type | Definition | Notes |
+|---|---|---|
+| **One-to-many** | Parent has `NSSet` of children; child has single parent ref | Always define inverse |
+| **Many-to-many** | Both sides are `NSSet` | Core Data manages the join table |
+
+**Always define inverse relationships.** Core Data uses inverses to maintain referential integrity. Omitting them causes Xcode warnings and can lead to data inconsistency.
+
+#### Delete Rules
+
+| Rule | Behavior |
+|---|---|
+| **Cascade** | Deleting the source deletes all related objects |
+| **Nullify** | Sets the inverse relationship to nil |
+| **Deny** | Prevents deletion if related objects exist |
+| **No Action** | Does nothing (dangerous — can leave orphans) |
+
+Best practice: **Cascade** from parent to children, **Nullify** from child to parent.
+
+### Migrations
+---
+
+#### Lightweight (Preferred)
+
+Core Data infers the mapping automatically. Supported changes (per Apple docs):
+
+| Change | Supported |
+|---|---|
+| Add/remove an attribute | Yes |
+| Non-optional → optional | Yes |
+| Optional → non-optional (with default value) | Yes |
+| Rename entity or property (with renaming identifier) | Yes |
+| Add/remove/rename a relationship | Yes |
+| To-one → to-many | Yes |
+| Ordered ↔ unordered to-many | Yes |
+| Add/remove/rename entities in a hierarchy | Yes |
+| Move properties up/down entity hierarchy | Yes |
+| Merge entity hierarchies | **No** |
+
+Since iOS 17+, `NSPersistentContainer` attempts lightweight migration by default — no extra code needed. For explicit control:
+
+```swift
+let options = [
+    NSMigratePersistentStoresAutomaticallyOption: true,
+    NSInferMappingModelAutomaticallyOption: true
+]
+try coordinator.addPersistentStore(type: .sqlite, at: storeURL, options: options)
+```
+
+**Renaming identifiers** create a canonical name that works across multi-version migrations (V1→V3 works even if V2 renamed the property). Set them in the destination model's Data Model Inspector.
+
+#### Staged Migrations
+
+Staged lightweight migrations (iOS 17+) break incompatible changes into a series of compatible stages. Use when lightweight alone can't handle the change — e.g., making an optional attribute non-optional requires setting `nil` values to concrete values first.
+
+Key components:
+- **`NSStagedMigrationManager`** — orchestrates stages sequentially
+- **`NSLightweightMigrationStage`** — a stage that Core Data can infer automatically
+- **`NSCustomMigrationStage`** — a stage with custom pre/post-migration logic
+
+```swift
+let lightweightStage = NSLightweightMigrationStage(["ModelV1", "ModelV2"])
+
+let customStage = NSCustomMigrationStage(
+    migratingFrom: modelV2,
+    to: modelV3
+)
+customStage.willMigrateHandler = { migrationManager, currentStage in
+    let context = migrationManager.container.newBackgroundContext()
+    try await context.perform {
+        // Set nil values before non-optional constraint takes effect
+        let request = NSFetchRequest<NSManagedObject>(entityName: "Task")
+        request.predicate = NSPredicate(format: "priority == nil")
+        let tasks = try context.fetch(request)
+        for task in tasks { task.setValue(0, forKey: "priority") }
+        try context.save()
+    }
+}
+
+let manager = NSStagedMigrationManager([lightweightStage, customStage])
+let description = container.persistentStoreDescriptions.first!
+description.setOption(manager, forKey: NSPersistentStoreStagedMigrationManagerOptionKey)
+```
+
+#### Manual (Heavyweight) Migrations
+
+Required for elaborate changes beyond staged capabilities (splitting entities, complex data transformations):
+
+```swift
+let mapping = NSMappingModel(from: [Bundle.main],
+                              forSourceModel: sourceModel,
+                              destinationModel: destModel)
+let manager = NSMigrationManager(sourceModel: sourceModel,
+                                  destinationModel: destModel)
+try manager.migrateStore(from: sourceURL, type: .sqlite,
+                          mapping: mapping!, to: destURL, type: .sqlite)
+```
+
+**Best practice:** Test each migration step with real data. Use staged migrations when possible — they are simpler and less error-prone than manual.
+
+### Batch Operations
+---
+
+Batch operations execute directly at the SQLite level, bypassing the managed object context. Dramatically faster for bulk work but require manual in-memory synchronization.
+
+#### NSBatchInsertRequest
+
+```swift
+let request = NSBatchInsertRequest(entity: Task.entity(),
+                                    managedObjectHandler: { obj in
+    let task = obj as! Task
+    task.title = nextItem.title
+    task.dueDate = nextItem.dueDate
+    return false  // return true when done
+})
+request.resultType = .objectIDs
+
+let result = try context.execute(request) as? NSBatchInsertResult
+let objectIDs = result?.result as? [NSManagedObjectID] ?? []
+
+NSManagedObjectContext.mergeChanges(
+    fromRemoteContextSave: [NSInsertedObjectsKey: objectIDs],
+    into: [container.viewContext]
+)
+```
+
+#### NSBatchDeleteRequest
+
+```swift
+let fetchRequest: NSFetchRequest<NSFetchRequestResult> = Task.fetchRequest()
+fetchRequest.predicate = NSPredicate(format: "isCompleted == YES")
+
+let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+deleteRequest.resultType = .resultTypeObjectIDs
+
+let result = try context.execute(deleteRequest) as? NSBatchDeleteResult
+let deletedIDs = result?.result as? [NSManagedObjectID] ?? []
+
+NSManagedObjectContext.mergeChanges(
+    fromRemoteContextSave: [NSDeletedObjectsKey: deletedIDs],
+    into: [container.viewContext]
+)
+```
+
+**Limitations:** Batch inserts cannot set relationships. Batch deletes don't fire cascade rules in the context — only at the SQLite level. Always merge changes back to keep in-memory state consistent.
+
+#### Merging Batch Changes via Persistent History Tracking
+
+`NSBatchInsertRequest` bypasses the context and doesn't trigger `NSManagedObjectContextDidSave` notifications. For large data feeds, use Persistent History Tracking instead of manual `mergeChanges`:
+
+```swift
+// 1. Enable on store description (required)
+description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+description.setOption(true as NSNumber,
+                       forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+
+// 2. Observe remote change notifications
+NotificationCenter.default.addObserver(
+    self, selector: #selector(storeRemoteChange),
+    name: .NSPersistentStoreRemoteChange, object: container.persistentStoreCoordinator
+)
+
+// 3. Fetch and merge history transactions
+@objc func storeRemoteChange(_ notification: Notification) {
+    let backgroundContext = container.newBackgroundContext()
+    backgroundContext.perform {
+        let request = NSPersistentHistoryChangeRequest.fetchHistory(after: self.lastToken)
+        guard let result = try? backgroundContext.execute(request) as? NSPersistentHistoryResult,
+              let transactions = result.result as? [NSPersistentHistoryTransaction]
+        else { return }
+
+        for transaction in transactions {
+            self.container.viewContext.perform {
+                self.container.viewContext.mergeChanges(
+                    fromContextDidSave: transaction.objectIDNotification()
+                )
+            }
+            self.lastToken = transaction.token
+        }
+    }
+}
+```
+
+This pattern is essential for multi-process scenarios (app + widget sharing a store) and large data imports where `automaticallyMergesChangesFromParent` can cause excessive memory growth.
+
+### Performance Tuning
+---
+
+| Parameter | Purpose | Recommendation |
+|---|---|---|
+| `fetchBatchSize` | Loads objects in batches (default 0 = all at once) | Set to 20–50 for large collections |
+| `fetchLimit` | Caps total number of results | Use when you only need "top N" |
+| `relationshipKeyPathsForPrefetching` | Eagerly loads specified relationships | Set for any relationship you'll access in a list |
+| `includesPropertyValues` | If `false`, returns faults without pre-loading attributes | Use for existence checks or delete-only fetches |
+| `returnsObjectsAsFaults` | If `false`, fully materializes objects immediately | Use when you know you need all attributes |
+| `propertiesToFetch` | Fetch only specific attributes | Reduces I/O for partial reads |
+
+Core Data lazily loads objects as "faults" — placeholders that trigger a database read only when a property is accessed. This keeps memory low but can cause N+1 query problems in large collections. Use `relationshipKeyPathsForPrefetching` and `fetchBatchSize` to mitigate.
+
+### Core Data + CloudKit
+---
+
+```swift
+let container = NSPersistentCloudKitContainer(name: "MyModel")
+
+let description = container.persistentStoreDescriptions.first!
+description.cloudKitContainerOptions = NSPersistentCloudKitContainerOptions(
+    containerIdentifier: "iCloud.com.example.app"
+)
+
+// Required for CloudKit sync
+description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+description.setOption(true as NSNumber,
+                       forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+
+container.loadPersistentStores { _, error in
+    if let error { fatalError("CloudKit store failed: \(error)") }
+}
+
+#if DEBUG
+try? container.initializeCloudKitSchema(options: [])
+#endif
+```
+
+Requirements:
+- All attributes must have default values or be optional.
+- Unique constraints are not supported with CloudKit sync.
+- Relationships must be optional.
+- `initializeCloudKitSchema()` is expensive — run only in debug builds.
+- Deploy the schema to production via the CloudKit Dashboard before shipping.
+
+### Core Data + SwiftUI
+---
+
+```swift
+// App entry point
+@main
+struct MyApp: App {
+    let persistence = PersistenceController.shared
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(\.managedObjectContext, persistence.container.viewContext)
+        }
+    }
+}
+
+// In a view
+struct TaskListView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+
+    @FetchRequest(
+        sortDescriptors: [SortDescriptor(\.dueDate, order: .forward)],
+        predicate: NSPredicate(format: "isCompleted == NO"),
+        animation: .default
+    )
+    private var tasks: FetchedResults<Task>
+
+    var body: some View {
+        List(tasks) { task in
+            TaskRow(task: task)
+        }
+    }
+}
+```
+
+For **dynamic filtering**, wrap `@FetchRequest` in a child view whose initializer accepts filter parameters:
+
+```swift
+struct FilteredTaskList: View {
+    @FetchRequest var tasks: FetchedResults<Task>
+
+    init(category: String) {
+        _tasks = FetchRequest(
+            sortDescriptors: [SortDescriptor(\.dueDate)],
+            predicate: NSPredicate(format: "category == %@", category)
+        )
+    }
+
+    var body: some View {
+        List(tasks) { task in TaskRow(task: task) }
+    }
+}
+```
+
+
+## SwiftData (iOS 17+)
+
+### @Model, ModelContainer, ModelContext
+---
+
+```swift
+import SwiftData
+
+// @Model replaces NSManagedObject + .xcdatamodeld
+@Model
+final class Trip {
+    var name: String
+    var startDate: Date
+    var endDate: Date
+    var isCompleted: Bool = false
+
+    @Relationship(deleteRule: .cascade, inverse: \Activity.trip)
+    var activities: [Activity] = []
+
+    init(name: String, startDate: Date, endDate: Date) {
+        self.name = name
+        self.startDate = startDate
+        self.endDate = endDate
+    }
+}
+
+@Model
+final class Activity {
+    var title: String
+    var trip: Trip?
+
+    init(title: String) {
+        self.title = title
+    }
+}
+```
+
+```swift
+// ModelContainer replaces NSPersistentContainer
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .modelContainer(for: [Trip.self, Activity.self])
+    }
+}
+```
+
+```swift
+// ModelContext replaces NSManagedObjectContext
+struct ContentView: View {
+    @Environment(\.modelContext) private var modelContext
+
+    func addTrip() {
+        let trip = Trip(name: "Iceland", startDate: .now,
+                        endDate: .now.addingTimeInterval(86400 * 7))
+        modelContext.insert(trip)
+        // SwiftData auto-saves; explicit save() is optional but available
+    }
+}
+```
+
+### @Query
+---
+
+`@Query` is SwiftData's equivalent of `@FetchRequest`:
+
+```swift
+struct TripListView: View {
+    @Query(sort: \Trip.startDate, order: .reverse)
+    private var trips: [Trip]
+
+    var body: some View {
+        List(trips) { trip in
+            TripRow(trip: trip)
+        }
+    }
+}
+```
+
+#### Filtering with #Predicate
+
+```swift
+@Query(filter: #Predicate<Trip> { trip in
+    trip.isCompleted == false && trip.name.contains("Europe")
+}, sort: \Trip.startDate)
+private var upcomingTrips: [Trip]
+```
+
+#### Multiple Sort Descriptors
+
+```swift
+@Query(sort: [
+    SortDescriptor(\Trip.startDate, order: .reverse),
+    SortDescriptor(\Trip.name)
+])
+private var trips: [Trip]
+```
+
+#### Dynamic Queries
+
+```swift
+struct FilteredTrips: View {
+    @Query private var trips: [Trip]
+
+    init(searchText: String) {
+        let predicate = #Predicate<Trip> { trip in
+            searchText.isEmpty || trip.name.localizedStandardContains(searchText)
+        }
+        _trips = Query(filter: predicate, sort: \Trip.startDate)
+    }
+
+    var body: some View {
+        List(trips) { trip in Text(trip.name) }
+    }
+}
+```
+
+**Limitation:** `#Predicate` does not support `NSCompoundPredicate`-style composition. Complex multi-step predicates require building the logic inline within the closure.
+
+### Relationships and Delete Rules
+---
+
+```swift
+@Model
+final class Author {
+    var name: String
+
+    @Relationship(deleteRule: .cascade, inverse: \Book.author)
+    var books: [Book] = []
+
+    init(name: String) { self.name = name }
+}
+
+@Model
+final class Book {
+    var title: String
+    var author: Author?
+
+    init(title: String) { self.title = title }
+}
+```
+
+Supported delete rules: `.cascade`, `.nullify`, `.deny`, `.noAction` — same semantics as Core Data.
+
+For CloudKit sync, **all relationships must be optional** and `@Attribute(.unique)` is not allowed.
+
+### Schema Migrations
+---
+
+```swift
+// 1. Define schema versions
+enum SchemaV1: VersionedSchema {
+    static var versionIdentifier = Schema.Version(1, 0, 0)
+    static var models: [any PersistentModel.Type] { [Trip.self] }
+
+    @Model final class Trip {
+        var name: String
+        var startDate: Date
+        init(name: String, startDate: Date) {
+            self.name = name
+            self.startDate = startDate
+        }
+    }
+}
+
+enum SchemaV2: VersionedSchema {
+    static var versionIdentifier = Schema.Version(2, 0, 0)
+    static var models: [any PersistentModel.Type] { [Trip.self] }
+
+    @Model final class Trip {
+        var name: String
+        var startDate: Date
+        var endDate: Date?  // New property
+        init(name: String, startDate: Date, endDate: Date? = nil) {
+            self.name = name
+            self.startDate = startDate
+            self.endDate = endDate
+        }
+    }
+}
+
+// 2. Define migration plan
+enum TripMigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any VersionedSchema.Type] {
+        [SchemaV1.self, SchemaV2.self]
+    }
+
+    static var stages: [MigrationStage] {
+        [migrateV1toV2]
+    }
+
+    static let migrateV1toV2 = MigrationStage.lightweight(
+        fromVersion: SchemaV1.self,
+        toVersion: SchemaV2.self
+    )
+}
+
+// 3. Use in container
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup { ContentView() }
+            .modelContainer(for: SchemaV2.Trip.self,
+                             migrationPlan: TripMigrationPlan.self)
+    }
+}
+```
+
+For **custom migrations** (when lightweight won't work):
+
+```swift
+static let migrateV1toV2 = MigrationStage.custom(
+    fromVersion: SchemaV1.self,
+    toVersion: SchemaV2.self,
+    willMigrate: { context in
+        let trips = try context.fetch(FetchDescriptor<SchemaV1.Trip>())
+        // Custom logic: deduplicate, transform data
+        try context.save()
+    },
+    didMigrate: nil
+)
+```
+
+### ModelActor for Background Operations
+---
+
+`@ModelActor` creates a dedicated actor with its own `ModelContext`:
+
+```swift
+@ModelActor
+actor TripDataHandler {
+    func importTrips(from dtos: [TripDTO]) throws {
+        for dto in dtos {
+            let trip = Trip(name: dto.name, startDate: dto.startDate, endDate: dto.endDate)
+            modelContext.insert(trip)
+        }
+        try modelContext.save()
+    }
+
+    func fetchTripIDs(matching name: String) throws -> [PersistentIdentifier] {
+        let predicate = #Predicate<Trip> { $0.name.contains(name) }
+        let descriptor = FetchDescriptor(predicate: predicate)
+        return try modelContext.fetch(descriptor).map(\.persistentModelID)
+    }
+}
+```
+
+#### Passing Data Across Actor Boundaries
+
+`PersistentModel` is not `Sendable`. Use `PersistentIdentifier` (which is `Sendable`) or DTOs:
+
+```swift
+struct TripDTO: Sendable {
+    let name: String
+    let startDate: Date
+    let endDate: Date
+}
+
+// From @MainActor context
+let handler = TripDataHandler(modelContainer: modelContainer)
+let ids = try await handler.fetchTripIDs(matching: "Europe")
+
+// Resolve on main context
+for id in ids {
+    if let trip = modelContext.model(for: id) as? Trip {
+        print(trip.name)
+    }
+}
+```
+
+#### ModelActor Subscript
+
+```swift
+@ModelActor
+actor BackgroundProcessor {
+    func processTrip(id: PersistentIdentifier) throws {
+        guard let trip = self[id, as: Trip.self] else { return }
+        trip.isCompleted = true
+        try modelContext.save()
+    }
+}
+```
+
+### SwiftData + CloudKit
+---
+
+```swift
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup { ContentView() }
+            .modelContainer(for: Trip.self)
+        // CloudKit sync is automatic when:
+        // 1. iCloud capability with CloudKit is enabled
+        // 2. Background Modes with Remote Notifications is enabled
+        // 3. A CloudKit container identifier is configured
+    }
+}
+```
+
+To specify the CloudKit container explicitly:
+
+```swift
+let config = ModelConfiguration(
+    cloudKitDatabase: .private("iCloud.com.example.app")
+)
+let container = try ModelContainer(for: Trip.self, configurations: config)
+```
+
+Constraints (same as Core Data + CloudKit):
+- No `@Attribute(.unique)` — CloudKit does not support unique constraints.
+- All properties must have default values or be optional.
+- All relationships must be optional.
+- Only the private CloudKit database is supported.
+
+### iOS 18+ Features
+---
+
+#### #Unique — Composite Unique Constraints
+
+```swift
+@Model
+final class Trip {
+    #Unique<Trip>([\.name, \.startDate, \.endDate])
+
+    var name: String
+    var startDate: Date
+    var endDate: Date
+
+    init(name: String, startDate: Date, endDate: Date) {
+        self.name = name
+        self.startDate = startDate
+        self.endDate = endDate
+    }
+}
+// On collision, SwiftData performs an upsert rather than creating a duplicate.
+```
+
+#### #Index — Query Performance
+
+```swift
+@Model
+final class Trip {
+    #Index<Trip>([\.name], [\.startDate, \.endDate])
+
+    var name: String
+    var startDate: Date
+    var endDate: Date
+    // ...
+}
+// Creates indexes for fast lookups by name and by date range.
+// Use #Index once per model — list all indexes in one call.
+```
+
+#### History Tracking
+
+SwiftData History organizes changes as chronological transactions. Each transaction groups one or more inserts, updates, or deletes that occurred when `ModelContext` saved.
+
+```swift
+@Model
+final class Trip {
+    // Preserve key values in tombstone on deletion — enables identification across processes
+    @Attribute(.preserveValueOnDeletion)
+    var bookingRef: String
+
+    var name: String
+    var startDate: Date
+    // ...
+}
+```
+
+##### Fetching History
+
+Use `HistoryDescriptor` with `DefaultToken` to fetch only transactions since the last sync:
+
+```swift
+func fetchTransactions(after tokenData: Data?) throws -> [DefaultHistoryTransaction] {
+    let context = ModelContext(modelContainer)
+    var descriptor = HistoryDescriptor<DefaultHistoryTransaction>()
+
+    if let tokenData {
+        let token = try JSONDecoder().decode(DefaultHistoryToken.self, from: tokenData)
+        descriptor.predicate = #Predicate { $0.token > token }
+    }
+
+    return try context.fetchHistory(descriptor)
+}
+```
+
+##### Processing Changes
+
+Transactions contain heterogeneous changes across model types. Filter by type and inspect attributes:
+
+```swift
+for transaction in transactions {
+    for change in transaction.changes {
+        if let insert = change as? DefaultHistoryInsert<Trip> {
+            let tripID = insert.changedModelID
+            // Fetch and process new trip
+        } else if let update = change as? DefaultHistoryUpdate<Trip> {
+            let updatedKeys = update.updatedAttributes
+            // React to specific attribute changes
+        } else if let deletion = change as? DefaultHistoryDelete<Trip> {
+            // Access preserved values via tombstone
+            let bookingRef = deletion.tombstone[\.bookingRef]
+        }
+    }
+}
+```
+
+##### Tagging Transactions with Authors
+
+Set `ModelContext.author` to identify transaction origins (app vs widget vs background sync):
+
+```swift
+let context = ModelContext(modelContainer)
+context.author = "widget"
+// ... mutations ...
+try context.save()
+
+// Later, filter by author
+descriptor.predicate = #Predicate { $0.author == "widget" }
+```
+
+##### Cleaning Up History
+
+Delete stale transactions to prevent excessive storage. If you fetch with an expired token, SwiftData throws `SwiftDataError.historyTokenExpired`.
+
+```swift
+func deleteHistory(before token: DefaultHistoryToken) throws {
+    let context = ModelContext(modelContainer)
+    var descriptor = HistoryDescriptor<DefaultHistoryTransaction>()
+    descriptor.predicate = #Predicate { $0.token < token }
+    try context.deleteHistory(descriptor)
+}
+```
+
+Use cases: remote server sync, out-of-process change handling (widget detects main app changes), audit logging.
+
+##### Server Data Caching Pattern
+
+For read-only caches of server data, combine `@Attribute(.unique)` with SwiftData's automatic upsert:
+
+```swift
+@Model
+final class Quake {
+    @Attribute(.unique) var code: String  // Server-side unique ID
+    var magnitude: Double
+    var time: Date
+
+    init(code: String, magnitude: Double, time: Date) {
+        self.code = code
+        self.magnitude = magnitude
+        self.time = time
+    }
+}
+
+// Insert-or-update: SwiftData checks unique constraint automatically
+for dto in serverResponse.items {
+    let quake = Quake(code: dto.code, magnitude: dto.magnitude, time: dto.time)
+    modelContext.insert(quake)  // Updates existing if code matches
+}
+// autosaveEnabled (default true) handles persistence
+```
+
+#### Custom Data Stores
+
+The `DataStore` protocol lets you replace SQLite with any persistence backend:
+
+```swift
+struct JSONDataStore: DataStore {
+    typealias Configuration = JSONStoreConfiguration
+    typealias Snapshot = DefaultSnapshot
+
+    func fetch<T>(_ request: DataStoreFetchRequest<T>) throws
+        -> DataStoreFetchResult<T, DefaultSnapshot> {
+        // Read from JSON file, create snapshots
+    }
+
+    func save(_ request: DataStoreSaveChangesRequest<DefaultSnapshot>) throws
+        -> DataStoreSaveChangesResult<DefaultSnapshot> {
+        // Write changes to JSON file
+    }
+}
+
+struct JSONStoreConfiguration: DataStoreConfiguration {
+    var name: String
+    var schema: Schema?
+    var fileURL: URL
+
+    static func == (lhs: Self, rhs: Self) -> Bool { lhs.fileURL == rhs.fileURL }
+    func hash(into hasher: inout Hasher) { hasher.combine(fileURL) }
+}
+```
+
+
+## Shared Patterns
+
+### App Groups (Sharing Data with Extensions/Widgets)
+---
+
+```swift
+let appGroupID = "group.com.example.app"
+
+// SwiftData
+let config = ModelConfiguration(groupContainer: .identifier(appGroupID))
+let container = try ModelContainer(for: Trip.self, configurations: config)
+
+// Core Data
+let storeURL = FileManager.default
+    .containerURL(forSecurityApplicationGroupIdentifier: appGroupID)!
+    .appendingPathComponent("Model.sqlite")
+let description = NSPersistentStoreDescription(url: storeURL)
+```
+
+Enable **Persistent History Tracking** when sharing stores between processes — it ensures each process can detect and merge changes made by others.
+
+### Data Validation
+---
+
+**Core Data** — override `validateForInsert()` and `validateForUpdate()`:
+
+```swift
+class Task: NSManagedObject {
+    public override func validateForInsert() throws {
+        try super.validateForInsert()
+        guard let title, !title.isEmpty else {
+            throw NSError(domain: "Validation", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "Title cannot be empty"])
+        }
+    }
+}
+```
+
+**SwiftData** — validate in `init` or use a repository layer:
+
+```swift
+@Model
+final class Task {
+    var title: String
+
+    init(title: String) {
+        precondition(!title.isEmpty, "Title must not be empty")
+        self.title = title
+    }
+}
+```
+
+### Testing with In-Memory Stores
+---
+
+```swift
+// SwiftData
+@Test func tripCreation() async throws {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    let container = try ModelContainer(for: Trip.self, configurations: config)
+    let context = ModelContext(container)
+
+    let trip = Trip(name: "Test", startDate: .now, endDate: .now)
+    context.insert(trip)
+    try context.save()
+
+    let trips = try context.fetch(FetchDescriptor<Trip>())
+    #expect(trips.count == 1)
+    #expect(trips.first?.name == "Test")
+}
+
+// Core Data — use /dev/null for full SQLite behavior
+func makeTestContainer() -> NSPersistentContainer {
+    let container = NSPersistentContainer(name: "Model")
+    let description = NSPersistentStoreDescription()
+    description.url = URL(fileURLWithPath: "/dev/null")
+    container.persistentStoreDescriptions = [description]
+    container.loadPersistentStores { _, error in
+        if let error { fatalError("Test store failed: \(error)") }
+    }
+    return container
+}
+```
+
+Prefer `/dev/null` over `NSInMemoryStoreType` for Core Data tests — cascade delete rules and other SQLite-specific behaviors work identically to production.
+
+### Repository Pattern
+---
+
+Abstract persistence behind a protocol to decouple business logic from Core Data/SwiftData:
+
+```swift
+protocol TripRepository: Sendable {
+    func fetchAll() async throws -> [TripDTO]
+    func fetch(id: String) async throws -> TripDTO?
+    func save(_ dto: TripDTO) async throws
+    func delete(id: String) async throws
+}
+
+// SwiftData implementation
+@ModelActor
+actor SwiftDataTripRepository: TripRepository {
+    func fetchAll() async throws -> [TripDTO] {
+        let descriptor = FetchDescriptor<Trip>(sortBy: [SortDescriptor(\.startDate)])
+        return try modelContext.fetch(descriptor).map { $0.toDTO() }
+    }
+
+    func save(_ dto: TripDTO) async throws {
+        let trip = Trip(name: dto.name, startDate: dto.startDate, endDate: dto.endDate)
+        modelContext.insert(trip)
+        try modelContext.save()
+    }
+
+    func fetch(id: String) async throws -> TripDTO? { /* ... */ }
+    func delete(id: String) async throws { /* ... */ }
+}
+
+// In-memory implementation for tests and previews
+actor InMemoryTripRepository: TripRepository {
+    private var storage: [String: TripDTO] = [:]
+
+    func fetchAll() async throws -> [TripDTO] {
+        Array(storage.values).sorted { $0.startDate < $1.startDate }
+    }
+
+    func save(_ dto: TripDTO) async throws { storage[dto.id] = dto }
+    func fetch(id: String) async throws -> TripDTO? { storage[id] }
+    func delete(id: String) async throws { storage[id] = nil }
+}
+```
+
+Benefits:
+- Swap implementations for tests, previews, or future backend changes.
+- Business logic never imports `SwiftData` or `CoreData`.
+- Actor-based repositories prevent data races in Swift 6 strict concurrency.
+- DTOs crossing actor boundaries are `Sendable` value types.
+
+
+## Common Pitfalls
+
+| Pitfall | Fix |
+|---|---|
+| Accessing `viewContext` from a background thread | Use `perform { }` or `performBackgroundTask`. Enable `-com.apple.CoreData.ConcurrencyDebug 1` to catch violations |
+| Forgetting to call `save()` on background context | Changes are discarded. Always save after mutations |
+| `performBackgroundTask` in a loop | Creates excessive threads. Use `newBackgroundContext()` instead |
+| Not setting `automaticallyMergesChangesFromParent` | Background saves don't reflect in the UI |
+| Batch operations without merge | In-memory state is stale. Always call `mergeChanges(fromRemoteContextSave:into:)` |
+| N+1 faulting in lists | Set `relationshipKeyPathsForPrefetching` and `fetchBatchSize` |
+| Passing `NSManagedObject` across queues | Use `NSManagedObjectID` instead |
+| Passing `PersistentModel` across actors | Use `PersistentIdentifier` or DTOs instead |
+| Missing inverse relationships (Core Data) | Always define inverses — prevents data inconsistency |
+| `@Attribute(.unique)` with CloudKit | Not supported — CloudKit ignores unique constraints |
+| SwiftData migration without `VersionedSchema` | Unversioned models break on schema changes in production |
+| `automaticallyMergesChangesFromParent` with large batch imports | Can cause excessive memory growth. Use Persistent History Tracking instead |
+| Fetching with expired `DefaultHistoryToken` | Throws `SwiftDataError.historyTokenExpired`. Delete stale history and reset token |
+| Not enabling history tracking for shared stores | Multi-process stores (app + widget) miss each other's changes silently |

--- a/registry/skills/apple-app-development/references/storekit.md
+++ b/registry/skills/apple-app-development/references/storekit.md
@@ -1,0 +1,692 @@
+# StoreKit Reference (In-App Purchases & Subscriptions)
+
+Comprehensive guide to monetization on Apple platforms using StoreKit 2. Covers product loading, purchase flows, transaction management, subscriptions, StoreKit SwiftUI views, testing, and server-side verification. StoreKit 2 is the modern Swift-native API (iOS 15+) — do not use the original StoreKit API for new code.
+
+## Architecture Overview
+
+| Component | Purpose |
+|---|---|
+| **Product** | Load product info from App Store, initiate purchases |
+| **Transaction** | Verify purchases, manage entitlements, listen for updates |
+| **SubscriptionStoreView** | SwiftUI view for merchandising subscriptions (iOS 17+) |
+| **StoreView** / **ProductView** | SwiftUI views for merchandising any product type (iOS 17+) |
+| **AppTransaction** | Verify the app itself was legitimately purchased |
+| **StoreKit Configuration File** | Local testing in Xcode without App Store Connect |
+
+## Product Types
+
+| Type | Behavior | Example |
+|---|---|---|
+| **Consumable** | Can be purchased multiple times, depletes | Gems, coins, extra lives |
+| **Non-consumable** | One-time permanent purchase | Remove ads, premium features |
+| **Auto-renewable subscription** | Recurring billing, automatic renewal | Monthly/yearly plans |
+| **Non-renewing subscription** | Fixed duration, no auto-renewal | Season pass, 30-day access |
+
+
+## Loading Products
+
+```swift
+import StoreKit
+
+// Define product identifiers (match App Store Connect or StoreKit config file)
+enum ProductID {
+    static let premium = "com.example.app.premium"
+    static let monthlyPlan = "com.example.app.monthly"
+    static let yearlyPlan = "com.example.app.yearly"
+    static let coins100 = "com.example.app.coins.100"
+
+    static let all = [premium, monthlyPlan, yearlyPlan, coins100]
+}
+
+// Load products
+let products = try await Product.products(for: ProductID.all)
+
+for product in products {
+    print("\(product.displayName): \(product.displayPrice)")
+    print("Type: \(product.type)")  // .consumable, .nonConsumable, .autoRenewable, .nonRenewing
+}
+```
+
+Key `Product` properties:
+- `id` — unique product identifier string
+- `displayName` — localized name
+- `description` — localized description
+- `displayPrice` — localized price string (e.g., "$9.99")
+- `price` — `Decimal` value
+- `type` — `Product.ProductType`
+- `subscription` — `Product.SubscriptionInfo?` (nil for non-subscriptions)
+- `isFamilyShareable` — Family Sharing support
+
+
+## Purchase Flow
+---
+
+```swift
+func purchase(_ product: Product) async throws {
+    let result = try await product.purchase()
+
+    switch result {
+    case .success(let verification):
+        // Verify the transaction
+        switch verification {
+        case .verified(let transaction):
+            // Deliver content
+            await deliverContent(for: transaction)
+            // MUST call finish() after delivering content
+            await transaction.finish()
+
+        case .unverified(let transaction, let error):
+            // Transaction failed verification — handle cautiously
+            print("Unverified transaction: \(error)")
+        }
+
+    case .userCancelled:
+        // User dismissed the purchase sheet
+        break
+
+    case .pending:
+        // Transaction is pending (e.g., Ask to Buy, SCA)
+        // Will arrive later via Transaction.updates
+        break
+
+    @unknown default:
+        break
+    }
+}
+```
+
+#### Purchase Options
+
+```swift
+// Associate purchase with your user account (for server-side tracking)
+let result = try await product.purchase(options: [
+    .appAccountToken(UUID(uuidString: userAccountID)!)
+])
+
+// Promotional offer
+let result = try await product.purchase(options: [
+    .promotionalOffer(offerID: "SPRING_SALE", keyID: keyID, nonce: nonce, signature: signature, timestamp: timestamp)
+])
+```
+
+#### Purchase with Confirmation Scene (iOS 17+)
+
+```swift
+// Specify where to present the purchase confirmation
+let result = try await product.purchase(confirmIn: windowScene)
+```
+
+
+## Transaction Management
+---
+
+### Transaction Listener
+
+**Start at app launch** — catches purchases made outside the app (other device, App Store, subscription renewals):
+
+```swift
+@main
+struct MyApp: App {
+    @State private var store = StoreManager()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(store)
+                .task {
+                    await store.listenForTransactions()
+                }
+        }
+    }
+}
+
+@Observable
+class StoreManager {
+    private var updateListenerTask: Task<Void, Never>?
+
+    func listenForTransactions() async {
+        for await result in Transaction.updates {
+            guard case .verified(let transaction) = result else { continue }
+            await handleVerifiedTransaction(transaction)
+            await transaction.finish()
+        }
+    }
+}
+```
+
+### Current Entitlements
+
+Determine what content the user has access to:
+
+```swift
+func updateEntitlements() async {
+    var activeProductIDs: Set<String> = []
+
+    for await result in Transaction.currentEntitlements {
+        guard case .verified(let transaction) = result else { continue }
+
+        switch transaction.productType {
+        case .nonConsumable, .autoRenewable:
+            if transaction.revocationDate == nil {
+                activeProductIDs.insert(transaction.productID)
+            }
+        default:
+            break
+        }
+    }
+
+    self.purchasedProductIDs = activeProductIDs
+}
+```
+
+### Restore Purchases
+
+StoreKit 2 handles this automatically via `Transaction.currentEntitlements`. For explicit restore (e.g., a "Restore Purchases" button):
+
+```swift
+func restorePurchases() async {
+    try? await AppStore.sync()  // Forces sync with App Store
+    await updateEntitlements()
+}
+```
+
+### Finishing Transactions
+
+**Always call `transaction.finish()`** after delivering content. Unfinished transactions:
+- Reappear in `Transaction.unfinished`
+- Block new purchases of the same product (non-consumables)
+- Indicate undelivered content to the App Store
+
+```swift
+// Process any unfinished transactions on launch
+func processUnfinishedTransactions() async {
+    for await result in Transaction.unfinished {
+        guard case .verified(let transaction) = result else { continue }
+        await deliverContent(for: transaction)
+        await transaction.finish()
+    }
+}
+```
+
+
+## Subscriptions
+---
+
+### Checking Subscription Status
+
+```swift
+func checkSubscriptionStatus() async throws -> Bool {
+    guard let product = try await Product.products(for: [ProductID.monthlyPlan]).first,
+          let subscription = product.subscription
+    else { return false }
+
+    let statuses = try await subscription.status
+
+    for status in statuses {
+        guard case .verified(let renewalInfo) = status.renewalInfo,
+              case .verified(let transaction) = status.transaction
+        else { continue }
+
+        switch status.state {
+        case .subscribed:
+            // Active subscription
+            return true
+        case .expired:
+            // Check expiration reason
+            if let expirationReason = renewalInfo.expirationReason {
+                handleExpiration(expirationReason)
+            }
+        case .revoked:
+            // Refunded or revoked
+            break
+        case .inBillingRetryPeriod:
+            // Payment failed, Apple is retrying
+            // Consider giving limited access
+            break
+        case .inGracePeriod:
+            // Payment failed but within grace period — maintain access
+            return true
+        default:
+            break
+        }
+    }
+    return false
+}
+```
+
+### Subscription Renewal Info
+
+```swift
+// From verified renewalInfo
+let willAutoRenew = renewalInfo.willAutoRenew
+let currentProductID = renewalInfo.currentProductID
+let autoRenewPreference = renewalInfo.autoRenewPreference  // Product they'll renew to
+let expirationReason = renewalInfo.expirationReason
+let gracePeriodExpirationDate = renewalInfo.gracePeriodExpirationDate
+```
+
+### Subscription Offers
+---
+
+Four types of offers exist. Each targets a different audience and has different configuration/redemption flows.
+
+| Offer Type | Target Audience | Payment Modes | Requires Signature | Configuration |
+|---|---|---|---|---|
+| **Introductory** | First-time subscribers only | Free trial, pay as you go, pay up front | No | App Store Connect |
+| **Promotional** | Existing or lapsed subscribers | Free trial, pay as you go, pay up front | Yes (server-side) | App Store Connect + server |
+| **Win-back** | Lapsed subscribers | Free trial, pay as you go, pay up front | No | App Store Connect |
+| **Offer codes** | Anyone with a code | Free or discounted | No | App Store Connect (up to 10 active, 1M codes/quarter) |
+
+#### Payment Modes
+
+| Mode | Behavior | Example |
+|---|---|---|
+| `.freeTrial` | No charge during offer period | "7-day free trial" |
+| `.payAsYouGo` | Discounted recurring rate for N periods | "$0.99/month for 3 months" |
+| `.payUpFront` | Single discounted payment for the entire offer period | "$9.99 for 6 months" |
+
+#### Accessing Offers on a Product
+
+```swift
+guard let subscription = product.subscription else { return }
+
+// Introductory offer (only one per subscription group)
+if let introOffer = subscription.introductoryOffer {
+    print("Intro: \(introOffer.displayPrice) - \(introOffer.paymentMode)")
+    print("Period: \(introOffer.period) x \(introOffer.periodCount)")
+}
+
+// Promotional offers (configured in App Store Connect)
+for offer in subscription.promotionalOffers {
+    print("Promo: \(offer.id ?? "") - \(offer.displayPrice)")
+}
+
+// Win-back offers (iOS 18+)
+for offer in subscription.winBackOffers {
+    print("Win-back: \(offer.id ?? "") - \(offer.displayPrice)")
+}
+```
+
+#### Introductory Offer Eligibility
+
+A user is eligible only if they have never subscribed to any product in the subscription group:
+
+```swift
+let isEligible = await product.subscription?.isEligibleForIntroOffer ?? false
+
+if isEligible, let introOffer = product.subscription?.introductoryOffer {
+    switch introOffer.paymentMode {
+    case .freeTrial:
+        showBanner("Start your \(introOffer.period) free trial")
+    case .payAsYouGo:
+        showBanner("\(introOffer.displayPrice)/\(introOffer.period) for \(introOffer.periodCount) periods")
+    case .payUpFront:
+        showBanner("\(introOffer.displayPrice) for \(introOffer.periodCount) \(introOffer.period)s")
+    default:
+        break
+    }
+}
+```
+
+#### Promotional Offers (Server-Signed)
+
+Require a server-generated signature. Used to retain existing subscribers or win back lapsed ones with targeted deals:
+
+```swift
+// 1. Request signature from your server
+let signatureData = try await yourServer.generateOfferSignature(
+    productID: product.id,
+    offerID: "SPRING_SALE",
+    appAccountToken: userID
+)
+
+// 2. Purchase with promotional offer
+let result = try await product.purchase(options: [
+    .promotionalOffer(
+        offerID: signatureData.offerID,
+        keyID: signatureData.keyID,
+        nonce: signatureData.nonce,
+        signature: signatureData.signature,
+        timestamp: signatureData.timestamp
+    )
+])
+```
+
+#### Win-Back Offers (iOS 18+)
+
+Automatically offered to lapsed subscribers. No server signature needed — Apple determines eligibility:
+
+```swift
+// Check win-back offer availability
+if let winBackOffers = product.subscription?.winBackOffers, !winBackOffers.isEmpty {
+    // Show win-back UI
+    for offer in winBackOffers {
+        print("Come back: \(offer.displayPrice) for \(offer.period)")
+    }
+}
+
+// SubscriptionStoreView handles win-back offers automatically
+SubscriptionStoreView(groupID: groupID)
+    // Win-back offers are displayed to eligible users without additional code
+```
+
+#### Offer Codes
+
+Alphanumeric codes distributed outside the app (email campaigns, social media, partnerships). Available for all product types (iOS 16.3+ for non-subscriptions):
+
+```swift
+// Present the redemption sheet
+// SwiftUI
+.offerCodeRedemption(isPresented: $showRedeemSheet) { result in
+    // Transaction arrives via Transaction.updates
+}
+
+// UIKit
+try await AppStore.presentOfferCodeRedeemSheet(in: windowScene)
+```
+
+Identifying offer code transactions:
+
+```swift
+if let offer = transaction.offer, offer.type == .code {
+    // This transaction came from an offer code redemption
+}
+```
+
+### Manage Subscriptions
+
+Open the system subscription management sheet:
+
+```swift
+// SwiftUI
+.manageSubscriptionsSheet(isPresented: $showManageSubscriptions)
+
+// Programmatic
+try await AppStore.showManageSubscriptions(in: windowScene)
+```
+
+
+## StoreKit SwiftUI Views (iOS 17+)
+---
+
+Pre-built views for merchandising — no custom UI needed for standard storefronts.
+
+### SubscriptionStoreView
+
+Displays auto-renewable subscription options for a subscription group:
+
+```swift
+import StoreKit
+
+struct PaywallView: View {
+    var body: some View {
+        SubscriptionStoreView(groupID: "YOUR_SUBSCRIPTION_GROUP_ID") {
+            // Custom marketing content (header)
+            VStack(spacing: 12) {
+                Image(systemName: "crown.fill")
+                    .font(.system(size: 60))
+                    .foregroundStyle(.yellow)
+                Text("Unlock Premium")
+                    .font(.title.bold())
+                Text("Get unlimited access to all features")
+                    .foregroundStyle(.secondary)
+            }
+            .padding()
+        }
+        .storeButton(.visible, for: .restorePurchases)
+        .storeButton(.hidden, for: .cancellation)
+        .subscriptionStoreControlStyle(.prominentPicker)
+    }
+}
+```
+
+#### Customization
+
+```swift
+SubscriptionStoreView(groupID: groupID)
+    // Control which subscription tiers to show
+    // .visibleRelationships: .upgrade — show only upgrades from current plan
+    .subscriptionStoreControlStyle(.prominentPicker)
+
+    // Policy links
+    .subscriptionStorePolicyDestination(url: termsURL, for: .termsOfService)
+    .subscriptionStorePolicyDestination(url: privacyURL, for: .privacyPolicy)
+
+    // Sign-in action
+    .subscriptionStoreSignInAction {
+        showSignIn = true
+    }
+
+    // Background
+    .containerBackground(.blue.gradient, for: .subscriptionStoreHeader)
+```
+
+### StoreView
+
+Displays a grid of any product type:
+
+```swift
+struct ShopView: View {
+    var body: some View {
+        StoreView(ids: ProductID.all)
+            .storeButton(.visible, for: .restorePurchases)
+            .productViewStyle(.regular)
+    }
+}
+```
+
+### ProductView
+
+Merchandises a single product:
+
+```swift
+ProductView(id: ProductID.premium) {
+    // Custom icon
+    Image(systemName: "star.fill")
+        .font(.title)
+}
+```
+
+
+## Verification
+---
+
+StoreKit 2 wraps transactions in `VerificationResult<Transaction>`. The App Store signs transactions in JWS (JSON Web Signature) format.
+
+### On-Device Verification (Default)
+
+StoreKit automatically verifies the signature. Handle both cases:
+
+```swift
+func handleVerification<T>(_ result: VerificationResult<T>) throws -> T {
+    switch result {
+    case .verified(let value):
+        return value
+    case .unverified(_, let error):
+        throw StoreError.verificationFailed(error)
+    }
+}
+```
+
+### Server-Side Verification
+
+For additional security, verify transactions on your server using the App Store Server API:
+
+```swift
+// Get JWS representation for server validation
+let jwsRepresentation = verificationResult.jwsRepresentation
+// Send to your server for verification against Apple's public key
+```
+
+### AppTransaction (App Purchase Verification)
+
+Verify the app itself was legitimately purchased (anti-piracy):
+
+```swift
+let appTransaction = try await AppTransaction.shared
+switch appTransaction {
+case .verified(let transaction):
+    // App was legitimately purchased
+    let originalPurchaseDate = transaction.originalPurchaseDate
+case .unverified(_, let error):
+    // Verification failed — handle accordingly
+    break
+}
+```
+
+
+## Refund Requests
+---
+
+```swift
+// Present refund request UI
+let status = try await Transaction.beginRefundRequest(
+    for: transaction.id,
+    in: windowScene
+)
+
+switch status {
+case .success:
+    // Refund request submitted
+    break
+case .userCancelled:
+    // User cancelled the refund request
+    break
+@unknown default:
+    break
+}
+```
+
+
+## Testing
+---
+
+### StoreKit Configuration File (Xcode)
+
+1. File → New → StoreKit Configuration File
+2. Add products matching your App Store Connect setup
+3. Scheme → Edit Scheme → Run → Options → StoreKit Configuration → select file
+4. Test purchases locally — no sandbox account needed
+
+```swift
+// Products load from the config file during testing
+let products = try await Product.products(for: ProductID.all)
+// Purchases complete immediately without payment
+```
+
+### Sandbox Testing
+
+For testing with real App Store infrastructure:
+1. Create sandbox tester in App Store Connect → Users and Access → Sandbox Testers
+2. Sign in with sandbox account on device (Settings → App Store → Sandbox Account)
+3. Purchases are free but follow real purchase flows
+
+### Transaction Manager (Xcode)
+
+Debug → StoreKit → Manage Transactions — lets you:
+- View all transactions
+- Delete transactions
+- Refund transactions
+- Expire subscriptions
+- Trigger Ask to Buy approval/rejection
+
+### Testing Specific Scenarios
+
+```swift
+// Simulate Ask to Buy (sandbox)
+let result = try await product.purchase(options: [
+    .simulatesAskToBuyInSandbox(true)
+])
+
+// Test subscription renewal by setting short renewal periods in StoreKit config
+```
+
+
+## Complete Store Implementation
+---
+
+```swift
+@Observable
+class StoreManager {
+    private(set) var products: [Product] = []
+    private(set) var purchasedProductIDs: Set<String> = []
+    private var updateListenerTask: Task<Void, Never>?
+
+    var isPremium: Bool {
+        purchasedProductIDs.contains(ProductID.premium) ||
+        purchasedProductIDs.contains(ProductID.monthlyPlan) ||
+        purchasedProductIDs.contains(ProductID.yearlyPlan)
+    }
+
+    init() {
+        updateListenerTask = Task { await listenForTransactions() }
+        Task { await loadProducts() }
+        Task { await updateEntitlements() }
+    }
+
+    deinit {
+        updateListenerTask?.cancel()
+    }
+
+    func loadProducts() async {
+        do {
+            products = try await Product.products(for: ProductID.all)
+                .sorted { $0.price < $1.price }
+        } catch {
+            print("Failed to load products: \(error)")
+        }
+    }
+
+    func purchase(_ product: Product) async throws -> Bool {
+        let result = try await product.purchase()
+
+        switch result {
+        case .success(let verification):
+            guard case .verified(let transaction) = verification else { return false }
+            await transaction.finish()
+            await updateEntitlements()
+            return true
+        case .userCancelled, .pending:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    func updateEntitlements() async {
+        var ids: Set<String> = []
+        for await result in Transaction.currentEntitlements {
+            guard case .verified(let transaction) = result,
+                  transaction.revocationDate == nil
+            else { continue }
+            ids.insert(transaction.productID)
+        }
+        purchasedProductIDs = ids
+    }
+
+    private func listenForTransactions() async {
+        for await result in Transaction.updates {
+            guard case .verified(let transaction) = result else { continue }
+            await transaction.finish()
+            await updateEntitlements()
+        }
+    }
+}
+```
+
+
+## Common Pitfalls
+
+| Pitfall | Fix |
+|---|---|
+| Not calling `transaction.finish()` | Unfinished transactions block future purchases and reappear in `unfinished`. Always finish after delivering content |
+| Not listening for `Transaction.updates` | Misses purchases from other devices, subscription renewals, offer redemptions. Start listener at app launch |
+| Checking entitlements only at purchase time | Use `Transaction.currentEntitlements` on every app launch to handle renewals, expirations, revocations |
+| Not handling `.pending` purchase result | Ask to Buy and SCA require deferred handling — the transaction arrives later via `Transaction.updates` |
+| Using original StoreKit API in new code | StoreKit 2 is simpler, safer, and actively developed. Original API is effectively legacy |
+| Hardcoding prices | Always use `product.displayPrice` — it's localized and currency-aware |
+| Not handling `.unverified` transactions | Decide a policy: reject, log, or accept with caution. Never silently ignore verification failures |
+| Testing only with StoreKit config file | Also test in sandbox with real App Store infrastructure before release |
+| Not syncing on "Restore Purchases" | Call `AppStore.sync()` then re-check `Transaction.currentEntitlements` |
+| Missing subscription grace period handling | Users in `.inGracePeriod` should retain access — Apple is retrying payment |
+| Not checking `revocationDate` | Revoked/refunded transactions should remove access. Always filter by `revocationDate == nil` |

--- a/registry/skills/apple-app-development/references/storekit.md
+++ b/registry/skills/apple-app-development/references/storekit.md
@@ -100,7 +100,7 @@ func purchase(_ product: Product) async throws {
 ```swift
 // Associate purchase with your user account (for server-side tracking)
 let result = try await product.purchase(options: [
-    .appAccountToken(UUID(uuidString: userAccountID)!)
+    .appAccountToken(UUID(uuidString: userAccountID) ?? UUID())
 ])
 
 // Promotional offer
@@ -421,11 +421,12 @@ import StoreKit
 struct PaywallView: View {
     var body: some View {
         SubscriptionStoreView(groupID: "YOUR_SUBSCRIPTION_GROUP_ID") {
-            // Custom marketing content (header)
+            // Custom marketing content — customize with your app's design tokens
             VStack(spacing: 12) {
                 Image(systemName: "crown.fill")
                     .font(.system(size: 60))
                     .foregroundStyle(.yellow)
+                    // Use AppTypography/AppSpacing tokens in production
                 Text("Unlock Premium")
                     .font(.title.bold())
                 Text("Get unlimited access to all features")


### PR DESCRIPTION
## Summary

  - Add 4 new reference files to the `apple-app-development` skill covering major iOS frameworks and patterns
  - **`persistence.md`** — Core Data (NSPersistentContainer, context concurrency, staged migrations, batch operations, Persistent History Tracking, CloudKit) and SwiftData (@Model, @Query,
  ModelActor, VersionedSchema, #Unique, #Index, history tracking, custom data stores)
  - **`media-playback.md`** — AVFoundation/AVKit (AVPlayer, VideoPlayer, AVPlayerViewController, AVAudioSession, PiP, AirPlay, offline HLS downloads, Now Playing/remote controls, media selection)
  - **`networking.md`** — URLSession (async/await, uploads, downloads, background sessions, WebSocket, auth challenges, caching, NWPathMonitor) with Alamofire as optional convenience layer
  (interceptors, retry, certificate pinning, multipart)
  - **`storekit.md`** — StoreKit 2 (Product, Transaction, entitlements, all subscription offer types — introductory/promotional/win-back/offer codes), StoreKit SwiftUI views (SubscriptionStoreView,
   StoreView), verification, testing
  - Update `SKILL.md` with references to all new files

  ## Test plan

  - [x] Verify all 4 new reference files are present under `registry/skills/apple-app-development/references/`
  - [x] Verify `SKILL.md` lists all new references in the Reference Files section
  - [x] Confirm no existing references were modified or removed
  - [x] Review code examples for correctness (Swift 6+, async/await patterns)

  🤖 Generated with [Claude Code](https://claude.com/claude-code)