### PR TITLE
Add documentation-engineering skill and documentation-specialist agent

### DIFF
--- a/registry/agents/documentation-specialist.md
+++ b/registry/agents/documentation-specialist.md
@@ -1,0 +1,33 @@
+---
+name: documentation-specialist
+description: >-
+  Delegate to this agent for repository documentation tasks — analyzing repo
+  structure, generating docs (README, architecture, API, onboarding, runbook),
+  publishing to Confluence, syncing documentation, and auditing doc quality.
+model: sonnet
+skills:
+  - documentation-engineering
+---
+
+# Documentation Specialist
+
+You are a senior technical writer who produces clear, accurate, and maintainable documentation. You analyze codebases systematically and generate docs that serve both humans and AI agents.
+
+## Responsibilities
+
+- Analyze repositories to extract structure, tech stack, APIs, and dependencies
+- Generate documentation: README, architecture docs, API reference, onboarding guides, runbooks
+- Publish and sync content to Confluence with proper Storage Format conversion
+- Audit documentation quality, coverage, and freshness
+
+## Guidelines
+
+- Always analyze the repository before generating documentation — detect tech stack from config files, not assumptions
+- Extract API endpoints from code, not README claims
+- Include working, copy-paste-ready code examples
+- Mark uncertain or incomplete sections clearly
+- Follow consistent heading hierarchy and formatting
+- Never publish to Confluence without user confirmation
+- Preserve manually-edited sections during sync updates
+- Score documentation on completeness, accuracy, readability, freshness, and formatting
+- Track coverage across repos and flag undocumented modules

--- a/registry/skills/documentation-engineering/SKILL.md
+++ b/registry/skills/documentation-engineering/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: documentation-engineering
+description: >-
+  Repository documentation and Confluence publishing. Use when asked to analyze
+  a repository's structure, generate documentation (README, architecture, API
+  reference, onboarding guide, runbook), publish to Confluence, sync docs, or
+  audit documentation quality and coverage.
+version: 0.1.0
+---
+
+# Documentation Engineering
+
+Full-lifecycle documentation skill: analyze repositories, generate docs, publish to Confluence, sync changes, and audit quality.
+
+## Repository Analysis
+
+Before generating documentation, scan the repo systematically:
+
+1. **Clone** with `git clone --depth 1`
+2. **Scan structure** — directories, entry points, config files
+3. **Detect tech stack** from `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`
+4. **Extract API endpoints** from route definitions, controllers, OpenAPI specs
+5. **Catalog dependencies** with versions
+6. **Parse CI/CD** from `.github/workflows/`, `.gitlab-ci.yml`
+7. **Inventory existing docs** — README, CHANGELOG, CONTRIBUTING, `docs/`
+
+### Key Artifacts
+
+| Artifact | Source Files | Purpose |
+|----------|-------------|---------|
+| Tech Stack | `package.json`, `requirements.txt`, `go.mod` | Languages, frameworks |
+| Entry Points | `main.*`, `app.*`, `index.*`, `cmd/` | Application startup |
+| API Endpoints | `routes/`, `controllers/`, OpenAPI specs | Public interfaces |
+| Database Schema | `migrations/`, `models/`, `schema.*` | Data layer |
+| CI/CD Pipeline | `.github/workflows/`, `.gitlab-ci.yml` | Build/deploy process |
+| Configuration | `.env.example`, `config/`, `settings.*` | Environment setup |
+
+### Output Format
+
+Produce structured JSON for downstream operations:
+
+```json
+{
+  "project_name": "example-service",
+  "tech_stack": { "language": "TypeScript", "framework": "NestJS", "database": "PostgreSQL" },
+  "structure": { "source_dir": "src/", "test_dir": "test/", "entry_point": "src/main.ts" },
+  "api_endpoints": [],
+  "dependencies": {},
+  "ci_cd": {}
+}
+```
+
+## Document Generation
+
+### README
+
+Include: project title + badges, prerequisites, installation, configuration (from `.env.example`), usage, API summary, testing, deployment, contributing guidelines.
+
+### Architecture Doc
+
+```markdown
+# Architecture: <Project Name>
+## Overview — high-level purpose
+## System Diagram — Mermaid or PlantUML
+## Components — purpose, technology, key files per component
+## Data Flow — request lifecycle
+## Infrastructure — hosting, databases, external services
+```
+
+### API Reference
+
+Extract from OpenAPI specs, route definitions, or controller decorators:
+
+```markdown
+### GET /api/v1/users
+**Auth**: Bearer token required
+**Query**: `page`, `limit`, `search`
+**Response**: `200 OK` — Array of User objects
+```
+
+### Onboarding Guide
+
+Day 1: environment setup. Day 2: codebase tour (modules, data models). Day 3: first contribution (branch, commit, PR workflow).
+
+### Runbook
+
+Service overview, health check endpoints, common issues with symptoms/diagnosis/resolution.
+
+## Confluence Publishing
+
+### Markdown to Storage Format
+
+| Markdown | Confluence Storage Format |
+|----------|--------------------------|
+| `# Heading` | `<h1>Heading</h1>` |
+| `**bold**` | `<strong>bold</strong>` |
+| `` `code` `` | `<code>code</code>` |
+| Code blocks | `<ac:structured-macro ac:name="code">` |
+| Tables | `<table><tr><th>...</th></tr></table>` |
+| Info boxes | `<ac:structured-macro ac:name="info">` |
+
+### Page Workflow
+
+1. Identify target space and parent page
+2. Search by title to avoid duplicates
+3. Convert Markdown to Storage Format
+4. Create or update page via REST API
+5. Add labels: `auto-generated`, `repo:<name>`, `type:<doctype>`
+6. Verify formatting by fetching page back
+
+### Sync Strategy
+
+- Detect changes with `git log --since="<last-sync>" --name-only`
+- Update only changed sections — preserve manual edits
+- Increment version number, add "Auto-updated from <repo> on <date>"
+
+## Documentation Quality
+
+Score on five dimensions: completeness, accuracy, readability, freshness, formatting. Flag broken links, outdated code examples, missing sections. Track coverage across repos.
+
+## Deep Dives
+
+| Topic | Reference |
+|---|---|
+| Repository analysis workflow | `references/repo-analysis.md` |
+| Document templates and generation | `references/doc-generation.md` |
+| Confluence publishing patterns | `references/confluence-publishing.md` |
+| Documentation sync and quality | `references/doc-sync.md` |

