### PR TITLE
Add prorag-development skill and prorag-specialist agent

### DIFF
--- a/registry/agents/prorag-specialist.md
+++ b/registry/agents/prorag-specialist.md
@@ -1,0 +1,39 @@
+---
+name: prorag-specialist
+description: >-
+  Delegate to this agent for ProRAG framework development — scaffolding projects,
+  writing custom pipeline steps with @step/@pipeline decorators, customizing
+  ingestion and RAG pipelines, configuring settings, and operating the lifecycle.
+model: sonnet
+skills:
+  - prorag-development
+---
+
+# ProRAG Specialist
+
+You are a senior Python engineer specializing in the ProRAG framework. You build composable RAG pipelines with deep knowledge of the framework's decorators, data models, and operational patterns.
+
+## Core Principles
+
+- **Composable pipelines** — plain Python function composition, no YAML or DAG builders
+- **TDD discipline** — write failing tests first, use `.fn()` to bypass Prefect wrappers
+- **Python 3.13 style** — `str | None`, `StrEnum`, `TYPE_CHECKING` guards, ruff + mypy strict
+- **Settings-driven** — `PROVRAG_*` env vars with `__` nested delimiter
+- **Live API reading** — read installed source for current signatures when `.venv` exists
+
+## Responsibilities
+
+- Scaffold new ProRAG projects with `provrag init`
+- Write custom `@step` and `@pipeline` functions for ingestion and retrieval
+- Implement customizations: PDF ingestion, cross-encoder reranking, hybrid search, custom prompts
+- Configure settings for local (OpenAI/MinIO) and AWS (Bedrock/S3/SSM) environments
+- Operate lifecycle: ingest, serve, status, index management
+- Write comprehensive tests using the `.fn()` bypass pattern
+
+## Workflow
+
+1. **Assess** — read `.provrag-spec.json` if present to understand project architecture
+2. **Plan** — identify which pipeline steps need creation or modification
+3. **Implement** — write code following ProRAG patterns (factory functions, data models)
+4. **Test** — write tests with `.fn()` calls, mock external services
+5. **Verify** — run `task check` (lint + typecheck + test)

--- a/registry/skills/prorag-development/SKILL.md
+++ b/registry/skills/prorag-development/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: prorag-development
+description: >-
+  Build and customize ProRAG applications. Use when scaffolding ProRAG projects,
+  writing custom pipeline steps with @step/@pipeline decorators, modifying
+  ingestion or RAG pipelines, configuring settings, writing tests, or operating
+  the ProRAG lifecycle (ingest, serve, status, index management).
+version: 0.1.0
+---
+
+# ProRAG Framework Development
+
+Build, customize, and operate RAG applications using ProRAG — a Python framework for composable retrieval-augmented generation pipelines with OpenSearch, S3, and LLM abstractions.
+
+## Core Architecture
+
+- `@step` = Prefect `@task` + Phoenix OpenTelemetry tracing span
+- `@pipeline` = Prefect `@flow`
+- Steps are plain Python functions called inside pipeline functions
+- Data flows through Python variables — no YAML, no DAG builder
+- Settings use Pydantic v2 BaseSettings with `PROVRAG_*` env prefix
+
+```python
+from provrag.decorators import step, pipeline
+from provrag.models import Document, Chunk
+
+@step(span_kind="CHAIN")
+def preprocess(docs: list[Document]) -> list[Document]:
+    return [d.model_copy(update={"content": d.content.strip()}) for d in docs]
+
+@pipeline
+def my_ingestion(source: str) -> None:
+    docs = load(source)
+    docs = preprocess(docs)
+    chunks = chunk(docs)
+    embedded = embed(chunks)
+    index(embedded)
+```
+
+## Data Models
+
+```python
+from provrag.models import Document, Chunk, ScoredChunk
+
+# Document — raw content with metadata
+doc = Document(content="...", metadata={"source": "file.pdf"})
+
+# Chunk — split document with embeddings
+chunk = Chunk(content="...", metadata={}, embedding=[0.1, 0.2, ...])
+
+# ScoredChunk — retrieval result with relevance score
+scored = ScoredChunk(content="...", metadata={}, score=0.95)
+```
+
+Use `model_copy(update={...})` to create modified copies (immutable pattern).
+
+## LLM Abstractions
+
+```python
+from provrag.llm import create_embedder, create_llm
+
+embedder = create_embedder()  # Auto-selects based on environment
+llm = create_llm()            # OpenAI locally, Bedrock on AWS
+```
+
+Protocols: `BaseEmbedder` (embed method) and `BaseLLM` (generate method). Factory functions select provider based on `PROVRAG_ENVIRONMENT`:
+- `local` → OpenAI
+- `aws` → Amazon Bedrock (Titan Embed v2, Claude 3 Sonnet)
+
+## Settings System
+
+Pydantic v2 BaseSettings with `PROVRAG_*` prefix and `__` nested delimiter:
+
+```bash
+# Core
+PROVRAG_ENVIRONMENT=local          # local | aws
+PROVRAG_DEBUG=false
+PROVRAG_LOG_LEVEL=INFO
+
+# OpenSearch
+PROVRAG_OPENSEARCH__HOST=localhost
+PROVRAG_OPENSEARCH__PORT=9200
+
+# S3 / MinIO
+PROVRAG_S3__ENDPOINT_URL=http://localhost:9005  # null for AWS
+PROVRAG_S3__BUCKET=provrag-documents
+
+# Bedrock (AWS only)
+PROVRAG_BEDROCK__REGION=us-east-2
+PROVRAG_BEDROCK__EMBEDDING_MODEL=amazon.titan-embed-text-v2:0
+```
+
+## CLI Operations
+
+```bash
+provrag init --name my-project     # Scaffold new project
+provrag ingest --index my-index    # Run ingestion pipeline
+provrag serve --port 8000          # Start FastAPI server
+provrag status                     # Check lifecycle stage
+provrag list                       # List indices
+provrag clean --index my-index     # Delete index (permanent!)
+```
+
+Taskfile commands: `task setup`, `task test`, `task lint`, `task check`, `task serve`, `task ingest`, `task connect` (SSM tunnel to AWS VPC).
+
+## Code Style
+
+- Python 3.13: `str | None`, `StrEnum`, `from __future__ import annotations`
+- `TYPE_CHECKING` guards for protocol imports
+- Ruff (line-length 120), mypy strict
+- No unnecessary comments or docstrings
+- TDD: write failing test first, then implement
+
+## Testing
+
+Use `.fn()` to bypass Prefect wrappers in tests:
+
+```python
+def test_preprocess():
+    docs = [Document(content="  hello  ", metadata={})]
+    result = preprocess.fn(docs)  # .fn() skips Prefect/OTEL
+    assert result[0].content == "hello"
+```
+
+## Customization Recipes
+
+Detailed implementation patterns in `references/customization-cookbook.md`:
+- PDF ingestion with pymupdf4llm
+- Cross-encoder reranking with SentenceTransformers
+- Hybrid search (BM25 + semantic)
+- Custom system prompts
+- Custom chunking strategies
+- Metadata enrichment
+- Mixed file type ingestion
+- Query expansion with LLM
+
+## Deep Dives
+
+| Topic | Reference |
+|---|---|
+| Full API: imports, decorators, models, built-in steps | `references/api-reference.md` |
+| CLI commands, Taskfile, installation, AWS connectivity | `references/cli-reference.md` |
+| PROVRAG_* environment variables and configuration | `references/settings-reference.md` |
+| Implementation recipes (PDF, reranking, hybrid search) | `references/customization-cookbook.md` |

