### PR TITLE
Add 6 MCP server definitions (Slack, GitLab, Atlassian, Google Drive, Google Workspace, Excalidraw)

### DIFF
--- a/registry/mcp/atlassian.yaml
+++ b/registry/mcp/atlassian.yaml
@@ -1,0 +1,13 @@
+name: "atlassian"
+description: "Atlassian Jira and Confluence integration — manage issues, sprints, boards, backlogs in Jira; create, update, search, and publish pages in Confluence."
+config:
+  atlassian:
+    type: stdio
+    command: npx
+    args:
+      - -y
+      - "@modelcontextprotocol/server-atlassian"
+    env:
+      ATLASSIAN_API_TOKEN: "${ATLASSIAN_API_TOKEN}"
+      ATLASSIAN_EMAIL: "${ATLASSIAN_EMAIL}"
+      ATLASSIAN_DOMAIN: "${ATLASSIAN_DOMAIN}"

--- a/registry/mcp/excalidraw.yaml
+++ b/registry/mcp/excalidraw.yaml
@@ -1,0 +1,6 @@
+name: "excalidraw"
+description: "Interactive visual diagramming — create and render Excalidraw diagrams directly from natural language descriptions. Supports architecture diagrams, flowcharts, sequence diagrams, and wireframes."
+config:
+  excalidraw:
+    type: http
+    url: "https://mcp.excalidraw.com/mcp"

--- a/registry/mcp/gitlab.yaml
+++ b/registry/mcp/gitlab.yaml
@@ -1,0 +1,12 @@
+name: "gitlab"
+description: "GitLab integration — repositories, merge requests, CI/CD pipelines, issues, code search, vulnerability reports, and container registry management."
+config:
+  gitlab:
+    type: stdio
+    command: npx
+    args:
+      - -y
+      - "@modelcontextprotocol/server-gitlab"
+    env:
+      GITLAB_PERSONAL_ACCESS_TOKEN: "${GITLAB_PERSONAL_ACCESS_TOKEN}"
+      GITLAB_API_URL: "${GITLAB_API_URL}"

--- a/registry/mcp/google-drive.yaml
+++ b/registry/mcp/google-drive.yaml
@@ -1,0 +1,9 @@
+name: "google-drive"
+description: "Google Drive file access — list, search, and read Drive files. Exports Google Docs as Markdown, Sheets as CSV, and Slides as plain text."
+config:
+  google-drive:
+    type: stdio
+    command: npx
+    args:
+      - -y
+      - "@modelcontextprotocol/server-gdrive"

--- a/registry/mcp/google-workspace.yaml
+++ b/registry/mcp/google-workspace.yaml
@@ -1,0 +1,8 @@
+name: "google-workspace"
+description: "Gmail and Google Calendar integration — list, search, send, and draft emails; list, create, update, and delete calendar events."
+config:
+  google-workspace:
+    type: stdio
+    command: uvx
+    args:
+      - "mcp-gsuite"

--- a/registry/mcp/slack.yaml
+++ b/registry/mcp/slack.yaml
@@ -1,0 +1,12 @@
+name: "slack"
+description: "Slack workspace access — channels, messages, users, threads, reactions, and search. Enables reading and posting messages across Slack workspaces."
+config:
+  slack:
+    type: stdio
+    command: npx
+    args:
+      - -y
+      - "slack-mcp-server@latest"
+    env:
+      SLACK_MCP_XOXC_TOKEN: "${SLACK_MCP_XOXC_TOKEN}"
+      SLACK_MCP_XOXD_TOKEN: "${SLACK_MCP_XOXD_TOKEN}"


### PR DESCRIPTION
## Summary

6 new MCP server definitions:

| MCP | Transport | Description |
|-----|-----------|-------------|
| `slack` | stdio (npx) | Workspace messaging, channels, threads, reactions, search |
| `gitlab` | stdio (npx) | Repositories, merge requests, CI/CD, issues, container registry |
| `atlassian` | stdio (npx) | Jira issues/sprints/boards + Confluence pages |
| `google-drive` | stdio (npx) | File listing, search, read (exports Docs/Sheets/Slides) |
| `google-workspace` | stdio (uvx) | Gmail + Google Calendar integration |
| `excalidraw` | http | Visual diagramming via remote MCP endpoint |

Adapted from provectus-marketplace common MCP configurations.

## Test plan

- [x] `uv run python -m awos_recruitment_mcp.validate` passes
- [x] `uv run pytest tests/ -v` — all tests pass
- [x] Semantic search: query "Slack integration" (type=tool) ranks `slack` #1 (score 64)