--- a/registry/skills/documentation-engineering/references/confluence-publishing.md
+++ b/registry/skills/documentation-engineering/references/confluence-publishing.md
@@ -1,0 +1,34 @@
+# Confluence Publishing Reference
+
+## Markdown to Confluence Storage Format
+
+Key conversions:
+
+| Markdown | Confluence Storage Format |
+|----------|--------------------------|
+| `# Heading` | `<h1>Heading</h1>` |
+| `**bold**` | `<strong>bold</strong>` |
+| `` `code` `` | `<code>code</code>` |
+| Code blocks | `<ac:structured-macro ac:name="code">` |
+| Tables | `<table><tr><th>...</th></tr></table>` |
+| Links | `<a href="...">text</a>` |
+| Images | `<ac:image><ri:url ri:value="..." /></ac:image>` |
+| Info boxes | `<ac:structured-macro ac:name="info">` |
+
+## Page Creation Workflow
+
+1. **Source credentials** — load .env file
+2. **Identify target space** — ask user or use provided `--space` parameter
+3. **Check for existing page** — search by title via API to avoid duplicates
+4. **Convert content** — Markdown to Confluence Storage Format
+5. **Create/update page** — via Confluence MCP server
+6. **Add labels** — auto-generated, auto-docs, repo name, doc type
+7. **Verify publication** — fetch page back and confirm formatting
+8. **Report result** — display page URL, space, and parent location
+
+## Page Update Strategy
+
+- Compare content hash to detect changes
+- Preserve existing page metadata (labels, watchers, restrictions)
+- Increment version number for Confluence versioning
+- Add update note: "Auto-updated from <repo> on <date>"

--- a/registry/skills/documentation-engineering/references/doc-generation.md
+++ b/registry/skills/documentation-engineering/references/doc-generation.md
@@ -1,0 +1,113 @@
+# Document Generation Reference
+
+## README Generation
+
+A generated README should include:
+
+1. **Project title and description** — extracted from package metadata
+2. **Tech stack badges** — language, framework, CI status
+3. **Prerequisites** — runtime versions, tools required
+4. **Installation** — step-by-step setup instructions
+5. **Configuration** — environment variables from `.env.example`
+6. **Usage** — how to run, common commands
+7. **API Reference** — endpoint summary if applicable
+8. **Testing** — how to run tests
+9. **Deployment** — CI/CD pipeline overview
+10. **Contributing** — guidelines extracted from CONTRIBUTING.md or inferred
+
+## Architecture Documentation Template
+
+```markdown
+# Architecture: <Project Name>
+
+## Overview
+High-level system description and purpose.
+
+## System Diagram
+[Mermaid or PlantUML diagram]
+
+## Components
+### Component A
+- **Purpose**: ...
+- **Technology**: ...
+- **Key Files**: ...
+
+## Data Flow
+1. Request enters via ...
+2. Processed by ...
+3. Stored in ...
+
+## Infrastructure
+- Hosting: ...
+- Database: ...
+- External Services: ...
+```
+
+## API Documentation Template
+
+Extract from OpenAPI/Swagger specs, route definitions, or controller decorators:
+
+```markdown
+## API Reference
+
+### GET /api/v1/users
+**Description**: List all users
+**Auth**: Bearer token required
+**Query Params**: `page`, `limit`, `search`
+**Response**: `200 OK` — Array of User objects
+
+### POST /api/v1/users
+**Description**: Create a new user
+**Auth**: Admin role required
+**Body**: `{ name, email, role }`
+**Response**: `201 Created` — User object
+```
+
+## Onboarding Guide Template
+
+```markdown
+# Developer Onboarding: <Project Name>
+
+## Day 1: Environment Setup
+1. Clone the repository
+2. Install dependencies
+3. Configure environment variables
+4. Run the application locally
+5. Run the test suite
+
+## Day 2: Codebase Tour
+- Project structure overview
+- Key modules and their responsibilities
+- Data models and relationships
+
+## Day 3: First Contribution
+- Pick a "good first issue"
+- Development workflow (branch, commit, PR)
+- Code review process
+```
+
+## Runbook Template
+
+```markdown
+# Runbook: <Project Name>
+
+## Service Overview
+- **Service**: ...
+- **Team**: ...
+- **On-call**: ...
+
+## Health Checks
+- Endpoint: `GET /health`
+- Expected: `200 OK`
+
+## Common Issues
+### Issue: High Latency
+- **Symptoms**: Response times > 2s
+- **Diagnosis**: Check database connections, cache hit rate
+- **Resolution**: Scale replicas, flush cache
+
+### Issue: OOM Errors
+- **Symptoms**: Pod restarts, memory alerts
+- **Diagnosis**: Check memory usage, heap dumps
+- **Resolution**: Increase memory limit, check for leaks
+```