--- a/registry/skills/prorag-development/references/api-reference.md
+++ b/registry/skills/prorag-development/references/api-reference.md
@@ -1,0 +1,508 @@
+# ProRAG API Reference
+
+Fallback reference for when the project is not yet set up. **Prefer reading the live installed source** (see SKILL.md "Reading the Live API" section).
+
+## Package Imports
+
+```python
+# Top-level exports
+from provrag import step, pipeline, Settings, LLMProvider, GenerateResult, get_settings
+
+# Data models
+from provrag.models.document import Document, Chunk, ScoredChunk
+
+# LLM abstractions (use TYPE_CHECKING guard in production code)
+from provrag.llm.embedder import BaseEmbedder, BedrockEmbedder, OpenAIEmbedder
+from provrag.llm.generator import BaseLLM, GenerateResult, BedrockLLM, OpenAILLM
+from provrag.llm.factory import create_embedder, create_llm
+
+# Retrieval
+from provrag.retrieval.opensearch_client import ProvragOpenSearchClient
+
+# Built-in ingestion steps
+from provrag.pipelines.ingestion import load_documents, chunk_documents, embed_chunks, index_chunks
+
+# Built-in RAG steps
+from provrag.pipelines.rag import embed_query, dense_retrieve, assemble_prompt, generate_answer
+from provrag.pipelines.rag import semantic_rag_pipeline, DEFAULT_SYSTEM_PROMPT
+
+# Storage
+from provrag.storage.s3 import S3DocumentLoader
+
+# Chunking
+from provrag.chunking.text_chunker import RecursiveCharacterChunker
+
+# API
+from provrag.api import create_app
+
+# Tracing
+from provrag.tracing.setup import init_tracing
+
+# Settings
+from provrag.settings import Settings, get_settings, Environment, LLMProvider
+```
+
+## Decorators
+
+### @step
+
+```python
+from provrag import step
+
+@step(name="my-step", span_kind="CHAIN")
+def my_step(data: list[str]) -> list[str]:
+    ...
+```
+
+Parameters:
+- `name`: Prefect task name + OTEL span name (defaults to function name)
+- `span_kind`: OTEL span kind -- `"CHAIN"` (default), `"EMBEDDING"`, `"RETRIEVER"`, or `"LLM"`
+- `retries` / `retry_delay_seconds`: Prefect retry configuration
+- `tags`: Prefect task tags (set[str])
+- Additional `**kwargs` passed to `prefect.task()`
+- Cache policy is always `NONE`
+
+### @pipeline
+
+```python
+from provrag import pipeline
+
+@pipeline(name="my-pipeline")
+def my_pipeline(query: str, ...) -> str:
+    ...
+```
+
+Parameters:
+- `name`: Prefect flow name (defaults to function name)
+- `retries` / `retry_delay_seconds`: Prefect retry configuration
+- `log_prints`: Capture print statements (default: `True`)
+- Additional `**kwargs` passed to `prefect.flow()`
+
+### Testing decorated functions
+
+Call `.fn()` to bypass the Prefect wrapper:
+
+```python
+result = my_step.fn(data=["hello"])
+count = my_pipeline.fn(settings=test_settings, index_name="test")
+```
+
+## Data Models
+
+```python
+from provrag.models.document import Document, Chunk, ScoredChunk
+
+# Document -- a loaded source document
+Document(
+    id: str,                              # Unique identifier (typically SHA-256 hash)
+    content: str,                         # Full text content
+    metadata: dict[str, Any] = {},        # Arbitrary metadata
+)
+
+# Chunk -- a split piece of a document
+Chunk(
+    id: str,                              # Unique chunk identifier
+    document_id: str,                     # Parent document ID
+    content: str,                         # Chunk text
+    metadata: dict[str, Any] = {},        # Metadata (inherits from document + chunk_index)
+    embedding: list[float] | None = None, # Vector embedding (set after embed step)
+)
+
+# ScoredChunk -- a chunk with a retrieval score
+ScoredChunk(
+    id: str,
+    document_id: str,
+    content: str,
+    metadata: dict[str, Any] = {},
+    score: float = 0.0,                   # Retrieval relevance score
+    embedding: list[float] | None = None,
+)
+```
+
+Use `model_copy(update={...})` to create modified copies (Pydantic v2 pattern):
+
+```python
+updated = chunk.model_copy(update={"embedding": vector})
+```
+
+## LLM Abstractions
+
+### Protocols (use with TYPE_CHECKING guard)
+
+```python
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from provrag.llm.embedder import BaseEmbedder
+    from provrag.llm.generator import BaseLLM
+
+# BaseEmbedder protocol:
+#   .model_name -> str
+#   .embed_texts(texts: list[str]) -> list[list[float]]
+#   .embed_query(text: str) -> list[float]
+
+# BaseLLM protocol:
+#   .model_name -> str
+#   .generate(system_prompt: str, user_message: str) -> GenerateResult
+
+# GenerateResult (frozen dataclass):
+#   .response: str
+#   .prompt_tokens: int | None
+#   .completion_tokens: int | None
+```
+
+### Factory Functions
+
+```python
+from provrag.llm.factory import create_embedder, create_llm
+
+embedder = create_embedder(settings)  # BedrockEmbedder if aws, OpenAIEmbedder if local
+llm = create_llm(settings)            # BedrockLLM if aws, OpenAILLM if local
+```
+
+Never instantiate `BedrockEmbedder` or `OpenAILLM` directly -- always use the factory.
+
+### Default Models
+
+- Bedrock embedder: `amazon.titan-embed-text-v2:0` (1024 dims)
+- Bedrock LLM: `anthropic.claude-3-sonnet-20240229-v1:0`
+- OpenAI embedder: `text-embedding-3-small`
+- OpenAI LLM: `gpt-4`
+
+## OpenSearch Client
+
+```python
+from provrag.retrieval.opensearch_client import ProvragOpenSearchClient
+
+os_client = ProvragOpenSearchClient(settings)
+
+# Index management
+os_client.create_index(index_name, dimension, engine="faiss", space_type="innerproduct",
+                       ef_construction=256, m=48)  # Returns bool (False if exists)
+os_client.delete_index(index_name)                  # Returns bool
+os_client.list_indices()                             # Returns list[str]
+
+# Indexing
+os_client.bulk_index(index_name, chunks)             # Returns int (count indexed)
+
+# Search
+os_client.knn_search(index_name, query_vector, top_k=10)  # Returns list[ScoredChunk]
+
+# Hybrid search (BM25 + k-NN)
+os_client.create_hybrid_search_pipeline(
+    pipeline_name, bm25_weight=0.3, knn_weight=0.7,
+    normalization="min_max", combination="arithmetic_mean",
+)
+os_client.hybrid_search(
+    index_name, query_text, query_vector, top_k=10,
+    pipeline_name="hybrid-search-pipeline",
+)  # Returns list[ScoredChunk]
+```
+
+## Built-in Steps
+
+### Ingestion Steps
+
+```python
+from provrag.pipelines.ingestion import load_documents, chunk_documents, embed_chunks, index_chunks
+
+load_documents(settings: Settings, prefix: str = "") -> list[Document]
+chunk_documents(documents: list[Document], chunk_size: int = 512, chunk_overlap: int = 50) -> list[Chunk]
+embed_chunks(chunks: list[Chunk], embedder: BaseEmbedder) -> list[Chunk]
+index_chunks(chunks: list[Chunk], os_client: ProvragOpenSearchClient, index_name: str) -> int  # retries=3
+```
+
+### RAG Steps
+
+```python
+from provrag.pipelines.rag import embed_query, dense_retrieve, assemble_prompt, generate_answer
+
+embed_query(query: str, embedder: BaseEmbedder) -> list[float]                    # span_kind="EMBEDDING"
+dense_retrieve(query_vector: list[float], os_client, index_name, top_k=10)        # span_kind="RETRIEVER"
+    -> list[ScoredChunk]
+assemble_prompt(query: str, context: list[ScoredChunk]) -> str                    # span_kind="CHAIN"
+generate_answer(query, assembled_prompt, llm, system_prompt=DEFAULT_SYSTEM_PROMPT) # span_kind="LLM"
+    -> str
+```
+
+### Built-in RAG Pipeline
+
+```python
+from provrag.pipelines.rag import semantic_rag_pipeline
+# Compose: embed_query -> dense_retrieve -> assemble_prompt -> generate_answer
+```
+
+## S3DocumentLoader
+
+```python
+from provrag.storage.s3 import S3DocumentLoader
+
+loader = S3DocumentLoader(settings)
+keys = loader.list_objects(prefix="pdfs/")      # list[str]
+doc = loader.load_document(key)                  # Document (reads as UTF-8 text)
+docs = loader.load_documents(prefix="")          # list[Document]
+
+# Access the underlying boto3 client:
+loader._client.get_object(Bucket=loader._bucket, Key=key)
+```
+
+## RecursiveCharacterChunker
+
+```python
+from provrag.chunking.text_chunker import RecursiveCharacterChunker
+
+chunker = RecursiveCharacterChunker(chunk_size=512, chunk_overlap=50)
+chunks = chunker.chunk(document)         # list[Chunk] from a single Document
+chunks = chunker.chunk_batch(documents)  # list[Chunk] from multiple Documents
+```
+
+Separators tried in order: `["\n\n", "\n", ". ", " ", ""]`
+
+## FastAPI App Factory
+
+```python
+from provrag.api import create_app
+
+app = create_app(
+    pipeline=rag_pipeline,       # The @pipeline function to serve
+    name="my-project",           # App title
+    path_prefix="/my-project",   # URL prefix
+    **pipeline_kwargs,           # Passed to pipeline on each request
+)
+# Creates: GET {prefix}/health, POST {prefix}/query
+```
+
+## Tracing
+
+```python
+from provrag.tracing.setup import init_tracing
+
+init_tracing(
+    phoenix_endpoint="http://localhost:6006/v1/traces",
+    project_name="my-project",
+)
+```
+
+## Settings
+
+```python
+from provrag.settings import Settings, get_settings, Environment, LLMProvider
+
+settings = get_settings()  # Cached singleton, reads PROVRAG_* env vars
+
+settings.environment    # Environment.LOCAL or Environment.AWS
+settings.llm_provider   # LLMProvider.BEDROCK or LLMProvider.OPENAI (auto-derived)
+settings.is_local       # Computed: True if LOCAL
+settings.debug          # bool
+settings.log_level      # str: DEBUG|INFO|WARNING|ERROR|CRITICAL
+
+settings.opensearch.host          # default: "localhost"
+settings.opensearch.port          # default: 9200
+settings.opensearch.use_ssl       # default: False
+settings.opensearch.signing_host  # For SSM tunnel SigV4 signing
+
+settings.s3.bucket                # default: "provrag-documents"
+settings.s3.endpoint_url          # default: "http://localhost:9005" (MinIO)
+
+settings.bedrock.embedding_model_id  # default: "amazon.titan-embed-text-v2:0"
+settings.bedrock.llm_model_id        # default: "anthropic.claude-3-sonnet-20240229-v1:0"
+
+settings.phoenix.endpoint         # default: "http://localhost:6006/v1/traces"
+settings.phoenix.project_name     # default: "provrag"
+```
+
+Env var convention: `PROVRAG_` prefix, `__` for nesting. Example: `PROVRAG_OPENSEARCH__HOST=localhost`
+
+For full settings reference, read `references/settings-reference.md`.
+
+## Template-Generated Project Structure
+
+After `provrag init`, the project has:
+
+```
+src/{package}/
+  __init__.py       # Package version
+  app.py            # FastAPI app using create_app(rag_pipeline, ...)
+  pipeline.py       # RAG pipeline: embed_query -> dense_retrieve -> rerank -> assemble -> generate
+  ingestion.py      # Ingestion pipeline: load_documents -> preprocess -> chunk -> embed -> index
+  steps.py          # Custom steps: rerank (score-sort), preprocess (whitespace normalization)
+tests/
+  test_pipeline.py  # Pipeline registration test
+  test_steps.py     # Step unit tests
+  test_ingestion.py # Ingestion pipeline test (mocked)
+pyproject.toml      # Dependencies (provrag from CodeArtifact)
+Taskfile.yml        # Dev commands (setup, test, lint, serve, ingest, connect, disconnect, etc.)
+.env                # PROVRAG_* environment variables
+Dockerfile          # Multi-stage build for ECS deployment
+infra/              # Pulumi infrastructure-as-code
+.gitlab-ci.yml      # CI/CD pipeline
+CLAUDE.md           # Developer guide
+```
+
+### Generated steps.py (starting point for customization)
+
+```python
+from __future__ import annotations
+import re
+from typing import TYPE_CHECKING
+from provrag import step
+
+if TYPE_CHECKING:
+    from provrag.models.document import Document, ScoredChunk
+
+@step(name="rerank", span_kind="CHAIN")
+def rerank(chunks: list[ScoredChunk], query: str, top_k: int = 5) -> list[ScoredChunk]:
+    return sorted(chunks, key=lambda c: c.score, reverse=True)[:top_k]
+
+@step(name="preprocess", span_kind="CHAIN")
+def preprocess(documents: list[Document]) -> list[Document]:
+    cleaned: list[Document] = []
+    for doc in documents:
+        content = re.sub(r"\s+", " ", doc.content).strip()
+        cleaned.append(doc.model_copy(update={"content": content}))
+    return cleaned
+```
+
+### Generated pipeline.py
+
+```python
+from __future__ import annotations
+from typing import TYPE_CHECKING, cast
+from provrag import pipeline
+from provrag.pipelines.rag import assemble_prompt, dense_retrieve, embed_query, generate_answer
+from {package}.steps import rerank
+
+if TYPE_CHECKING:
+    from provrag.llm.embedder import BaseEmbedder
+    from provrag.llm.generator import BaseLLM
+    from provrag.retrieval.opensearch_client import ProvragOpenSearchClient
+
+@pipeline(name="{slug}-rag")
+def rag_pipeline(
+    query: str, embedder: BaseEmbedder, llm: BaseLLM,
+    os_client: ProvragOpenSearchClient,
+    index_name: str = "{index}", top_k: int = 10,
+) -> str:
+    query_vector = embed_query(query=query, embedder=embedder)
+    raw_chunks = dense_retrieve(query_vector=query_vector, os_client=os_client,
+                                index_name=index_name, top_k=top_k * 2)
+    reranked = rerank(chunks=raw_chunks, query=query, top_k=top_k)
+    prompt = assemble_prompt(query=query, context=reranked)
+    return cast("str", generate_answer(query=query, assembled_prompt=prompt, llm=llm))
+```
+
+### Generated ingestion.py
+
+```python
+from __future__ import annotations
+from typing import TYPE_CHECKING, cast
+from provrag import pipeline
+from provrag.llm.factory import create_embedder
+from provrag.pipelines.ingestion import chunk_documents, embed_chunks, index_chunks, load_documents
+from provrag.retrieval.opensearch_client import ProvragOpenSearchClient
+from {package}.steps import preprocess
+
+if TYPE_CHECKING:
+    from provrag.settings import Settings
+
+@pipeline(name="{slug}-ingestion")
+def ingest_pipeline(
+    settings: Settings, index_name: str = "{index}",
+    s3_prefix: str = "", chunk_size: int = 512,
+    chunk_overlap: int = 50, dimension: int = 1024,
+) -> int:
+    embedder = create_embedder(settings)
+    os_client = ProvragOpenSearchClient(settings)
+    os_client.create_index(index_name, dimension=dimension)
+    docs = load_documents(settings=settings, prefix=s3_prefix)
+    cleaned = preprocess(documents=docs)
+    chunks = chunk_documents(documents=cleaned, chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+    embedded = embed_chunks(chunks=chunks, embedder=embedder)
+    return cast("int", index_chunks(chunks=embedded, os_client=os_client, index_name=index_name))
+```
+
+## Customization Patterns
+
+For detailed recipes with complete implementations, read `references/customization-cookbook.md`.
+
+Key customization points:
+
+1. **Replace a step**: Write a new `@step` function in `steps.py`, swap the call in the pipeline
+2. **Add a step**: Write a new `@step`, insert the call at the right position in the pipeline function
+3. **Change retrieval**: Switch from `knn_search` to `hybrid_search` on the OpenSearch client
+4. **Custom system prompt**: Pass `system_prompt=` parameter to `generate_answer`
+5. **Different file types**: Replace `load_documents` with a custom loader step
+6. **Add dependencies**: Edit `pyproject.toml`, run `uv sync --extra dev`
+
+## Testing Patterns
+
+```python
+# Call .fn() to bypass Prefect wrapper
+result = my_step.fn(data=["test"])
+
+# Mock external services
+from unittest.mock import MagicMock, patch
+
+@patch("{package}.ingestion.ProvragOpenSearchClient")
+@patch("{package}.ingestion.create_embedder")
+@patch("provrag.pipelines.ingestion.S3DocumentLoader")
+def test_ingest(mock_loader_cls, mock_embedder, mock_os):
+    mock_loader = MagicMock()
+    mock_loader_cls.return_value = mock_loader
+    mock_loader.load_documents.return_value = [
+        Document(id="d1", content="test content"),
+    ]
+    ...
+
+# Settings in tests
+from provrag.settings import Settings, Environment
+settings = Settings(environment=Environment.LOCAL)
+```
+
+## Code Style
+
+- Python 3.13: `str | None` not `Optional[str]`, `StrEnum` not `str, Enum`
+- `from __future__ import annotations` at top of every file
+- `TYPE_CHECKING` guards for protocol types (`BaseEmbedder`, `BaseLLM`, `ProvragOpenSearchClient`, `Settings`)
+- Ruff formatting: line-length 120
+- mypy strict mode
+- No unnecessary comments or docstrings
+- TDD: write failing test first, then implement
+- Use `cast("str", ...)` for Prefect-wrapped return types
+
+## CLI Reference
+
+For full CLI commands and flags, read `references/cli-reference.md`.
+
+Quick reference:
+- `provrag init` -- Scaffold a new project
+- `provrag ingest` -- Run ingestion pipeline
+- `provrag serve` -- Start API server
+- `provrag status` -- Check project lifecycle stage
+- `provrag list` -- List OpenSearch indices
+- `provrag clean --index <name> --yes` -- Delete an index
+
+## ProRAG Installation
+
+ProRAG is distributed via **AWS CodeArtifact**, not PyPI:
+
+```bash
+# In a generated project:
+task ca:login    # Authenticates to CodeArtifact, writes token to .env
+task setup       # Runs uv sync with CodeArtifact auth
+
+# The pyproject.toml has a custom index:
+# [[tool.uv.index]]
+# name = "provrag"
+# url = "https://provrag-257394491982.d.codeartifact.us-east-2.amazonaws.com/pypi/provrag/simple/"
+```
+
+## AWS Connectivity
+
+For AWS environments, use SSM tunnels to access services behind VPC:
+
+```bash
+task connect      # Start SSM tunnels: OpenSearch :9200, Prefect :4200, Phoenix :6006, API :8080
+task disconnect   # Kill all SSM tunnel sessions
+```
+
+Requires: AWS SSO login (`aws sso login --profile provectus-demos`), bastion host running.

--- a/registry/skills/prorag-development/references/cli-reference.md
+++ b/registry/skills/prorag-development/references/cli-reference.md
@@ -1,0 +1,213 @@
+# ProRAG CLI Reference
+
+## Installation
+
+ProRAG is distributed via AWS CodeArtifact (not PyPI):
+
+```bash
+# In a generated project directory:
+task ca:login    # Authenticate to CodeArtifact, writes token to .env
+task setup       # Create venv and install all dependencies
+```
+
+CodeArtifact details:
+- Domain: `provrag`
+- Account: `257394491982`
+- Region: `us-east-2`
+- AWS Profile: `provectus-demos`
+
+## provrag CLI Commands
+
+### provrag init
+
+Scaffold a new ProRAG project from the Copier template.
+
+```bash
+# Interactive (prompts for all fields):
+provrag init
+
+# Non-interactive:
+provrag init --name "Acme Legal RAG" --description "Legal document Q&A" \
+  --index acme-legal-docs --dimension 1024 --author "Team Name" \
+  --gitlab-group provectus-internals/MLP-COL/ai-accelerators/provrag-projects
+```
+
+Flags:
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output-dir <dir>` | `.` | Parent directory for the new project |
+| `--name <name>` | (prompted) | Project name (e.g., "acme-legal-rag") |
+| `--description <desc>` | "RAG application built with ProRAG" | Short description |
+| `--index <name>` | `{slug}-docs` | Default OpenSearch index name |
+| `--dimension <int>` | `1024` | Embedding vector dimension |
+| `--author <name>` | "Provectus" | Author name |
+| `--gitlab-group <path>` | `provectus-internals/MLP-COL/ai-accelerators/provrag-projects` | GitLab group for repo creation |
+| `--no-gitlab` | `false` | Skip GitLab repo creation |
+
+After scaffolding:
+1. `cd <project-name>`
+2. `task ca:login` (authenticate to CodeArtifact)
+3. `task setup` (install dependencies)
+4. Configure `.env` for your environment
+
+### provrag ingest
+
+Run an ingestion pipeline to load, chunk, embed, and index documents.
+
+```bash
+provrag ingest --index my-docs --pipeline my_package.ingestion:ingest_pipeline
+provrag ingest --index my-docs --prefix pdfs/ --pipeline my_package.ingestion:ingest_pipeline
+```
+
+Flags:
+| Flag | Description |
+|------|-------------|
+| `--index <name>` | Override OpenSearch index name |
+| `--prefix <s3-prefix>` | S3 key prefix to filter documents |
+| `--pipeline <module:function>` | Pipeline path (auto-discovered if single pipeline) |
+
+### provrag serve
+
+Start the FastAPI server.
+
+```bash
+provrag serve --index my-docs --port 8000 --pipeline my_package.pipeline:rag_pipeline
+```
+
+Flags:
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host <host>` | `0.0.0.0` | Bind host |
+| `--port <int>` | `8000` | Bind port |
+| `--index <name>` | (required) | OpenSearch index to query |
+| `--pipeline <module:function>` | (auto-discovered) | Query pipeline path |
+
+Test with:
+```bash
+curl http://localhost:8000/health
+curl -X POST http://localhost:8000/query \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "What is the refund policy?"}'
+```
+
+### provrag status
+
+Show project lifecycle stage.
+
+```bash
+provrag status          # JSON output
+provrag status --human  # Pretty-printed (for human users only, agents should use plain `provrag status`)
+provrag status --stage-only  # Just the stage name
+```
+
+Stages (in order):
+`unknown` -> `scaffolded` -> `configured` -> `repo_created` -> `infra_previewed` -> `infra_deployed` -> `app_built` -> `app_deployed` -> `live`
+
+### provrag list
+
+List all OpenSearch indices.
+
+```bash
+provrag list
+```
+
+### provrag clean
+
+Delete an OpenSearch index permanently.
+
+```bash
+provrag clean --index my-docs        # Interactive confirmation
+provrag clean --index my-docs --yes  # Skip confirmation
+```
+
+Flags:
+| Flag | Description |
+|------|-------------|
+| `--index <name>` | Index to delete (required) |
+| `--yes` / `-y` | Skip confirmation prompt |
+
+## Taskfile Commands (in generated projects)
+
+### Development
+
+| Command | Description |
+|---------|-------------|
+| `task setup` | Create venv, install deps (requires `task ca:login` first) |
+| `task ca:login` | Authenticate to AWS CodeArtifact (writes token to `.env`) |
+| `task test` | Run unit tests (`uv run pytest tests/ -v`) |
+| `task lint` | Ruff check (`uv run ruff check src/ tests/`) |
+| `task format` | Ruff format (`uv run ruff format src/ tests/`) |
+| `task typecheck` | mypy strict (`uv run mypy src/`) |
+| `task check` | Run all checks: lint + typecheck + test |
+| `task upgrade` | Upgrade ProRAG to latest version |
+
+### Operations
+
+| Command | Description |
+|---------|-------------|
+| `task serve` | Start API server (`provrag serve --index {index} --port 8000`) |
+| `task ingest` | Run ingestion pipeline (`provrag ingest --index {index}`) |
+
+### AWS Connectivity
+
+| Command | Description |
+|---------|-------------|
+| `task connect` | Start SSM tunnels to AWS services via bastion host |
+| `task disconnect` | Kill all active SSM tunnel sessions |
+
+#### task connect
+
+Establishes SSM port-forwarding tunnels through the ProRAG bastion host to VPC services:
+
+| Local Port | Remote Service | Purpose |
+|------------|---------------|---------|
+| `localhost:9200` | OpenSearch VPC endpoint (port 443) | Vector search queries |
+| `localhost:4200` | ALB -> Prefect Server | Workflow UI and API |
+| `localhost:6006` | ALB -> Phoenix | Observability UI and traces |
+| `localhost:8080` | ALB -> ECS Service (port 80) | Deployed API (at `/{project-slug}/`) |
+
+Prerequisites:
+- AWS SSO session active: `aws sso login --profile provectus-demos`
+- Bastion host running (tag: `provrag-bastion-bastion`)
+- `OPENSEARCH_ENDPOINT` set in `.env`
+
+```bash
+task connect      # Starts all tunnels in background, blocks until Ctrl+C
+task disconnect   # Kills all aws ssm start-session processes
+```
+
+After connecting:
+- Access OpenSearch via `localhost:9200` (with SSL, SigV4 signing via `signing_host`)
+- Access Prefect UI at `http://localhost:4200`
+- Access Phoenix UI at `http://localhost:6006`
+- Access deployed API at `http://localhost:8080/{project-slug}/health`
+
+## Bootstrap Script
+
+Located at: `scripts/bootstrap.sh` in the ProRAG repository.
+
+Run before first `provrag init`:
+```bash
+bash scripts/bootstrap.sh
+```
+
+Checks and optionally installs:
+1. git
+2. Homebrew (macOS)
+3. Docker (+ daemon running)
+4. mise (version manager)
+5. Python 3.13 (via mise)
+6. uv (Python package manager)
+7. go-task (task runner)
+8. AWS CLI
+9. AWS SSO (`provectus-demos` profile + login)
+10. Pulumi (infrastructure-as-code)
+11. glab (GitLab CLI)
+12. glab authentication to `gitlab.provectus.com`
+13. ProRAG repository clone
+
+AWS SSO details:
+- Profile: `provectus-demos`
+- Region: `us-east-2`
+- SSO Start URL: `https://provectus.awsapps.com/start`
+- GitLab host: `gitlab.provectus.com`