--- a/registry/skills/documentation-engineering/references/doc-sync.md
+++ b/registry/skills/documentation-engineering/references/doc-sync.md
@@ -1,0 +1,24 @@
+# Documentation Sync Reference
+
+## Change Detection
+
+Use `git log --since="<last-sync-date>" --name-only` to detect repo changes since the last Confluence sync. Filter for doc-relevant paths (README, docs/, api/, schema, models, routes, controllers).
+
+## Sync Workflow
+
+1. Fetch current Confluence page content via API
+2. Re-analyze repository for changes
+3. Generate updated documentation sections
+4. Diff old vs new content
+5. Update only changed sections (preserve manual edits)
+6. Update sync timestamp label
+
+## Reference Assets
+
+| Asset | Source | Description |
+|-------|--------|-------------|
+| README templates | Provectus repos | Standardized README structures |
+| Architecture templates | `docs/architecture/` | System design document templates |
+| API doc generators | OpenAPI specs | Automated API documentation |
+| Confluence macros | Atlassian docs | Storage format reference |
+| Runbook templates | SRE practices | Incident response documentation |

--- a/registry/skills/documentation-engineering/references/repo-analysis.md
+++ b/registry/skills/documentation-engineering/references/repo-analysis.md
@@ -1,0 +1,49 @@
+# Repository Analysis Reference
+
+## Workflow
+
+1. **Clone the repo** using `git clone --depth 1` with token auth
+2. **Scan directory structure** using `find`, `ls`, file reading
+3. **Detect tech stack** from config files (package.json, requirements.txt, go.mod, etc.)
+4. **Extract entry points** — find main.*, app.*, index.*, cmd/ patterns
+5. **Map API endpoints** — scan route definitions, controllers, OpenAPI specs
+6. **Catalog dependencies** — list direct and dev dependencies with versions
+7. **Analyze CI/CD** — parse .github/workflows/, .gitlab-ci.yml, Jenkinsfile
+8. **Identify existing docs** — check for README, CHANGELOG, CONTRIBUTING, docs/ directory
+9. **Produce analysis JSON** — structured output for downstream operations
+
+## Key Artifacts to Extract
+
+| Artifact | Source Files | Purpose |
+|----------|-------------|---------|
+| Tech Stack | `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml` | Identify languages, frameworks, dependencies |
+| Entry Points | `main.*`, `app.*`, `index.*`, `cmd/` | Understand application startup |
+| API Endpoints | `routes/`, `controllers/`, `api/`, OpenAPI specs | Document public interfaces |
+| Database Schema | `migrations/`, `models/`, `schema.*` | Document data layer |
+| CI/CD Pipeline | `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile` | Document build/deploy process |
+| Configuration | `.env.example`, `config/`, `settings.*` | Document environment setup |
+| Tests | `test/`, `tests/`, `__tests__/`, `*_test.*` | Understand test coverage |
+
+## Analysis Output Format
+
+```json
+{
+  "project_name": "example-service",
+  "description": "Extracted from README or package.json",
+  "tech_stack": {
+    "language": "TypeScript",
+    "framework": "NestJS",
+    "database": "PostgreSQL",
+    "cache": "Redis"
+  },
+  "structure": {
+    "source_dir": "src/",
+    "test_dir": "test/",
+    "docs_dir": "docs/",
+    "entry_point": "src/main.ts"
+  },
+  "api_endpoints": [],
+  "dependencies": {},
+  "ci_cd": {}
+}
+```


### PR DESCRIPTION
## Summary

- **Skill**: `documentation-engineering` — repo analysis, document generation (README, architecture, API reference, onboarding guide, runbook), Confluence publishing with Storage Format conversion, doc sync and quality auditing. 4 reference files.
- **Agent**: `documentation-specialist` — orchestration for systematic repo analysis and documentation workflows.

Adapted from provectus-marketplace `proagent-documentation` plugin.

## Test plan

- [x] `uv run python -m awos_recruitment_mcp.validate` passes
- [x] `uv run pytest tests/ -v` — all tests pass
- [x] Semantic search: query "generate README documentation confluence" ranks `documentation-engineering` #1