--- a/registry/skills/prorag-development/references/customization-cookbook.md
+++ b/registry/skills/prorag-development/references/customization-cookbook.md
@@ -1,0 +1,551 @@
+# ProRAG Customization Cookbook
+
+Concrete recipes for customizing ProRAG-generated projects. Each recipe shows what to modify, the implementation, dependencies to add, and how to test.
+
+## Recipe: PDF Ingestion
+
+Replace the default text-based `load_documents` step with PDF parsing.
+
+### What to modify
+
+- `src/{package}/steps.py` -- Add `load_pdfs` step
+- `src/{package}/ingestion.py` -- Replace `load_documents` with `load_pdfs`
+- `pyproject.toml` -- Add `pymupdf4llm` dependency
+- `tests/test_steps.py` -- Add `load_pdfs` tests
+
+### Implementation
+
+```python
+# steps.py -- add this step
+
+import hashlib
+import tempfile
+from pathlib import Path
+
+from provrag import step
+from provrag.storage.s3 import S3DocumentLoader
+
+if TYPE_CHECKING:
+    from provrag.models.document import Document
+    from provrag.settings import Settings
+
+
+@step(name="load-pdfs", span_kind="CHAIN")
+def load_pdfs(settings: Settings, prefix: str = "") -> list[Document]:
+    import pymupdf4llm
+
+    loader = S3DocumentLoader(settings)
+    keys = loader.list_objects(prefix=prefix)
+
+    documents: list[Document] = []
+    for key in keys:
+        if not key.lower().endswith(".pdf"):
+            continue
+        response = loader._client.get_object(Bucket=loader._bucket, Key=key)
+        pdf_bytes = response["Body"].read()
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            tmp.write(pdf_bytes)
+            tmp_path = tmp.name
+
+        try:
+            md_text = pymupdf4llm.to_markdown(tmp_path)
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+        doc_id = hashlib.sha256(key.encode()).hexdigest()[:16]
+        documents.append(Document(
+            id=doc_id,
+            content=md_text,
+            metadata={"s3_key": key, "s3_bucket": loader._bucket, "source_type": "pdf"},
+        ))
+
+    return documents
+```
+
+### Ingestion pipeline update
+
+```python
+# ingestion.py -- swap load_documents for load_pdfs
+
+from {package}.steps import load_pdfs, preprocess
+
+@pipeline(name="{slug}-ingestion")
+def ingest_pipeline(settings: Settings, ...) -> int:
+    ...
+    docs = load_pdfs(settings=settings, prefix=s3_prefix)  # Changed
+    cleaned = preprocess(documents=docs)
+    ...
+```
+
+### Dependencies
+
+```bash
+uv add pymupdf4llm
+```
+
+### Test
+
+```python
+def test_load_pdfs_filters_non_pdf(self) -> None:
+    mock_loader = MagicMock()
+    mock_loader.list_objects.return_value = ["doc.pdf", "readme.txt", "data.pdf"]
+    # ... assert only .pdf files are processed
+```
+
+---
+
+## Recipe: Cross-Encoder Reranking
+
+Replace the naive score-sort rerank with a cross-encoder model.
+
+### What to modify
+
+- `src/{package}/steps.py` -- Replace `rerank` implementation
+- `pyproject.toml` -- Add `sentence-transformers` dependency
+- `tests/test_steps.py` -- Update rerank tests
+
+### Implementation
+
+```python
+# steps.py -- replace the rerank step
+
+@step(name="cross-encoder-rerank", span_kind="CHAIN")
+def rerank(chunks: list[ScoredChunk], query: str, top_k: int = 5) -> list[ScoredChunk]:
+    from sentence_transformers import CrossEncoder
+
+    if not chunks:
+        return []
+
+    model = CrossEncoder("cross-encoder/ms-marco-MiniLM-L-6-v2")
+    pairs = [(query, chunk.content) for chunk in chunks]
+    scores = model.predict(pairs)
+
+    scored = [
+        chunk.model_copy(update={"score": float(score)})
+        for chunk, score in zip(chunks, scores, strict=True)
+    ]
+    scored.sort(key=lambda c: c.score, reverse=True)
+    return scored[:top_k]
+```
+
+### Dependencies
+
+```bash
+uv add sentence-transformers
+```
+
+### Performance note
+
+The CrossEncoder model loads on first call (~200ms). For production, cache at module level:
+
+```python
+_RERANKER: CrossEncoder | None = None
+
+def _get_reranker() -> CrossEncoder:
+    global _RERANKER
+    if _RERANKER is None:
+        from sentence_transformers import CrossEncoder
+        _RERANKER = CrossEncoder("cross-encoder/ms-marco-MiniLM-L-6-v2")
+    return _RERANKER
+
+@step(name="cross-encoder-rerank", span_kind="CHAIN")
+def rerank(chunks: list[ScoredChunk], query: str, top_k: int = 5) -> list[ScoredChunk]:
+    if not chunks:
+        return []
+    model = _get_reranker()
+    ...
+```
+
+### Alternative cross-encoder models
+
+| Model | Speed | Quality | Use case |
+|-------|-------|---------|----------|
+| `cross-encoder/ms-marco-MiniLM-L-6-v2` | Fast | Good | General purpose |
+| `cross-encoder/ms-marco-MiniLM-L-12-v2` | Medium | Better | Higher quality |
+| `BAAI/bge-reranker-base` | Medium | Good | Multilingual |
+| `BAAI/bge-reranker-large` | Slow | Best | Maximum quality |
+
+### Test
+
+```python
+def test_rerank_uses_cross_encoder(self) -> None:
+    with patch("{package}.steps.CrossEncoder") as mock_ce:
+        mock_model = MagicMock()
+        mock_ce.return_value = mock_model
+        mock_model.predict.return_value = [0.9, 0.1, 0.5]
+
+        chunks = [
+            ScoredChunk(id="1", document_id="d1", content="relevant", score=0.0),
+            ScoredChunk(id="2", document_id="d1", content="irrelevant", score=0.0),
+            ScoredChunk(id="3", document_id="d1", content="somewhat", score=0.0),
+        ]
+        result = rerank.fn(chunks=chunks, query="test", top_k=2)
+
+        assert len(result) == 2
+        assert result[0].score == 0.9
+        assert result[1].score == 0.5
+```
+
+---
+
+## Recipe: Hybrid Search (BM25 + Semantic)
+
+Replace dense-only retrieval with hybrid search combining BM25 lexical and k-NN semantic search.
+
+### What to modify
+
+- `src/{package}/steps.py` -- Add `hybrid_retrieve` step and `setup_hybrid_pipeline` step
+- `src/{package}/pipeline.py` -- Replace `dense_retrieve` with `hybrid_retrieve`
+- `src/{package}/ingestion.py` -- Add hybrid pipeline setup after index creation
+
+### Implementation
+
+```python
+# steps.py -- add hybrid retrieval steps
+
+@step(name="setup-hybrid-pipeline", span_kind="CHAIN")
+def setup_hybrid_pipeline(
+    os_client: ProvragOpenSearchClient,
+    pipeline_name: str = "hybrid-search-pipeline",
+    bm25_weight: float = 0.3,
+    knn_weight: float = 0.7,
+) -> str:
+    os_client.create_hybrid_search_pipeline(
+        pipeline_name=pipeline_name,
+        bm25_weight=bm25_weight,
+        knn_weight=knn_weight,
+    )
+    return pipeline_name
+
+
+@step(name="hybrid-retrieve", span_kind="RETRIEVER")
+def hybrid_retrieve(
+    query: str,
+    query_vector: list[float],
+    os_client: ProvragOpenSearchClient,
+    index_name: str,
+    top_k: int = 10,
+    pipeline_name: str = "hybrid-search-pipeline",
+) -> list[ScoredChunk]:
+    return os_client.hybrid_search(
+        index_name=index_name,
+        query_text=query,
+        query_vector=query_vector,
+        top_k=top_k,
+        pipeline_name=pipeline_name,
+    )
+```
+
+### Pipeline update
+
+```python
+# pipeline.py -- use hybrid_retrieve
+
+from {package}.steps import rerank, hybrid_retrieve
+
+@pipeline(name="{slug}-rag")
+def rag_pipeline(
+    query: str, embedder: BaseEmbedder, llm: BaseLLM,
+    os_client: ProvragOpenSearchClient,
+    index_name: str = "{index}", top_k: int = 10,
+) -> str:
+    query_vector = embed_query(query=query, embedder=embedder)
+    raw_chunks = hybrid_retrieve(
+        query=query,
+        query_vector=query_vector,
+        os_client=os_client,
+        index_name=index_name,
+        top_k=top_k * 2,
+    )
+    reranked = rerank(chunks=raw_chunks, query=query, top_k=top_k)
+    prompt = assemble_prompt(query=query, context=reranked)
+    return cast("str", generate_answer(query=query, assembled_prompt=prompt, llm=llm))
+```
+
+### Ingestion pipeline update
+
+Add hybrid pipeline setup after index creation:
+
+```python
+# ingestion.py -- add setup_hybrid_pipeline after create_index
+
+from {package}.steps import preprocess, setup_hybrid_pipeline
+
+@pipeline(name="{slug}-ingestion")
+def ingest_pipeline(settings: Settings, ...) -> int:
+    embedder = create_embedder(settings)
+    os_client = ProvragOpenSearchClient(settings)
+    os_client.create_index(index_name, dimension=dimension)
+    setup_hybrid_pipeline(os_client=os_client)  # Add this
+    docs = load_documents(settings=settings, prefix=s3_prefix)
+    ...
+```
+
+---
+
+## Recipe: Custom System Prompt
+
+Override the default RAG system prompt for domain-specific responses.
+
+### What to modify
+
+- `src/{package}/pipeline.py` -- Add custom system prompt
+
+### Implementation
+
+```python
+# pipeline.py -- add custom system prompt
+
+SYSTEM_PROMPT = """\
+You are a legal research assistant for Acme Corp.
+Answer questions based only on the provided context from company legal documents.
+Always cite the source document by its metadata s3_key.
+If the context does not contain an answer, say "I could not find this in the provided documents."
+Never provide legal advice -- only summarize what the documents say.
+"""
+
+@pipeline(name="{slug}-rag")
+def rag_pipeline(
+    query: str, embedder: BaseEmbedder, llm: BaseLLM,
+    os_client: ProvragOpenSearchClient,
+    index_name: str = "{index}", top_k: int = 10,
+) -> str:
+    query_vector = embed_query(query=query, embedder=embedder)
+    raw_chunks = dense_retrieve(
+        query_vector=query_vector, os_client=os_client,
+        index_name=index_name, top_k=top_k * 2,
+    )
+    reranked = rerank(chunks=raw_chunks, query=query, top_k=top_k)
+    prompt = assemble_prompt(query=query, context=reranked)
+    return cast("str", generate_answer(
+        query=query,
+        assembled_prompt=prompt,
+        llm=llm,
+        system_prompt=SYSTEM_PROMPT,  # Override default
+    ))
+```
+
+---
+
+## Recipe: Custom Chunking Strategy
+
+Replace recursive character chunking with a domain-specific strategy.
+
+### Sentence-based chunking
+
+```python
+# steps.py
+
+@step(name="sentence-chunk", span_kind="CHAIN")
+def sentence_chunk(
+    documents: list[Document],
+    sentences_per_chunk: int = 5,
+    overlap_sentences: int = 1,
+) -> list[Chunk]:
+    import re
+    all_chunks: list[Chunk] = []
+    for doc in documents:
+        sentences = re.split(r'(?<=[.!?])\s+', doc.content)
+        for i in range(0, len(sentences), sentences_per_chunk - overlap_sentences):
+            chunk_sentences = sentences[i:i + sentences_per_chunk]
+            if not chunk_sentences:
+                continue
+            content = " ".join(chunk_sentences)
+            chunk_id = hashlib.sha256(f"{doc.id}:{i}".encode()).hexdigest()[:16]
+            all_chunks.append(Chunk(
+                id=chunk_id,
+                document_id=doc.id,
+                content=content,
+                metadata={**doc.metadata, "chunk_index": i},
+            ))
+    return all_chunks
+```
+
+Then replace `chunk_documents` in the ingestion pipeline:
+
+```python
+# ingestion.py
+from {package}.steps import preprocess, sentence_chunk
+
+@pipeline(name="{slug}-ingestion")
+def ingest_pipeline(settings: Settings, ...) -> int:
+    ...
+    docs = load_documents(settings=settings, prefix=s3_prefix)
+    cleaned = preprocess(documents=docs)
+    chunks = sentence_chunk(documents=cleaned, sentences_per_chunk=5)  # Changed
+    embedded = embed_chunks(chunks=chunks, embedder=embedder)
+    ...
+```
+
+### Markdown-aware chunking
+
+For documents that are already markdown (e.g., from PDF-to-markdown conversion):
+
+```python
+@step(name="markdown-chunk", span_kind="CHAIN")
+def markdown_chunk(
+    documents: list[Document],
+    chunk_size: int = 512,
+    chunk_overlap: int = 50,
+) -> list[Chunk]:
+    """Split on markdown headers first, then by size."""
+    import re
+    all_chunks: list[Chunk] = []
+    for doc in documents:
+        sections = re.split(r'\n(?=#{1,3}\s)', doc.content)
+        chunker = RecursiveCharacterChunker(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+        for section in sections:
+            if not section.strip():
+                continue
+            section_doc = doc.model_copy(update={"content": section})
+            all_chunks.extend(chunker.chunk(section_doc))
+    return all_chunks
+```
+
+---
+
+## Recipe: Metadata Enrichment
+
+Add document-level metadata before chunking for better filtering.
+
+```python
+@step(name="enrich-metadata", span_kind="CHAIN")
+def enrich_metadata(documents: list[Document]) -> list[Document]:
+    enriched: list[Document] = []
+    for doc in documents:
+        key = doc.metadata.get("s3_key", "")
+        # Extract category from S3 path: docs/legal/contract.pdf -> "legal"
+        parts = key.split("/")
+        category = parts[1] if len(parts) > 2 else "general"
+
+        enriched.append(doc.model_copy(update={
+            "metadata": {
+                **doc.metadata,
+                "category": category,
+                "char_count": len(doc.content),
+                "word_count": len(doc.content.split()),
+            },
+        }))
+    return enriched
+```
+
+Insert in ingestion pipeline after loading, before preprocessing:
+
+```python
+docs = load_documents(settings=settings, prefix=s3_prefix)
+docs = enrich_metadata(documents=docs)  # Add this
+cleaned = preprocess(documents=docs)
+```
+
+---
+
+## Recipe: Mixed File Type Ingestion
+
+Handle both PDF and text files in a single ingestion pipeline.
+
+```python
+@step(name="load-mixed-documents", span_kind="CHAIN")
+def load_mixed_documents(settings: Settings, prefix: str = "") -> list[Document]:
+    import pymupdf4llm
+
+    loader = S3DocumentLoader(settings)
+    keys = loader.list_objects(prefix=prefix)
+    documents: list[Document] = []
+
+    for key in keys:
+        if key.lower().endswith(".pdf"):
+            response = loader._client.get_object(Bucket=loader._bucket, Key=key)
+            pdf_bytes = response["Body"].read()
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+                tmp.write(pdf_bytes)
+                tmp_path = tmp.name
+            try:
+                content = pymupdf4llm.to_markdown(tmp_path)
+            finally:
+                Path(tmp_path).unlink(missing_ok=True)
+            source_type = "pdf"
+        elif key.lower().endswith((".txt", ".md", ".csv")):
+            response = loader._client.get_object(Bucket=loader._bucket, Key=key)
+            content = response["Body"].read().decode("utf-8")
+            source_type = "text"
+        else:
+            continue
+
+        doc_id = hashlib.sha256(key.encode()).hexdigest()[:16]
+        documents.append(Document(
+            id=doc_id,
+            content=content,
+            metadata={"s3_key": key, "s3_bucket": loader._bucket, "source_type": source_type},
+        ))
+
+    return documents
+```
+
+---
+
+## Recipe: Query Expansion
+
+Add a query expansion step before embedding for better retrieval coverage.
+
+```python
+@step(name="expand-query", span_kind="LLM")
+def expand_query(query: str, llm: BaseLLM) -> str:
+    system_prompt = (
+        "You are a query expansion assistant. Given a user question, "
+        "generate 3 alternative phrasings separated by newlines. "
+        "Return ONLY the alternative queries, no numbering or explanation."
+    )
+    result = llm.generate(system_prompt=system_prompt, user_message=query)
+    expanded = f"{query}\n{result.response}"
+    return expanded
+```
+
+Use in the RAG pipeline before embedding:
+
+```python
+@pipeline(name="{slug}-rag")
+def rag_pipeline(query, embedder, llm, os_client, index_name, top_k=10):
+    expanded = expand_query(query=query, llm=llm)
+    # Embed the original query for vector search
+    query_vector = embed_query(query=query, embedder=embedder)
+    # Use expanded query for hybrid text search
+    raw_chunks = hybrid_retrieve(
+        query=expanded,
+        query_vector=query_vector,
+        os_client=os_client,
+        index_name=index_name,
+        top_k=top_k * 2,
+    )
+    ...
+```
+
+---
+
+## General Pattern: Adding a New Step
+
+Template for any new step:
+
+```python
+from __future__ import annotations
+from typing import TYPE_CHECKING
+from provrag import step
+
+if TYPE_CHECKING:
+    # Import types only for type checking
+    from provrag.models.document import Document, ScoredChunk
+
+@step(name="my-step-name", span_kind="CHAIN")
+def my_step(input_data: InputType, param: str = "default") -> OutputType:
+    # Transform data
+    result = ...
+    return result
+```
+
+Then insert the call in the appropriate pipeline function at the right position.
+
+`span_kind` choices:
+- `"CHAIN"` -- general transformation (default)
+- `"EMBEDDING"` -- embedding operation
+- `"RETRIEVER"` -- search/retrieval operation
+- `"LLM"` -- language model call

--- a/registry/skills/prorag-development/references/settings-reference.md
+++ b/registry/skills/prorag-development/references/settings-reference.md
@@ -1,0 +1,146 @@
+# ProRAG Settings Reference
+
+All settings use Pydantic v2 BaseSettings with `PROVRAG_` prefix and `__` nested delimiter.
+
+Source: `.env` file or system environment variables.
+
+## Settings Class
+
+```python
+from provrag.settings import Settings, get_settings, Environment, LLMProvider
+
+settings = get_settings()  # Cached singleton
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="PROVRAG_",
+        env_nested_delimiter="__",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    environment: Environment = Environment.LOCAL   # "local" or "aws"
+    debug: bool = False
+    log_level: str = "INFO"                        # DEBUG|INFO|WARNING|ERROR|CRITICAL
+    llm_provider: LLMProvider | None = None        # "bedrock" or "openai", auto-derived
+
+    opensearch: OpenSearchSettings
+    prefect: PrefectSettings
+    phoenix: PhoenixSettings
+    s3: S3Settings
+    bedrock: BedrockSettings
+
+    @computed_field
+    @property
+    def is_local(self) -> bool:
+        return self.environment == Environment.LOCAL
+```
+
+LLM provider auto-derivation: if `llm_provider` is not set, it defaults to `BEDROCK` when `environment=aws`, `OPENAI` when `environment=local`.
+
+## Environment Variables
+
+### Core
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `PROVRAG_ENVIRONMENT` | `local` \| `aws` | `local` | Runtime environment |
+| `PROVRAG_DEBUG` | bool | `false` | Debug mode |
+| `PROVRAG_LOG_LEVEL` | str | `INFO` | Log level |
+| `PROVRAG_LLM_PROVIDER` | `bedrock` \| `openai` | (derived) | LLM provider override |
+
+### OpenSearch (`PROVRAG_OPENSEARCH__*`)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PROVRAG_OPENSEARCH__HOST` | `localhost` | OpenSearch host |
+| `PROVRAG_OPENSEARCH__PORT` | `9200` | OpenSearch port |
+| `PROVRAG_OPENSEARCH__USE_SSL` | `false` | Enable SSL |
+| `PROVRAG_OPENSEARCH__VERIFY_CERTS` | `false` | Verify SSL certificates |
+| `PROVRAG_OPENSEARCH__AWS_REGION` | `us-east-1` | AWS region for SigV4 signing |
+| `PROVRAG_OPENSEARCH__SIGNING_HOST` | (none) | Real VPC endpoint hostname for SSM tunnel SigV4 |
+
+### S3 / MinIO (`PROVRAG_S3__*`)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PROVRAG_S3__ENDPOINT_URL` | `http://localhost:9005` | S3/MinIO endpoint (null for real S3) |
+| `PROVRAG_S3__BUCKET` | `provrag-documents` | Document bucket name |
+| `PROVRAG_S3__AWS_REGION` | `us-east-1` | AWS region |
+| `PROVRAG_S3__ACCESS_KEY` | `minioadmin` | MinIO access key (null for real S3) |
+| `PROVRAG_S3__SECRET_KEY` | `minioadmin` | MinIO secret key (null for real S3) |
+
+### Prefect (`PROVRAG_PREFECT__*`)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PROVRAG_PREFECT__API_URL` | `http://localhost:4200/api` | Prefect server API URL |
+
+Note: Also set `PREFECT_API_URL` (no `PROVRAG_` prefix) as an env var for the Prefect client.
+
+### Phoenix (`PROVRAG_PHOENIX__*`)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PROVRAG_PHOENIX__ENDPOINT` | `http://localhost:6006/v1/traces` | Phoenix OTEL collector endpoint |
+| `PROVRAG_PHOENIX__PROJECT_NAME` | `provrag` | Phoenix project name |
+
+### Bedrock (`PROVRAG_BEDROCK__*`)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PROVRAG_BEDROCK__AWS_REGION` | `us-east-1` | Bedrock region |
+| `PROVRAG_BEDROCK__EMBEDDING_MODEL_ID` | `amazon.titan-embed-text-v2:0` | Embedding model |
+| `PROVRAG_BEDROCK__LLM_MODEL_ID` | `anthropic.claude-3-sonnet-20240229-v1:0` | LLM model |
+
+## Local Environment Example (.env)
+
+```bash
+PROVRAG_ENVIRONMENT=local
+PROVRAG_DEBUG=true
+PROVRAG_LOG_LEVEL=DEBUG
+
+PROVRAG_OPENSEARCH__HOST=localhost
+PROVRAG_OPENSEARCH__PORT=9200
+
+PROVRAG_S3__ENDPOINT_URL=http://localhost:9005
+PROVRAG_S3__BUCKET=provrag-documents
+PROVRAG_S3__ACCESS_KEY=minioadmin
+PROVRAG_S3__SECRET_KEY=minioadmin
+
+PREFECT_API_URL=http://localhost:4200/api
+PROVRAG_PREFECT__API_URL=http://localhost:4200/api
+
+PROVRAG_PHOENIX__ENDPOINT=http://localhost:6006/v1/traces
+PROVRAG_PHOENIX__PROJECT_NAME=my-project
+```
+
+## AWS Environment Example (.env)
+
+```bash
+PROVRAG_ENVIRONMENT=aws
+PROVRAG_LOG_LEVEL=INFO
+AWS_PROFILE=provectus-demos
+
+PROVRAG_OPENSEARCH__HOST=localhost
+PROVRAG_OPENSEARCH__PORT=9200
+PROVRAG_OPENSEARCH__USE_SSL=true
+PROVRAG_OPENSEARCH__VERIFY_CERTS=false
+PROVRAG_OPENSEARCH__AWS_REGION=us-east-2
+PROVRAG_OPENSEARCH__SIGNING_HOST=<vpc-opensearch-endpoint>
+
+PROVRAG_S3__BUCKET=<s3-bucket-name>
+# No endpoint_url, access_key, secret_key -- uses IAM
+
+PREFECT_API_URL=http://localhost:4200/api
+PROVRAG_PREFECT__API_URL=http://localhost:4200/api
+
+PROVRAG_PHOENIX__ENDPOINT=http://localhost:6006/v1/traces
+PROVRAG_PHOENIX__PROJECT_NAME=my-project
+
+OPENSEARCH_ENDPOINT=<vpc-opensearch-endpoint>
+```
+
+Note: In AWS mode with SSM tunnels (`task connect`), services are accessed via localhost ports but signed with the real VPC endpoint hostname via `signing_host`.


### PR DESCRIPTION
## Summary

- **Skill**: `prorag-development` — ProRAG framework architecture (@step/@pipeline decorators), data models (Document, Chunk, ScoredChunk), LLM abstractions, OpenSearch retrieval, settings system (PROVRAG_* env vars), CLI operations, testing with .fn() bypass, Python 3.13 style. 4 reference files.
- **Agent**: `prorag-specialist` — TDD-first orchestration for composable RAG pipeline development.

Adapted from provectus-marketplace `proagent-prorag` plugin.

## Test plan

- [x] `uv run python -m awos_recruitment_mcp.validate` passes
- [x] `uv run pytest tests/ -v` — all tests pass
- [x] Semantic search: query "RAG pipeline ingestion retrieval" ranks `prorag-development` #1