### PR TITLE
Feature/apple dev skill additional refs

### DIFF
--- a/registry/skills/apple-app-development/SKILL.md
+++ b/registry/skills/apple-app-development/SKILL.md
@@ -14,7 +14,7 @@ For Swift language fundamentals (type system, optionals, error handling, concurr
 
 - **Always generate Swift.** Only write Objective-C when the project explicitly requires it (legacy codebase, Obj-C-only API). See `references/objc-interop.md` for bridging patterns.
 - **SwiftUI-first.** Use UIKit/AppKit only when SwiftUI lacks the capability. See `references/uikit-interop.md` for interop patterns.
-- **Respect the existing UI framework.** In legacy UIKit codebases, do not mix SwiftUI and UIKit within the same screen or component — this causes lifecycle, navigation, and responder chain conflicts. New **isolated flows** (full screens or self-contained features) may use SwiftUI, but existing UIKit screens should not be partially rewritten without explicit request. For greenfield projects, use SwiftUI exclusively.
+- **Respect the existing UI framework.** In legacy UIKit codebases, do not mix SwiftUI and UIKit **lifecycle or navigation** within the same screen (e.g., nesting `UINavigationController` inside `NavigationStack`). Using `UIViewRepresentable` to embed individual UIKit views (maps, web views, text editors) within a SwiftUI screen is expected and supported. New **isolated flows** (full screens or self-contained features) may use SwiftUI, but existing UIKit screens should not be partially rewritten without explicit request. For greenfield projects, use SwiftUI exclusively.
 - **Check the project context.** Before applying patterns, check the deployment target, Swift version, and existing architecture. Adapt recommendations accordingly.
 - **No `#if` / compiler directives for multi-target branching.** Do not use `#if TARGET_NAME` or custom build flags to branch behavior between app targets. Instead, use dependency injection (protocol + per-target conformance) or separate file implementations (one per target, added to the correct target membership in Xcode). `#if` directives are reserved for excluding code from compilation entirely (e.g., `#if DEBUG`, `#if os(iOS)`, `#if canImport(UIKit)`) — not for runtime or build-time polymorphism between targets in the same project.
 - **Always localize user-facing text.** Never use explicit string literals for user-facing text (e.g., `"Welcome back"`, `Text("Sign in")`). Always use whichever localization solution is already in use in the project (e.g., String Catalogs, `.strings` files, a custom localization layer). Do not migrate to a different solution unless explicitly asked. When you encounter an existing explicit string that should be localized, flag it and suggest the appropriate key name and parameter names, but do not migrate it unless asked. See `references/localization.md` for String Catalog patterns and named parameter format.
@@ -161,7 +161,8 @@ Rules:
 - Use `@Observable` (iOS 17+) over `ObservableObject`/`@Published` for new code.
 - Use `.task` for async work tied to view lifecycle — it cancels automatically.
 - Keep views small. Extract subviews when `body` exceeds ~30 lines.
-- Use `@State` for view-local state, `@Binding` for parent-child communication.
+- Use `@State` for view-local state, `@Binding` for parent-child communication, `@Bindable` for bindings to `@Observable` properties, and `@Environment` for shared/injected state.
+- **`@State` + `@Observable` caveat:** Unlike `@StateObject`, `@State` re-evaluates the initializer expression on every view struct recreation (SwiftUI discards the new instance but `init()` still runs). Avoid side effects in `@Observable` class initializers — use `.task` for deferred setup.
 
 For navigation, lists, forms, custom modifiers, and advanced patterns see `references/swiftui-patterns.md`.
 
@@ -270,7 +271,7 @@ struct HomeView: View {
 
 ### TCA (The Composable Architecture) — Alternative
 
-For teams that prefer a stricter unidirectional architecture (similar to MVI on Android), TCA provides `State` + `Action` + `Reducer` + `Store` with built-in dependency injection, side effect management, and exhaustive testing. It is a third-party framework (Point-Free) but widely adopted in the iOS community.
+For teams that prefer a stricter unidirectional architecture (similar to MVI on Android), TCA provides `State` + `Action` + `Reducer` + `Store` with built-in dependency injection, side effect management, and exhaustive testing. It is a third-party framework (Point-Free), well-established and actively maintained in the iOS community.
 
 ```swift
 // TCA pattern (requires swift-composable-architecture package)
@@ -339,7 +340,7 @@ MyApp/
 Rules:
 - Organize by feature, not by technical role.
 - Extract shared logic into local SPM packages for build time and testability.
-- One type per file, file name matches type name.
+- Prefer one primary type per file, file name matches type name. Small closely-related helper types may co-locate.
 
 For SPM multi-module setup, build configurations, targets, schemes see `references/project-structure.md`.
 
@@ -388,5 +389,5 @@ Cross-platform features:
 | String-based navigation | Use `NavigationPath` with typed destinations |
 | Magic numbers in UI (`padding(16)`, `.cornerRadius(8)`) | Define design tokens (`AppSpacing.medium`, `AppCornerRadius.standard`) |
 | `#if TARGET_NAME` for multi-target branching | Use DI (protocol + per-target conformance) or separate files per target |
-| Mixing SwiftUI and UIKit in one screen | Keep frameworks isolated: new flows in SwiftUI, existing UIKit screens untouched |
+| Mixing SwiftUI and UIKit lifecycle/navigation in one screen | Don't nest `UINavigationController` inside `NavigationStack`; `UIViewRepresentable` for individual views is fine |
 | Hard-coded user-facing strings (`"Welcome back"`, `Text("Sign in")`) | Use localized strings — reference the project's localization solution (String Catalogs, `.strings`, etc.) |

--- a/registry/skills/apple-app-development/SKILL.md
+++ b/registry/skills/apple-app-development/SKILL.md
@@ -17,6 +17,7 @@ For Swift language fundamentals (type system, optionals, error handling, concurr
 - **Respect the existing UI framework.** In legacy UIKit codebases, do not mix SwiftUI and UIKit within the same screen or component — this causes lifecycle, navigation, and responder chain conflicts. New **isolated flows** (full screens or self-contained features) may use SwiftUI, but existing UIKit screens should not be partially rewritten without explicit request. For greenfield projects, use SwiftUI exclusively.
 - **Check the project context.** Before applying patterns, check the deployment target, Swift version, and existing architecture. Adapt recommendations accordingly.
 - **No `#if` / compiler directives for multi-target branching.** Do not use `#if TARGET_NAME` or custom build flags to branch behavior between app targets. Instead, use dependency injection (protocol + per-target conformance) or separate file implementations (one per target, added to the correct target membership in Xcode). `#if` directives are reserved for excluding code from compilation entirely (e.g., `#if DEBUG`, `#if os(iOS)`, `#if canImport(UIKit)`) — not for runtime or build-time polymorphism between targets in the same project.
+- **Always localize user-facing text.** Never use explicit string literals for user-facing text (e.g., `"Welcome back"`, `Text("Sign in")`). Always use whichever localization solution is already in use in the project (e.g., String Catalogs, `.strings` files, a custom localization layer). Do not migrate to a different solution unless explicitly asked. When you encounter an existing explicit string that should be localized, flag it and suggest the appropriate key name and parameter names, but do not migrate it unless asked. See `references/localization.md` for String Catalog patterns and named parameter format.
 
 ## Reference Files
 
@@ -38,6 +39,7 @@ For Swift language fundamentals (type system, optionals, error handling, concurr
 - **`references/carplay-patterns.md`** — CarPlay app lifecycle, CPTemplate API, navigation, media, EV charging, communication apps
 - **`references/objc-interop.md`** — Bridging headers, `@objc`, `NS_SWIFT_NAME`, nullability annotations, incremental migration
 - **`references/testing.md`** — Swift Testing (@Test, #expect, traits, parameterized), XCTest (unit tests, async, performance), XCUITest (UI automation, page objects), test doubles, snapshot testing, test plans, CI/CD
+- **`references/localization.md`** — String Catalogs (.xcstrings), code-generated accessors, named parameter format (`%(name)@`, `%1$(name)@`), custom table namespacing, localization best practices
 - **`references/code-quality.md`** — Xcode Static Analyzer, sanitizers (ASan, TSan, UBSan), Periphery (dead code), Danger-Swift, Xcode build settings, xcconfig. For SwiftLint/SwiftFormat, see `swift-development` skill's `references/static-analysis.md`
 
 ## Code Style
@@ -387,3 +389,4 @@ Cross-platform features:
 | Magic numbers in UI (`padding(16)`, `.cornerRadius(8)`) | Define design tokens (`AppSpacing.medium`, `AppCornerRadius.standard`) |
 | `#if TARGET_NAME` for multi-target branching | Use DI (protocol + per-target conformance) or separate files per target |
 | Mixing SwiftUI and UIKit in one screen | Keep frameworks isolated: new flows in SwiftUI, existing UIKit screens untouched |
+| Hard-coded user-facing strings (`"Welcome back"`, `Text("Sign in")`) | Use localized strings — reference the project's localization solution (String Catalogs, `.strings`, etc.) |

--- a/registry/skills/apple-app-development/SKILL.md
+++ b/registry/skills/apple-app-development/SKILL.md
@@ -36,7 +36,7 @@ For Swift language fundamentals (type system, optionals, error handling, concurr
 - **`references/carplay-patterns.md`** — CarPlay app lifecycle, CPTemplate API, navigation, media, EV charging, communication apps
 - **`references/objc-interop.md`** — Bridging headers, `@objc`, `NS_SWIFT_NAME`, nullability annotations, incremental migration
 - **`references/testing.md`** — Swift Testing (@Test, #expect, traits, parameterized), XCTest (unit tests, async, performance), XCUITest (UI automation, page objects), test doubles, snapshot testing, test plans, CI/CD
-- **`references/code-quality.md`** — SwiftLint (configuration, rules, custom rules), SwiftFormat, Periphery (dead code), Xcode static analysis, sanitizers, CI/CD quality gates
+- **`references/code-quality.md`** — Xcode Static Analyzer, sanitizers (ASan, TSan, UBSan), Periphery (dead code), Danger-Swift, Xcode build settings, xcconfig. For SwiftLint/SwiftFormat, see `swift-development` skill's `references/static-analysis.md`
 
 ## Code Style
 

--- a/registry/skills/apple-app-development/SKILL.md
+++ b/registry/skills/apple-app-development/SKILL.md
@@ -14,6 +14,7 @@ For Swift language fundamentals (type system, optionals, error handling, concurr
 
 - **Always generate Swift.** Only write Objective-C when the project explicitly requires it (legacy codebase, Obj-C-only API). See `references/objc-interop.md` for bridging patterns.
 - **SwiftUI-first.** Use UIKit/AppKit only when SwiftUI lacks the capability. See `references/uikit-interop.md` for interop patterns.
+- **Respect the existing UI framework.** In legacy UIKit codebases, do not mix SwiftUI and UIKit within the same screen or component — this causes lifecycle, navigation, and responder chain conflicts. New **isolated flows** (full screens or self-contained features) may use SwiftUI, but existing UIKit screens should not be partially rewritten without explicit request. For greenfield projects, use SwiftUI exclusively.
 - **Check the project context.** Before applying patterns, check the deployment target, Swift version, and existing architecture. Adapt recommendations accordingly.
 - **No `#if` / compiler directives for multi-target branching.** Do not use `#if TARGET_NAME` or custom build flags to branch behavior between app targets. Instead, use dependency injection (protocol + per-target conformance) or separate file implementations (one per target, added to the correct target membership in Xcode). `#if` directives are reserved for excluding code from compilation entirely (e.g., `#if DEBUG`, `#if os(iOS)`, `#if canImport(UIKit)`) — not for runtime or build-time polymorphism between targets in the same project.
 
@@ -385,3 +386,4 @@ Cross-platform features:
 | String-based navigation | Use `NavigationPath` with typed destinations |
 | Magic numbers in UI (`padding(16)`, `.cornerRadius(8)`) | Define design tokens (`AppSpacing.medium`, `AppCornerRadius.standard`) |
 | `#if TARGET_NAME` for multi-target branching | Use DI (protocol + per-target conformance) or separate files per target |
+| Mixing SwiftUI and UIKit in one screen | Keep frameworks isolated: new flows in SwiftUI, existing UIKit screens untouched |

--- a/registry/skills/apple-app-development/SKILL.md
+++ b/registry/skills/apple-app-development/SKILL.md
@@ -35,6 +35,8 @@ For Swift language fundamentals (type system, optionals, error handling, concurr
 - **`references/widgets-app-intents.md`** — WidgetKit (timeline, configuration), App Intents, Shortcuts, Live Activities
 - **`references/carplay-patterns.md`** — CarPlay app lifecycle, CPTemplate API, navigation, media, EV charging, communication apps
 - **`references/objc-interop.md`** — Bridging headers, `@objc`, `NS_SWIFT_NAME`, nullability annotations, incremental migration
+- **`references/testing.md`** — Swift Testing (@Test, #expect, traits, parameterized), XCTest (unit tests, async, performance), XCUITest (UI automation, page objects), test doubles, snapshot testing, test plans, CI/CD
+- **`references/code-quality.md`** — SwiftLint (configuration, rules, custom rules), SwiftFormat, Periphery (dead code), Xcode static analysis, sanitizers, CI/CD quality gates
 
 ## Code Style
 
@@ -339,31 +341,13 @@ For SPM multi-module setup, build configurations, targets, schemes see `referenc
 
 ## Testable Design
 
-For general testable design patterns (DI, fakes over mocks, protocol-based injection), see the `swift-development` skill. Below are Apple platform-specific testing patterns.
+For general testable design patterns (DI, fakes over mocks, protocol-based injection), see the `swift-development` skill. For comprehensive testing guidance, see `references/testing.md` (Swift Testing, XCTest, XCUITest, test doubles, test plans, CI/CD) and `references/code-quality.md` (linting, static analysis, sanitizers).
 
+Key principles:
 - **`@Environment` injection** — use SwiftUI environment for injecting dependencies in the view layer.
-- **ViewInspector or snapshot tests** — for testing SwiftUI view output.
-- **XCTest UI tests** — for end-to-end flows on device/simulator.
-
-```swift
-// Environment-based injection for views
-private struct UserRepositoryKey: EnvironmentKey {
-    static let defaultValue: UserRepository = RemoteUserRepository()
-}
-
-extension EnvironmentValues {
-    var userRepository: UserRepository {
-        get { self[UserRepositoryKey.self] }
-        set { self[UserRepositoryKey.self] = newValue }
-    }
-}
-
-// Inject in previews/tests
-#Preview {
-    HomeView()
-        .environment(\.userRepository, FakeUserRepository())
-}
-```
+- **Protocol-based DI** — inject dependencies via init for testability. Inject `Clock` for time-dependent code.
+- **Snapshot tests** — verify UI appearance with swift-snapshot-testing.
+- **XCUITest** — for end-to-end flows on device/simulator with Page Object pattern.
 
 ## Platform-Specific Guidance
 

--- a/registry/skills/apple-app-development/SKILL.md
+++ b/registry/skills/apple-app-development/SKILL.md
@@ -15,6 +15,7 @@ For Swift language fundamentals (type system, optionals, error handling, concurr
 - **Always generate Swift.** Only write Objective-C when the project explicitly requires it (legacy codebase, Obj-C-only API). See `references/objc-interop.md` for bridging patterns.
 - **SwiftUI-first.** Use UIKit/AppKit only when SwiftUI lacks the capability. See `references/uikit-interop.md` for interop patterns.
 - **Check the project context.** Before applying patterns, check the deployment target, Swift version, and existing architecture. Adapt recommendations accordingly.
+- **No `#if` / compiler directives for multi-target branching.** Do not use `#if TARGET_NAME` or custom build flags to branch behavior between app targets. Instead, use dependency injection (protocol + per-target conformance) or separate file implementations (one per target, added to the correct target membership in Xcode). `#if` directives are reserved for excluding code from compilation entirely (e.g., `#if DEBUG`, `#if os(iOS)`, `#if canImport(UIKit)`) — not for runtime or build-time polymorphism between targets in the same project.
 
 ## Reference Files
 
@@ -383,3 +384,4 @@ Cross-platform features:
 | `@State` for shared state | Use `@Observable` model or `@Environment` |
 | String-based navigation | Use `NavigationPath` with typed destinations |
 | Magic numbers in UI (`padding(16)`, `.cornerRadius(8)`) | Define design tokens (`AppSpacing.medium`, `AppCornerRadius.standard`) |
+| `#if TARGET_NAME` for multi-target branching | Use DI (protocol + per-target conformance) or separate files per target |

--- a/registry/skills/apple-app-development/SKILL.md
+++ b/registry/skills/apple-app-development/SKILL.md
@@ -289,12 +289,15 @@ struct HomeFeature {
         case deleteItem(id: UUID)
     }
 
+    // Inject dependencies via @Dependency (uses swift-dependencies package)
+    @Dependency(\.itemRepository) var repository
+
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case .loadItems:
                 state.isLoading = true
-                return .run { send in
+                return .run { [repository] send in
                     await send(.itemsLoaded(Result { try await repository.getItems() }))
                 }
             case .itemsLoaded(.success(let items)):

--- a/registry/skills/apple-app-development/references/app-lifecycle.md
+++ b/registry/skills/apple-app-development/references/app-lifecycle.md
@@ -395,9 +395,7 @@ func application(
             return .newData
         case "badge-update":
             let count = userInfo["badge_count"] as? Int ?? 0
-            await MainActor.run {
-                UNUserNotificationCenter.current().setBadgeCount(count)
-            }
+            try? await UNUserNotificationCenter.current().setBadgeCount(count)
             return .newData
         default:
             return .noData

--- a/registry/skills/apple-app-development/references/app-lifecycle.md
+++ b/registry/skills/apple-app-development/references/app-lifecycle.md
@@ -419,6 +419,20 @@ APNs payload for silent push:
 
 Note: Push notification delegate methods still require `UIApplicationDelegate` / `@UIApplicationDelegateAdaptor`. There is no pure SwiftUI equivalent.
 
+### Live Activities Push Notifications (iOS 16.1+)
+
+Live Activities use ActivityKit push notifications to update or end activities remotely. See `references/widgets-app-intents.md` for full Live Activities coverage.
+
+```swift
+// Observe push token for a Live Activity
+for await tokenData in activity.pushTokenUpdates {
+    let token = tokenData.map { String(format: "%02x", $0) }.joined()
+    // Send token to your server for APNs updates
+}
+```
+
+iOS 18 introduced **broadcast push notifications** for Live Activities — send a single push via a channel ID instead of tracking per-device tokens. This is critical for high-audience scenarios (sports scores, flight tracking). See `references/widgets-app-intents.md` for details.
+
 ## Deep Links and Universal Links
 
 ### Custom URL Schemes
@@ -806,7 +820,20 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     }
 }
 
-// Access in views
+// In your App struct, inject the delegate into the environment
+@main
+struct MyApp: App {
+    @UIApplicationDelegateAdaptor private var appDelegate: AppDelegate
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(appDelegate) // Required — @UIApplicationDelegateAdaptor does NOT auto-inject
+        }
+    }
+}
+
+// Then access in any view
 struct SettingsView: View {
     @Environment(AppDelegate.self) private var appDelegate
 

--- a/registry/skills/apple-app-development/references/code-quality.md
+++ b/registry/skills/apple-app-development/references/code-quality.md
@@ -1,609 +1,29 @@
-# Code Quality Reference (SwiftLint, SwiftFormat, Static Analysis)
+# Code Quality Reference (Xcode Analysis, Sanitizers, Dead Code)
 
-Tools and configuration for enforcing code quality, consistent style, and catching bugs early on Apple platforms. SwiftLint and SwiftFormat are complementary — use both together. Add Periphery for dead code detection and Xcode's built-in analyzers for memory/threading bugs.
+Apple platform-specific quality tools that complement language-level linting. For SwiftLint and SwiftFormat configuration, rules, and CI setup, see the `swift-development` skill's `references/static-analysis.md`. This reference covers Xcode-specific tooling: static analyzer, runtime sanitizers, dead code detection, Danger-Swift, and build settings.
 
 ## Contents
 - When to use which tool (decision table)
-- SwiftLint (configuration, rules, custom rules, build integration)
-- SwiftFormat (configuration, rules, build integration)
-- Using SwiftLint + SwiftFormat together (conflict avoidance)
-- Xcode Static Analyzer (Analyze, sanitizers)
+- Xcode Static Analyzer (Analyze, build settings)
+- Sanitizers (Address, Thread, Undefined Behavior)
 - Periphery — dead code detection
-- CI/CD integration (GitHub Actions, pre-commit, Danger)
+- Danger-Swift for PR automation
 - Xcode build settings for quality
+- Xcode configuration files (`.xcconfig`)
 - Common pitfalls
 
 ## When to Use Which
 
 | Tool | Purpose | Runs On |
 |---|---|---|
-| SwiftLint | Style enforcement + code smell detection | Build phase, CLI, CI |
-| SwiftFormat | Automatic code formatting | Build phase, CLI, CI, editor |
 | Xcode Static Analyzer | Memory leaks, null dereferences, logic errors | Xcode Analyze (Cmd+Shift+B) |
-| Periphery | Dead code detection | CLI, CI |
 | Address Sanitizer | Runtime memory bug detection | Xcode scheme, test plans |
 | Thread Sanitizer | Data race detection | Xcode scheme, test plans |
-| SwiftLint + SwiftFormat | Complementary — lint for rules, format for style | Together in build/CI |
-
-**Rule:** Use SwiftLint for detecting code smells and enforcing conventions that require judgment. Use SwiftFormat for mechanical formatting that can be auto-applied. Use both — they solve different problems.
-
-
-## SwiftLint
-
-SwiftLint enforces Swift style and conventions via a configurable rule set. It can warn, error, and auto-correct.
-
-### Installation
----
-
-#### Homebrew
-
-```bash
-brew install swiftlint
-```
-
-#### Mint
-
-```bash
-mint install realm/SwiftLint
-```
-
-#### SPM Build Plugin (recommended for reproducibility)
-
-```swift
-// Package.swift
-let package = Package(
-    name: "MyApp",
-    dependencies: [
-        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.57.0"),
-    ],
-    targets: [
-        .target(
-            name: "MyApp",
-            plugins: [
-                .plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLintPlugins"),
-            ]
-        ),
-    ]
-)
-```
-
-For Xcode projects without SPM, add as a build tool plugin via File > Add Package Dependencies.
-
-### Configuration (`.swiftlint.yml`)
----
-
-Place `.swiftlint.yml` in the project root. A realistic production configuration:
-
-```yaml
-# .swiftlint.yml
-
-# Only lint project sources, not dependencies or generated code
-included:
-  - Sources
-  - Tests
-
-excluded:
-  - Sources/Generated
-  - Sources/Resources
-  - "**/.build"
-  - "**/DerivedData"
-
-# Disable rules that conflict with SwiftFormat or are too noisy
-disabled_rules:
-  - trailing_comma           # SwiftFormat handles this
-  - opening_brace            # SwiftFormat handles this
-  - vertical_whitespace      # SwiftFormat handles this
-  - todo                     # Useful during development
-
-# Enable recommended opt-in rules
-opt_in_rules:
-  - anonymous_argument_in_multiline_closure
-  - array_init
-  - attributes
-  - closure_body_length
-  - closure_spacing
-  - collection_alignment
-  - comma_inheritance
-  - contains_over_filter_count
-  - contains_over_first_not_nil
-  - contains_over_range_nil_comparison
-  - convenience_type
-  - discouraged_none_name
-  - discouraged_object_literal
-  - empty_collection_literal
-  - empty_count
-  - empty_string
-  - enum_case_associated_values_count
-  - explicit_init
-  - extension_access_modifier
-  - fallthrough
-  - fatal_error_message
-  - file_name_no_space
-  - first_where
-  - flatmap_over_map_reduce
-  - force_unwrapping
-  - identical_operands
-  - implicit_return
-  - joined_default_parameter
-  - last_where
-  - legacy_multiple
-  - literal_expression_end_indentation
-  - local_doc_comment
-  - lower_acl_than_parent
-  - modifier_order
-  - multiline_arguments
-  - multiline_function_chains
-  - multiline_parameters
-  - number_separator
-  - operator_usage_whitespace
-  - overridden_super_call
-  - override_in_extension
-  - pattern_matching_keywords
-  - prefer_self_in_static_references
-  - prefer_self_type_over_type_of_self
-  - prefer_zero_over_explicit_init
-  - private_action
-  - private_outlet
-  - prohibited_super_call
-  - raw_value_for_camel_cased_codable_enum
-  - reduce_into
-  - redundant_nil_coalescing
-  - redundant_type_annotation
-  - return_value_from_void_function
-  - sorted_first_last
-  - strong_iboutlet
-  - toggle_bool
-  - unavailable_function
-  - unneeded_parentheses_in_closure_argument
-  - unowned_variable_capture
-  - untyped_error_in_catch
-  - vertical_parameter_alignment_on_call
-  - yoda_condition
-
-# Configurable rule thresholds
-line_length:
-  warning: 120
-  error: 200
-  ignores_comments: true
-  ignores_urls: true
-  ignores_interpolated_strings: true
-
-type_body_length:
-  warning: 300
-  error: 500
-
-file_length:
-  warning: 500
-  error: 1000
-  ignore_comment_only_lines: true
-
-function_body_length:
-  warning: 50
-  error: 100
-
-function_parameter_count:
-  warning: 5
-  error: 8
-
-type_name:
-  min_length: 3
-  max_length:
-    warning: 50
-    error: 60
-
-identifier_name:
-  min_length:
-    warning: 2
-    error: 1
-  max_length:
-    warning: 50
-    error: 60
-  excluded:
-    - id
-    - x
-    - y
-    - i
-    - j
-    - to
-
-nesting:
-  type_level:
-    warning: 2
-  function_level:
-    warning: 3
-
-large_tuple:
-  warning: 3
-  error: 4
-
-cyclomatic_complexity:
-  warning: 10
-  error: 20
-
-# Reporter type (xcode, json, csv, checkstyle, codeclimate, github-actions-logging)
-reporter: "xcode"
-```
-
-### Key Rule Categories
----
-
-#### Style Rules
-
-Rules that enforce consistent code style (indentation, spacing, naming):
-
-- `line_length` — maximum characters per line
-- `identifier_name` — variable/function naming conventions
-- `type_name` — type naming length and format
-- `modifier_order` — consistent ordering of access modifiers
-- `implicit_return` — single-expression returns omit `return`
-
-#### Lint Rules
-
-Rules that detect potential bugs or code smells:
-
-- `force_unwrapping` — flags `!` force unwrap usage
-- `force_cast` — flags `as!` force cast usage
-- `force_try` — flags `try!` usage
-- `unowned_variable_capture` — prefer `weak` over `unowned`
-- `unused_closure_parameter` — replace unused params with `_`
-
-#### Performance Rules
-
-Rules that flag potentially slow patterns:
-
-- `first_where` — use `.first(where:)` instead of `.filter().first`
-- `sorted_first_last` — use `.min()`/`.max()` instead of `.sorted().first`/`.last`
-- `contains_over_filter_count` — use `.contains(where:)` instead of `.filter().count > 0`
-- `reduce_into` — use `reduce(into:)` for reference types
-- `flatmap_over_map_reduce` — use `.flatMap()` instead of `.map().reduce([], +)`
-- `empty_count` — use `.isEmpty` instead of `.count == 0`
-
-#### Idiomatic Rules
-
-Rules that enforce modern Swift idioms:
-
-- `prefer_self_in_static_references` — use `Self` instead of type name in static context
-- `toggle_bool` — use `.toggle()` instead of `x = !x`
-- `legacy_multiple` — use `isMultiple(of:)` instead of `% 2 == 0`
-- `joined_default_parameter` — use `.joined()` instead of `.joined(separator: "")`
-
-### Disabling Rules Inline
----
-
-```swift
-// Disable a rule for the entire file (place at top)
-// swiftlint:disable force_unwrapping
-
-// Disable for the next line only
-// swiftlint:disable:next force_cast
-let view = object as! UIView
-
-// Disable for the current line
-let url = URL(string: "https://example.com")! // swiftlint:disable:this force_unwrapping
-
-// Disable for a block
-// swiftlint:disable cyclomatic_complexity
-func complexLegacyFunction() {
-    // ... complex logic that cannot be easily refactored
-}
-// swiftlint:enable cyclomatic_complexity
-```
-
-Rules:
-- Prefer fixing the violation over disabling the rule.
-- When disabling, always use the most narrow scope possible (`:next` > `:this` > block > file).
-- Add a comment explaining why the rule is disabled for block-level disables.
-
-### Custom Rules (Regex-Based)
----
-
-Define project-specific rules directly in `.swiftlint.yml`:
-
-```yaml
-custom_rules:
-  no_print_in_production:
-    name: "No print() in production code"
-    regex: 'print\s*\('
-    match_kinds:
-      - identifier
-    message: "Use os_log or Logger instead of print()"
-    severity: warning
-    excluded: ".*Tests/.*"
-
-  no_hardcoded_urls:
-    name: "No hardcoded URLs"
-    regex: 'URL\(string:\s*"https?://'
-    message: "Use environment-based URL configuration instead of hardcoded URLs"
-    severity: warning
-
-  no_nslog:
-    name: "No NSLog"
-    regex: 'NSLog\s*\('
-    message: "Use Logger (os.log) instead of NSLog"
-    severity: error
-
-  mark_format:
-    name: "MARK format"
-    regex: '\/\/\s*MARK:\s*[^-\s]'
-    message: "Use '// MARK: - Section Name' with a dash for visual separator"
-    severity: warning
-```
-
-### Running as Xcode Build Phase
----
-
-Add a Run Script build phase (after "Compile Sources"):
-
-```bash
-# Run Script — SwiftLint
-if command -v swiftlint >/dev/null 2>&1; then
-    swiftlint lint --config "${SRCROOT}/.swiftlint.yml"
-else
-    echo "warning: SwiftLint not installed. Run 'brew install swiftlint'"
-fi
-```
-
-For the SPM plugin approach, no build phase is needed — the plugin runs automatically during build.
-
-### Auto-Correct
----
-
-```bash
-# Fix all auto-correctable violations
-swiftlint lint --fix --config .swiftlint.yml
-
-# Fix specific files
-swiftlint lint --fix --path Sources/Models/
-
-# Dry run — show what would be fixed without modifying
-swiftlint lint --config .swiftlint.yml
-```
-
-Rules:
-- Always review auto-correct changes before committing.
-- Run auto-correct before linting in CI to reduce noise.
-- Not all rules are auto-correctable — some require manual fixes.
-
-### Nested Configurations
----
-
-Place additional `.swiftlint.yml` files in subdirectories to override the root config:
-
-```
-MyApp/
-├── .swiftlint.yml              # Root config
-├── Sources/
-│   └── .swiftlint.yml          # Stricter rules for production code
-└── Tests/
-    └── .swiftlint.yml          # Relaxed rules for test code
-```
-
-```yaml
-# Tests/.swiftlint.yml — relax rules for test code
-disabled_rules:
-  - force_unwrapping       # Acceptable in tests
-  - force_cast             # Acceptable in tests
-  - function_body_length   # Test methods can be longer
-  - type_body_length       # Test classes can be larger
-  - file_length            # Test files can be larger
-  - identifier_name        # Shorter names OK in tests
-
-line_length:
-  warning: 150
-  error: 250
-```
-
-Child configs inherit from the parent and can override any setting.
-
-
-## SwiftFormat
-
-SwiftFormat reformats Swift code automatically. Where SwiftLint detects problems, SwiftFormat fixes formatting without human intervention.
-
-### Installation
----
-
-#### Homebrew
-
-```bash
-brew install swiftformat
-```
-
-#### Mint
-
-```bash
-mint install nicklockwood/SwiftFormat
-```
-
-#### SPM Build Plugin
-
-```swift
-// Package.swift
-let package = Package(
-    name: "MyApp",
-    dependencies: [
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.55.0"),
-    ],
-    targets: [
-        .target(
-            name: "MyApp",
-            plugins: [
-                .plugin(name: "SwiftFormatPlugin", package: "SwiftFormat"),
-            ]
-        ),
-    ]
-)
-```
-
-### Configuration (`.swiftformat`)
----
-
-Place `.swiftformat` in the project root. A realistic production configuration:
-
-```
-# .swiftformat
-
-# File options
---exclude DerivedData,**/.build,Sources/Generated
-
-# Formatting rules
---indent 4
---indentcase false
---trimwhitespace always
---voidtype void
---wraparguments before-first
---wrapparameters before-first
---wrapcollections before-first
---wrapconditions after-first
---wrapreturntype preserve
---maxwidth 120
---closingparen balanced
---commas always
---decimalgrouping 3
---exponentcase lowercase
---extensionacl on-extension
---fractiongrouping disabled
---header ignore
---hexgrouping 4,8
---hexliteralcase uppercase
---ifdef indent
---importgrouping alpha
---lifecycle            # uses default modifier lifecycle ordering
---modifierorder        # enforces consistent modifier order
---nospaceoperators     # no spaces around range operators (..<, ...)
---operatorfunc spaced
---patternlet hoist
---ranges spaced
---redundanttype inferred
---self remove
---semicolons inline
---stripunusedargs closure-only
---swiftversion 6.0
---typeattributes prev-line
---varattributes same-line
---funcattributes prev-line
---storedvarattrs same-line
---computedvarattrs same-line
-
-# Disable rules that conflict with SwiftLint or project conventions
---disable blankLinesAtStartOfScope
---disable blankLinesAtEndOfScope
-
-# Enable additional rules
---enable isEmpty
---enable markTypes
---enable sortSwitchCases
---enable wrapMultilineStatementBraces
---enable docComments
---enable blockComments
-```
-
-### Key Formatting Rules
----
-
-| Rule | What It Does |
-|---|---|
-| `redundantSelf` | Removes unnecessary `self.` |
-| `trailingCommas` | Adds/removes trailing commas in collections |
-| `unusedArguments` | Replaces unused closure args with `_` |
-| `redundantReturn` | Removes `return` from single-expression functions |
-| `sortImports` | Alphabetizes import statements |
-| `wrapArguments` | Wraps function arguments consistently |
-| `braces` | Enforces brace placement (K&R style) |
-| `indent` | Normalizes indentation |
-| `blankLinesBetweenScopes` | Adds blank lines between type/function declarations |
-| `markTypes` | Adds `// MARK: -` comments for type extensions |
-| `isEmpty` | Replaces `.count == 0` with `.isEmpty` |
-| `consecutiveSpaces` | Collapses multiple spaces |
-
-### SwiftFormat vs SwiftLint — What Each Handles Best
----
-
-| Concern | SwiftFormat | SwiftLint |
-|---|---|---|
-| Indentation | Best — auto-fixes | Detects but limited auto-fix |
-| Brace placement | Best — auto-fixes | Detects only |
-| Import sorting | Best — auto-fixes | Not covered |
-| Trailing commas | Best — auto-fixes | Detects only |
-| Redundant code | Good — removes redundant `self`, `return` | Detects broader patterns |
-| Naming conventions | Not covered | Best — configurable rules |
-| Code complexity | Not covered | Best — cyclomatic complexity, body length |
-| Code smells | Not covered | Best — force unwrap, force cast, etc. |
-| Force unwrapping | Not covered | Best — warns/errors |
-| Custom rules | Not supported | Best — regex-based custom rules |
-
-### Running as Xcode Build Phase
----
-
-```bash
-# Run Script — SwiftFormat (place BEFORE SwiftLint build phase)
-if command -v swiftformat >/dev/null 2>&1; then
-    swiftformat "${SRCROOT}/Sources" --config "${SRCROOT}/.swiftformat"
-else
-    echo "warning: SwiftFormat not installed. Run 'brew install swiftformat'"
-fi
-```
-
-### Editor Integration
----
-
-Install the SwiftFormat for Xcode extension from the Mac App Store, or run via command palette in VS Code with the SwiftFormat extension. For Xcode:
-
-1. Install SwiftFormat for Xcode from the App Store
-2. Enable in System Settings > Privacy & Security > Extensions > Xcode Source Editor
-3. Use Editor > SwiftFormat > Format File (bind to a keyboard shortcut)
-
-
-## Using SwiftLint + SwiftFormat Together
-
-The key is avoiding conflicts — disable formatting-related rules in SwiftLint and let SwiftFormat handle them.
-
-### Recommended Setup
----
-
-#### Rules to disable in SwiftLint (let SwiftFormat handle these):
-
-```yaml
-# .swiftlint.yml — disable rules that SwiftFormat handles better
-disabled_rules:
-  - trailing_comma
-  - opening_brace
-  - closing_brace
-  - vertical_whitespace
-  - statement_position
-  - return_arrow_whitespace
-  - colon
-  - comma
-  - leading_whitespace
-  - trailing_newline
-  - trailing_semicolon
-  - trailing_whitespace
-```
-
-#### Rules to keep in SwiftLint (SwiftFormat cannot enforce these):
-
-```yaml
-# These stay in SwiftLint — SwiftFormat has no equivalent
-opt_in_rules:
-  - force_unwrapping
-  - cyclomatic_complexity
-  - function_body_length
-  - type_body_length
-  - file_length
-  - identifier_name
-  - type_name
-  - empty_count
-  - first_where
-  - contains_over_filter_count
-  - unowned_variable_capture
-```
-
-#### Execution order:
-
-1. **SwiftFormat first** — auto-fix formatting
-2. **SwiftLint second** — check remaining rules
-
-In Xcode build phases, place SwiftFormat before SwiftLint. In CI, run format-check before lint.
+| Undefined Behavior Sanitizer | Integer overflow, misaligned pointers | Xcode scheme, test plans |
+| Periphery | Dead code detection | CLI, CI |
+| Danger-Swift | Automated PR checks and conventions | CI |
+
+**Rule:** Run Xcode Analyze before releases. Enable sanitizers in dedicated test plan configurations. Run Periphery after major refactors. For linting and formatting (SwiftLint, SwiftFormat), see `swift-development` skill's `references/static-analysis.md`.
 
 
 ## Xcode Static Analyzer
@@ -631,8 +51,7 @@ CLANG_STATIC_ANALYZER_MODE = deep            // shallow (faster) or deep (thorou
 CLANG_STATIC_ANALYZER_MODE_ON_ANALYZE_ACTION = deep
 ```
 
-### Sanitizers
----
+## Sanitizers
 
 Sanitizers are runtime tools that detect bugs during test execution. Enable them in your scheme or test plan.
 
@@ -719,7 +138,7 @@ Run separate test plan configurations in CI for sanitizer checks — they incur 
 
 ## Periphery — Dead Code Detection
 
-Periphery scans your project for unused declarations: classes, structs, enums, protocols, functions, properties, and more.
+Periphery scans your Xcode project for unused declarations: classes, structs, enums, protocols, functions, properties, and more. It requires an Xcode project or SPM package to perform indexing.
 
 ### Installation and Basic Usage
 ---
@@ -798,46 +217,54 @@ Rules:
 - Set `retain_objc_accessible: true` to avoid false positives with `@objc` declarations.
 
 
+## Danger-Swift for PR Automation
+
+Danger-Swift runs during CI and automates PR review conventions: size warnings, missing tests, lint integration.
+
+### Setup
+---
+
+```swift
+// Dangerfile.swift
+import Danger
+
+let danger = Danger()
+
+// Warn if PR is too large
+let bigPRThreshold = 500
+if danger.github.pullRequest.additions + danger.github.pullRequest.deletions > bigPRThreshold {
+    warn("This PR is quite large. Consider breaking it into smaller PRs.")
+}
+
+// Check for SwiftLint violations
+SwiftLint.lint(inline: true, configFile: ".swiftlint.yml")
+
+// Ensure tests are updated when source changes
+let sourceChanges = danger.git.modifiedFiles.filter { $0.hasPrefix("Sources/") }
+let testChanges = danger.git.modifiedFiles.filter { $0.hasPrefix("Tests/") }
+if !sourceChanges.isEmpty && testChanges.isEmpty {
+    warn("Source files were modified but no tests were updated. Please add or update tests.")
+}
+
+// Check for TODO/FIXME in added lines
+for file in danger.git.modifiedFiles.filter({ $0.hasSuffix(".swift") }) {
+    for line in danger.utils.diff(for: file)?.hunks.flatMap(\.lines) ?? [] where line.type == .addition {
+        if line.text.contains("TODO") || line.text.contains("FIXME") {
+            message("New TODO/FIXME found in \(file). Consider resolving before merge.")
+            break
+        }
+    }
+}
+```
+
+
 ## CI/CD Integration
 
-### GitHub Actions Workflow
+### Periphery in GitHub Actions
 ---
 
 ```yaml
-# .github/workflows/code-quality.yml
-name: Code Quality
-
-on:
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - '**/*.swift'
-      - '.swiftlint.yml'
-      - '.swiftformat'
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-jobs:
-  lint-and-format:
-    name: SwiftLint & SwiftFormat
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install tools
-        run: |
-          brew install swiftlint swiftformat
-
-      - name: SwiftFormat check (no modifications)
-        run: |
-          swiftformat --lint --config .swiftformat Sources/ Tests/
-
-      - name: SwiftLint
-        run: |
-          swiftlint lint --strict --config .swiftlint.yml --reporter github-actions-logging
-
+# .github/workflows/code-quality.yml (add to existing workflow)
   periphery:
     name: Dead Code Detection
     runs-on: macos-latest
@@ -856,89 +283,32 @@ jobs:
             --format github-actions
 ```
 
+### Sanitizer CI Job
+---
+
+```yaml
+  sanitizers:
+    name: Sanitizer Checks
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        sanitizer: [thread, address]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run tests with ${{ matrix.sanitizer }} sanitizer
+        run: |
+          xcodebuild test \
+            -project MyApp.xcodeproj \
+            -scheme MyApp \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -enableAddressSanitizer ${{ matrix.sanitizer == 'address' && 'YES' || 'NO' }} \
+            -enableThreadSanitizer ${{ matrix.sanitizer == 'thread' && 'YES' || 'NO' }}
+```
+
 Rules:
-- Use `--reporter github-actions-logging` with SwiftLint to annotate PRs inline.
-- Use `swiftformat --lint` (not `swiftformat`) in CI to check without modifying files.
-- Use `--strict` with SwiftLint to treat warnings as errors in CI.
-
-### Pre-Commit Hooks
----
-
-```bash
-#!/bin/bash
-# .git/hooks/pre-commit
-
-# Get staged Swift files
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.swift$')
-
-if [ -z "$STAGED_FILES" ]; then
-    exit 0
-fi
-
-echo "Running SwiftFormat on staged files..."
-echo "$STAGED_FILES" | xargs swiftformat --config .swiftformat
-
-echo "Running SwiftLint on staged files..."
-echo "$STAGED_FILES" | xargs swiftlint lint --strict --config .swiftlint.yml
-
-LINT_STATUS=$?
-
-# Re-stage formatted files
-echo "$STAGED_FILES" | xargs git add
-
-if [ $LINT_STATUS -ne 0 ]; then
-    echo "SwiftLint found violations. Please fix them before committing."
-    exit 1
-fi
-
-exit 0
-```
-
-Make executable: `chmod +x .git/hooks/pre-commit`
-
-For team-wide hooks, use a shared hooks directory:
-
-```bash
-# Set hooks path for the repo
-git config core.hooksPath .githooks/
-
-# Place pre-commit in .githooks/pre-commit (committed to repo)
-```
-
-### Danger-Swift for PR Automation
----
-
-```swift
-// Dangerfile.swift
-import Danger
-
-let danger = Danger()
-
-// Warn if PR is too large
-let bigPRThreshold = 500
-if (danger.github.pullRequest.additions ?? 0) + (danger.github.pullRequest.deletions ?? 0) > bigPRThreshold {
-    warn("This PR is quite large. Consider breaking it into smaller PRs.")
-}
-
-// Check for SwiftLint violations
-SwiftLint.lint(inline: true, configFile: ".swiftlint.yml")
-
-// Ensure tests are updated when source changes
-let sourceChanges = danger.git.modifiedFiles.filter { $0.hasPrefix("Sources/") }
-let testChanges = danger.git.modifiedFiles.filter { $0.hasPrefix("Tests/") }
-if !sourceChanges.isEmpty && testChanges.isEmpty {
-    warn("Source files were modified but no tests were updated. Please add or update tests.")
-}
-
-// Check for TODO/FIXME in diff
-let diffTodos = danger.git.modifiedFiles
-    .filter { $0.hasSuffix(".swift") }
-    .compactMap { danger.utils.readFile($0) }
-    .filter { $0.contains("TODO") || $0.contains("FIXME") }
-if !diffTodos.isEmpty {
-    message("This PR contains TODO/FIXME comments. Consider resolving them.")
-}
-```
+- Run sanitizer jobs on a schedule (nightly) or on merge to main — not on every PR push due to overhead.
+- Use matrix strategy to run ASan and TSan in parallel (they cannot run simultaneously in one build).
 
 
 ## Xcode Build Settings for Quality
@@ -977,14 +347,14 @@ Rules:
 
 ```
 // Enable testability for test targets
-ENABLE_TESTING_SEARCH_PATHS = YES         // On test targets only
+ENABLE_TESTABILITY = YES                  // On test targets only
 
 // Enable module stability for frameworks
 BUILD_LIBRARY_FOR_DISTRIBUTION = YES      // For distributed frameworks only
 
 // Optimization
 SWIFT_COMPILATION_MODE = wholemodule      // Release — better optimization
-SWIFT_COMPILATION_MODE = singlefile       // Debug — faster incremental builds
+SWIFT_COMPILATION_MODE = incremental       // Debug — faster incremental builds
 
 // Warnings
 CLANG_WARN_DOCUMENTATION_COMMENTS = YES
@@ -1004,7 +374,7 @@ SWIFT_STRICT_CONCURRENCY = complete
 
 // Debug.xcconfig
 #include "Shared.xcconfig"
-SWIFT_COMPILATION_MODE = singlefile
+SWIFT_COMPILATION_MODE = incremental
 SWIFT_TREAT_WARNINGS_AS_ERRORS = NO
 ENABLE_TESTABILITY = YES
 
@@ -1021,20 +391,14 @@ SWIFT_OPTIMIZATION_LEVEL = -O
 
 | Pitfall | Fix |
 |---|---|
-| Over-configuring linting (too many rules enabled) | Start with defaults, enable opt-in rules incrementally. If developers routinely disable rules inline, the rule is too strict |
-| Inconsistent configs across modules | Use a single root `.swiftlint.yml` with nested overrides only where necessary (e.g., relaxed test rules) |
-| Not auto-fixing what can be auto-fixed | Run `swiftlint lint --fix` and `swiftformat` before linting. Reduces noise and developer friction |
-| Running linters before formatters | Always run SwiftFormat first, then SwiftLint. Formatting changes may resolve lint violations |
-| SwiftLint and SwiftFormat conflicting on the same rules | Disable formatting rules in SwiftLint, let SwiftFormat handle them exclusively |
 | Ignoring Periphery false positives without investigation | Always verify whether flagged code is truly unused before adding `// periphery:ignore` |
 | Enabling all sanitizers simultaneously | Address Sanitizer and Thread Sanitizer cannot coexist. Use separate test plan configurations |
 | Running sanitizers in every CI build | Sanitizers add 5-15x overhead. Run in a scheduled nightly job or a separate CI stage |
-| Not pinning tool versions | Different SwiftLint/SwiftFormat versions may produce different results. Pin versions via SPM plugins or Mint |
 | Treat-warnings-as-errors in Debug | Blocks development. Enable only for Release builds |
 | Skipping static analysis entirely | Run Xcode Analyze at least before releases. Catches memory bugs that compiler warnings miss |
-| Not configuring `excluded` paths | Generated code, vendored code, and build artifacts produce irrelevant violations. Always exclude them |
 
 ## Related References
 
+- **`swift-development` skill's `references/static-analysis.md`** — SwiftLint, SwiftFormat configuration, rules, combined setup, pre-commit hooks, CI integration.
 - **`references/testing.md`** — Test plans, test configurations, and CI/CD test commands. Sanitizers configured here are enabled in test plans described there.
 - **`references/project-structure.md`** — Build configurations, schemes, and xcconfig setup referenced in the build settings section above.

--- a/registry/skills/apple-app-development/references/code-quality.md
+++ b/registry/skills/apple-app-development/references/code-quality.md
@@ -1,0 +1,1040 @@
+# Code Quality Reference (SwiftLint, SwiftFormat, Static Analysis)
+
+Tools and configuration for enforcing code quality, consistent style, and catching bugs early on Apple platforms. SwiftLint and SwiftFormat are complementary — use both together. Add Periphery for dead code detection and Xcode's built-in analyzers for memory/threading bugs.
+
+## Contents
+- When to use which tool (decision table)
+- SwiftLint (configuration, rules, custom rules, build integration)
+- SwiftFormat (configuration, rules, build integration)
+- Using SwiftLint + SwiftFormat together (conflict avoidance)
+- Xcode Static Analyzer (Analyze, sanitizers)
+- Periphery — dead code detection
+- CI/CD integration (GitHub Actions, pre-commit, Danger)
+- Xcode build settings for quality
+- Common pitfalls
+
+## When to Use Which
+
+| Tool | Purpose | Runs On |
+|---|---|---|
+| SwiftLint | Style enforcement + code smell detection | Build phase, CLI, CI |
+| SwiftFormat | Automatic code formatting | Build phase, CLI, CI, editor |
+| Xcode Static Analyzer | Memory leaks, null dereferences, logic errors | Xcode Analyze (Cmd+Shift+B) |
+| Periphery | Dead code detection | CLI, CI |
+| Address Sanitizer | Runtime memory bug detection | Xcode scheme, test plans |
+| Thread Sanitizer | Data race detection | Xcode scheme, test plans |
+| SwiftLint + SwiftFormat | Complementary — lint for rules, format for style | Together in build/CI |
+
+**Rule:** Use SwiftLint for detecting code smells and enforcing conventions that require judgment. Use SwiftFormat for mechanical formatting that can be auto-applied. Use both — they solve different problems.
+
+
+## SwiftLint
+
+SwiftLint enforces Swift style and conventions via a configurable rule set. It can warn, error, and auto-correct.
+
+### Installation
+---
+
+#### Homebrew
+
+```bash
+brew install swiftlint
+```
+
+#### Mint
+
+```bash
+mint install realm/SwiftLint
+```
+
+#### SPM Build Plugin (recommended for reproducibility)
+
+```swift
+// Package.swift
+let package = Package(
+    name: "MyApp",
+    dependencies: [
+        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.57.0"),
+    ],
+    targets: [
+        .target(
+            name: "MyApp",
+            plugins: [
+                .plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLintPlugins"),
+            ]
+        ),
+    ]
+)
+```
+
+For Xcode projects without SPM, add as a build tool plugin via File > Add Package Dependencies.
+
+### Configuration (`.swiftlint.yml`)
+---
+
+Place `.swiftlint.yml` in the project root. A realistic production configuration:
+
+```yaml
+# .swiftlint.yml
+
+# Only lint project sources, not dependencies or generated code
+included:
+  - Sources
+  - Tests
+
+excluded:
+  - Sources/Generated
+  - Sources/Resources
+  - "**/.build"
+  - "**/DerivedData"
+
+# Disable rules that conflict with SwiftFormat or are too noisy
+disabled_rules:
+  - trailing_comma           # SwiftFormat handles this
+  - opening_brace            # SwiftFormat handles this
+  - vertical_whitespace      # SwiftFormat handles this
+  - todo                     # Useful during development
+
+# Enable recommended opt-in rules
+opt_in_rules:
+  - anonymous_argument_in_multiline_closure
+  - array_init
+  - attributes
+  - closure_body_length
+  - closure_spacing
+  - collection_alignment
+  - comma_inheritance
+  - contains_over_filter_count
+  - contains_over_first_not_nil
+  - contains_over_range_nil_comparison
+  - convenience_type
+  - discouraged_none_name
+  - discouraged_object_literal
+  - empty_collection_literal
+  - empty_count
+  - empty_string
+  - enum_case_associated_values_count
+  - explicit_init
+  - extension_access_modifier
+  - fallthrough
+  - fatal_error_message
+  - file_name_no_space
+  - first_where
+  - flatmap_over_map_reduce
+  - force_unwrapping
+  - identical_operands
+  - implicit_return
+  - joined_default_parameter
+  - last_where
+  - legacy_multiple
+  - literal_expression_end_indentation
+  - local_doc_comment
+  - lower_acl_than_parent
+  - modifier_order
+  - multiline_arguments
+  - multiline_function_chains
+  - multiline_parameters
+  - number_separator
+  - operator_usage_whitespace
+  - overridden_super_call
+  - override_in_extension
+  - pattern_matching_keywords
+  - prefer_self_in_static_references
+  - prefer_self_type_over_type_of_self
+  - prefer_zero_over_explicit_init
+  - private_action
+  - private_outlet
+  - prohibited_super_call
+  - raw_value_for_camel_cased_codable_enum
+  - reduce_into
+  - redundant_nil_coalescing
+  - redundant_type_annotation
+  - return_value_from_void_function
+  - sorted_first_last
+  - strong_iboutlet
+  - toggle_bool
+  - unavailable_function
+  - unneeded_parentheses_in_closure_argument
+  - unowned_variable_capture
+  - untyped_error_in_catch
+  - vertical_parameter_alignment_on_call
+  - yoda_condition
+
+# Configurable rule thresholds
+line_length:
+  warning: 120
+  error: 200
+  ignores_comments: true
+  ignores_urls: true
+  ignores_interpolated_strings: true
+
+type_body_length:
+  warning: 300
+  error: 500
+
+file_length:
+  warning: 500
+  error: 1000
+  ignore_comment_only_lines: true
+
+function_body_length:
+  warning: 50
+  error: 100
+
+function_parameter_count:
+  warning: 5
+  error: 8
+
+type_name:
+  min_length: 3
+  max_length:
+    warning: 50
+    error: 60
+
+identifier_name:
+  min_length:
+    warning: 2
+    error: 1
+  max_length:
+    warning: 50
+    error: 60
+  excluded:
+    - id
+    - x
+    - y
+    - i
+    - j
+    - to
+
+nesting:
+  type_level:
+    warning: 2
+  function_level:
+    warning: 3
+
+large_tuple:
+  warning: 3
+  error: 4
+
+cyclomatic_complexity:
+  warning: 10
+  error: 20
+
+# Reporter type (xcode, json, csv, checkstyle, codeclimate, github-actions-logging)
+reporter: "xcode"
+```
+
+### Key Rule Categories
+---
+
+#### Style Rules
+
+Rules that enforce consistent code style (indentation, spacing, naming):
+
+- `line_length` — maximum characters per line
+- `identifier_name` — variable/function naming conventions
+- `type_name` — type naming length and format
+- `modifier_order` — consistent ordering of access modifiers
+- `implicit_return` — single-expression returns omit `return`
+
+#### Lint Rules
+
+Rules that detect potential bugs or code smells:
+
+- `force_unwrapping` — flags `!` force unwrap usage
+- `force_cast` — flags `as!` force cast usage
+- `force_try` — flags `try!` usage
+- `unowned_variable_capture` — prefer `weak` over `unowned`
+- `unused_closure_parameter` — replace unused params with `_`
+
+#### Performance Rules
+
+Rules that flag potentially slow patterns:
+
+- `first_where` — use `.first(where:)` instead of `.filter().first`
+- `sorted_first_last` — use `.min()`/`.max()` instead of `.sorted().first`/`.last`
+- `contains_over_filter_count` — use `.contains(where:)` instead of `.filter().count > 0`
+- `reduce_into` — use `reduce(into:)` for reference types
+- `flatmap_over_map_reduce` — use `.flatMap()` instead of `.map().reduce([], +)`
+- `empty_count` — use `.isEmpty` instead of `.count == 0`
+
+#### Idiomatic Rules
+
+Rules that enforce modern Swift idioms:
+
+- `prefer_self_in_static_references` — use `Self` instead of type name in static context
+- `toggle_bool` — use `.toggle()` instead of `x = !x`
+- `legacy_multiple` — use `isMultiple(of:)` instead of `% 2 == 0`
+- `joined_default_parameter` — use `.joined()` instead of `.joined(separator: "")`
+
+### Disabling Rules Inline
+---
+
+```swift
+// Disable a rule for the entire file (place at top)
+// swiftlint:disable force_unwrapping
+
+// Disable for the next line only
+// swiftlint:disable:next force_cast
+let view = object as! UIView
+
+// Disable for the current line
+let url = URL(string: "https://example.com")! // swiftlint:disable:this force_unwrapping
+
+// Disable for a block
+// swiftlint:disable cyclomatic_complexity
+func complexLegacyFunction() {
+    // ... complex logic that cannot be easily refactored
+}
+// swiftlint:enable cyclomatic_complexity
+```
+
+Rules:
+- Prefer fixing the violation over disabling the rule.
+- When disabling, always use the most narrow scope possible (`:next` > `:this` > block > file).
+- Add a comment explaining why the rule is disabled for block-level disables.
+
+### Custom Rules (Regex-Based)
+---
+
+Define project-specific rules directly in `.swiftlint.yml`:
+
+```yaml
+custom_rules:
+  no_print_in_production:
+    name: "No print() in production code"
+    regex: 'print\s*\('
+    match_kinds:
+      - identifier
+    message: "Use os_log or Logger instead of print()"
+    severity: warning
+    excluded: ".*Tests/.*"
+
+  no_hardcoded_urls:
+    name: "No hardcoded URLs"
+    regex: 'URL\(string:\s*"https?://'
+    message: "Use environment-based URL configuration instead of hardcoded URLs"
+    severity: warning
+
+  no_nslog:
+    name: "No NSLog"
+    regex: 'NSLog\s*\('
+    message: "Use Logger (os.log) instead of NSLog"
+    severity: error
+
+  mark_format:
+    name: "MARK format"
+    regex: '\/\/\s*MARK:\s*[^-\s]'
+    message: "Use '// MARK: - Section Name' with a dash for visual separator"
+    severity: warning
+```
+
+### Running as Xcode Build Phase
+---
+
+Add a Run Script build phase (after "Compile Sources"):
+
+```bash
+# Run Script — SwiftLint
+if command -v swiftlint >/dev/null 2>&1; then
+    swiftlint lint --config "${SRCROOT}/.swiftlint.yml"
+else
+    echo "warning: SwiftLint not installed. Run 'brew install swiftlint'"
+fi
+```
+
+For the SPM plugin approach, no build phase is needed — the plugin runs automatically during build.
+
+### Auto-Correct
+---
+
+```bash
+# Fix all auto-correctable violations
+swiftlint lint --fix --config .swiftlint.yml
+
+# Fix specific files
+swiftlint lint --fix --path Sources/Models/
+
+# Dry run — show what would be fixed without modifying
+swiftlint lint --config .swiftlint.yml
+```
+
+Rules:
+- Always review auto-correct changes before committing.
+- Run auto-correct before linting in CI to reduce noise.
+- Not all rules are auto-correctable — some require manual fixes.
+
+### Nested Configurations
+---
+
+Place additional `.swiftlint.yml` files in subdirectories to override the root config:
+
+```
+MyApp/
+├── .swiftlint.yml              # Root config
+├── Sources/
+│   └── .swiftlint.yml          # Stricter rules for production code
+└── Tests/
+    └── .swiftlint.yml          # Relaxed rules for test code
+```
+
+```yaml
+# Tests/.swiftlint.yml — relax rules for test code
+disabled_rules:
+  - force_unwrapping       # Acceptable in tests
+  - force_cast             # Acceptable in tests
+  - function_body_length   # Test methods can be longer
+  - type_body_length       # Test classes can be larger
+  - file_length            # Test files can be larger
+  - identifier_name        # Shorter names OK in tests
+
+line_length:
+  warning: 150
+  error: 250
+```
+
+Child configs inherit from the parent and can override any setting.
+
+
+## SwiftFormat
+
+SwiftFormat reformats Swift code automatically. Where SwiftLint detects problems, SwiftFormat fixes formatting without human intervention.
+
+### Installation
+---
+
+#### Homebrew
+
+```bash
+brew install swiftformat
+```
+
+#### Mint
+
+```bash
+mint install nicklockwood/SwiftFormat
+```
+
+#### SPM Build Plugin
+
+```swift
+// Package.swift
+let package = Package(
+    name: "MyApp",
+    dependencies: [
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.55.0"),
+    ],
+    targets: [
+        .target(
+            name: "MyApp",
+            plugins: [
+                .plugin(name: "SwiftFormatPlugin", package: "SwiftFormat"),
+            ]
+        ),
+    ]
+)
+```
+
+### Configuration (`.swiftformat`)
+---
+
+Place `.swiftformat` in the project root. A realistic production configuration:
+
+```
+# .swiftformat
+
+# File options
+--exclude DerivedData,**/.build,Sources/Generated
+
+# Formatting rules
+--indent 4
+--indentcase false
+--trimwhitespace always
+--voidtype void
+--wraparguments before-first
+--wrapparameters before-first
+--wrapcollections before-first
+--wrapconditions after-first
+--wrapreturntype preserve
+--maxwidth 120
+--closingparen balanced
+--commas always
+--decimalgrouping 3
+--exponentcase lowercase
+--extensionacl on-extension
+--fractiongrouping disabled
+--header ignore
+--hexgrouping 4,8
+--hexliteralcase uppercase
+--ifdef indent
+--importgrouping alpha
+--lifecycle            # uses default modifier lifecycle ordering
+--modifierorder        # enforces consistent modifier order
+--nospaceoperators     # no spaces around range operators (..<, ...)
+--operatorfunc spaced
+--patternlet hoist
+--ranges spaced
+--redundanttype inferred
+--self remove
+--semicolons inline
+--stripunusedargs closure-only
+--swiftversion 6.0
+--typeattributes prev-line
+--varattributes same-line
+--funcattributes prev-line
+--storedvarattrs same-line
+--computedvarattrs same-line
+
+# Disable rules that conflict with SwiftLint or project conventions
+--disable blankLinesAtStartOfScope
+--disable blankLinesAtEndOfScope
+
+# Enable additional rules
+--enable isEmpty
+--enable markTypes
+--enable sortSwitchCases
+--enable wrapMultilineStatementBraces
+--enable docComments
+--enable blockComments
+```
+
+### Key Formatting Rules
+---
+
+| Rule | What It Does |
+|---|---|
+| `redundantSelf` | Removes unnecessary `self.` |
+| `trailingCommas` | Adds/removes trailing commas in collections |
+| `unusedArguments` | Replaces unused closure args with `_` |
+| `redundantReturn` | Removes `return` from single-expression functions |
+| `sortImports` | Alphabetizes import statements |
+| `wrapArguments` | Wraps function arguments consistently |
+| `braces` | Enforces brace placement (K&R style) |
+| `indent` | Normalizes indentation |
+| `blankLinesBetweenScopes` | Adds blank lines between type/function declarations |
+| `markTypes` | Adds `// MARK: -` comments for type extensions |
+| `isEmpty` | Replaces `.count == 0` with `.isEmpty` |
+| `consecutiveSpaces` | Collapses multiple spaces |
+
+### SwiftFormat vs SwiftLint — What Each Handles Best
+---
+
+| Concern | SwiftFormat | SwiftLint |
+|---|---|---|
+| Indentation | Best — auto-fixes | Detects but limited auto-fix |
+| Brace placement | Best — auto-fixes | Detects only |
+| Import sorting | Best — auto-fixes | Not covered |
+| Trailing commas | Best — auto-fixes | Detects only |
+| Redundant code | Good — removes redundant `self`, `return` | Detects broader patterns |
+| Naming conventions | Not covered | Best — configurable rules |
+| Code complexity | Not covered | Best — cyclomatic complexity, body length |
+| Code smells | Not covered | Best — force unwrap, force cast, etc. |
+| Force unwrapping | Not covered | Best — warns/errors |
+| Custom rules | Not supported | Best — regex-based custom rules |
+
+### Running as Xcode Build Phase
+---
+
+```bash
+# Run Script — SwiftFormat (place BEFORE SwiftLint build phase)
+if command -v swiftformat >/dev/null 2>&1; then
+    swiftformat "${SRCROOT}/Sources" --config "${SRCROOT}/.swiftformat"
+else
+    echo "warning: SwiftFormat not installed. Run 'brew install swiftformat'"
+fi
+```
+
+### Editor Integration
+---
+
+Install the SwiftFormat for Xcode extension from the Mac App Store, or run via command palette in VS Code with the SwiftFormat extension. For Xcode:
+
+1. Install SwiftFormat for Xcode from the App Store
+2. Enable in System Settings > Privacy & Security > Extensions > Xcode Source Editor
+3. Use Editor > SwiftFormat > Format File (bind to a keyboard shortcut)
+
+
+## Using SwiftLint + SwiftFormat Together
+
+The key is avoiding conflicts — disable formatting-related rules in SwiftLint and let SwiftFormat handle them.
+
+### Recommended Setup
+---
+
+#### Rules to disable in SwiftLint (let SwiftFormat handle these):
+
+```yaml
+# .swiftlint.yml — disable rules that SwiftFormat handles better
+disabled_rules:
+  - trailing_comma
+  - opening_brace
+  - closing_brace
+  - vertical_whitespace
+  - statement_position
+  - return_arrow_whitespace
+  - colon
+  - comma
+  - leading_whitespace
+  - trailing_newline
+  - trailing_semicolon
+  - trailing_whitespace
+```
+
+#### Rules to keep in SwiftLint (SwiftFormat cannot enforce these):
+
+```yaml
+# These stay in SwiftLint — SwiftFormat has no equivalent
+opt_in_rules:
+  - force_unwrapping
+  - cyclomatic_complexity
+  - function_body_length
+  - type_body_length
+  - file_length
+  - identifier_name
+  - type_name
+  - empty_count
+  - first_where
+  - contains_over_filter_count
+  - unowned_variable_capture
+```
+
+#### Execution order:
+
+1. **SwiftFormat first** — auto-fix formatting
+2. **SwiftLint second** — check remaining rules
+
+In Xcode build phases, place SwiftFormat before SwiftLint. In CI, run format-check before lint.
+
+
+## Xcode Static Analyzer
+
+### When to Use
+---
+
+The Xcode Static Analyzer performs deep analysis of control flow and memory management. Run it via Product > Analyze (Cmd+Shift+B) or enable it in build settings.
+
+#### What It Catches
+
+- Memory leaks in Objective-C and bridged code
+- Null pointer dereferences
+- Use-after-free
+- Logic errors (dead code branches, unreachable code)
+- Division by zero
+- API misuse (CoreFoundation reference counting)
+
+#### Build Settings
+
+```
+// Enable static analysis during builds (slows build — use selectively)
+RUN_CLANG_STATIC_ANALYZER = YES              // Analyze During 'Build'
+CLANG_STATIC_ANALYZER_MODE = deep            // shallow (faster) or deep (thorough)
+CLANG_STATIC_ANALYZER_MODE_ON_ANALYZE_ACTION = deep
+```
+
+### Sanitizers
+---
+
+Sanitizers are runtime tools that detect bugs during test execution. Enable them in your scheme or test plan.
+
+#### Address Sanitizer (ASan)
+
+Detects memory corruption: buffer overflows, use-after-free, stack overflow, heap overflow.
+
+```
+// Scheme > Test > Diagnostics > Address Sanitizer
+ENABLE_ADDRESS_SANITIZER = YES
+
+// Also enable:
+CLANG_ADDRESS_SANITIZER_CONTAINER_OVERFLOW = YES
+```
+
+#### Thread Sanitizer (TSan)
+
+Detects data races — concurrent access to shared mutable state without synchronization.
+
+```
+// Scheme > Test > Diagnostics > Thread Sanitizer
+ENABLE_THREAD_SANITIZER = YES
+```
+
+Rules:
+- Thread Sanitizer and Address Sanitizer cannot be enabled simultaneously.
+- Thread Sanitizer adds ~5-15x slowdown — run in CI on a dedicated test plan.
+- Thread Sanitizer is especially valuable when migrating to Swift 6 strict concurrency.
+
+#### Undefined Behavior Sanitizer (UBSan)
+
+Detects undefined behavior: integer overflow, misaligned pointers, null reference.
+
+```
+// Scheme > Test > Diagnostics > Undefined Behavior Sanitizer
+ENABLE_UNDEFINED_BEHAVIOR_SANITIZER = YES
+CLANG_UNDEFINED_BEHAVIOR_SANITIZER_INTEGER = YES
+CLANG_UNDEFINED_BEHAVIOR_SANITIZER_NULLABILITY = YES
+```
+
+### Enabling Sanitizers in Test Plans
+---
+
+```json
+{
+    "configurations": [
+        {
+            "name": "Default",
+            "options": {
+                "addressSanitizer": {
+                    "enabled": false
+                },
+                "threadSanitizer": {
+                    "enabled": false
+                }
+            }
+        },
+        {
+            "name": "Thread Safety",
+            "options": {
+                "threadSanitizer": {
+                    "enabled": true
+                }
+            }
+        },
+        {
+            "name": "Memory Safety",
+            "options": {
+                "addressSanitizer": {
+                    "enabled": true,
+                    "detectStackUseAfterReturn": true
+                },
+                "undefinedBehaviorSanitizer": {
+                    "enabled": true
+                }
+            }
+        }
+    ]
+}
+```
+
+Run separate test plan configurations in CI for sanitizer checks — they incur significant overhead and should not run in the default test suite.
+
+
+## Periphery — Dead Code Detection
+
+Periphery scans your project for unused declarations: classes, structs, enums, protocols, functions, properties, and more.
+
+### Installation and Basic Usage
+---
+
+```bash
+# Install
+brew install peripheryapp/periphery/periphery
+
+# Scan an Xcode project
+periphery scan --project MyApp.xcodeproj --schemes MyApp --targets MyApp
+
+# Scan an SPM package
+periphery scan --spm
+```
+
+### Configuration (`.periphery.yml`)
+---
+
+```yaml
+# .periphery.yml
+project: MyApp.xcodeproj
+schemes:
+  - MyApp
+targets:
+  - MyApp
+  - MyAppKit
+
+# Retain declarations matching these patterns (avoid false positives)
+retain_public: false        # Set true for frameworks/libraries
+retain_objc_accessible: true
+
+# Exclude files from scanning
+index_exclude:
+  - "Sources/Generated/**"
+  - "Sources/Resources/**"
+
+# Additional retain patterns
+retain_unused_protocol_func_params: false
+```
+
+### Handling False Positives
+---
+
+Periphery may flag code that is actually used through dynamic dispatch or runtime features:
+
+```swift
+// @objc methods called from Objective-C or Interface Builder
+// periphery:ignore
+@objc func buttonTapped(_ sender: UIButton) {
+    // ...
+}
+
+// Codable synthesized conformance — properties appear unused
+// periphery:ignore
+struct APIResponse: Codable {
+    let id: String
+    let name: String
+}
+
+// IBOutlet/IBAction connected in storyboards
+// periphery:ignore
+@IBOutlet weak var titleLabel: UILabel!
+
+// Protocol conformance required by framework
+// periphery:ignore
+func application(_ application: UIApplication,
+                 didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    return true
+}
+```
+
+Rules:
+- Run Periphery after major refactors to find leftover dead code.
+- Use `// periphery:ignore` sparingly — investigate whether the code is truly needed first.
+- Set `retain_public: true` for library/framework targets where public API is consumed externally.
+- Set `retain_objc_accessible: true` to avoid false positives with `@objc` declarations.
+
+
+## CI/CD Integration
+
+### GitHub Actions Workflow
+---
+
+```yaml
+# .github/workflows/code-quality.yml
+name: Code Quality
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - '**/*.swift'
+      - '.swiftlint.yml'
+      - '.swiftformat'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-format:
+    name: SwiftLint & SwiftFormat
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: |
+          brew install swiftlint swiftformat
+
+      - name: SwiftFormat check (no modifications)
+        run: |
+          swiftformat --lint --config .swiftformat Sources/ Tests/
+
+      - name: SwiftLint
+        run: |
+          swiftlint lint --strict --config .swiftlint.yml --reporter github-actions-logging
+
+  periphery:
+    name: Dead Code Detection
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Periphery
+        run: brew install peripheryapp/periphery/periphery
+
+      - name: Scan for unused code
+        run: |
+          periphery scan \
+            --project MyApp.xcodeproj \
+            --schemes MyApp \
+            --targets MyApp \
+            --format github-actions
+```
+
+Rules:
+- Use `--reporter github-actions-logging` with SwiftLint to annotate PRs inline.
+- Use `swiftformat --lint` (not `swiftformat`) in CI to check without modifying files.
+- Use `--strict` with SwiftLint to treat warnings as errors in CI.
+
+### Pre-Commit Hooks
+---
+
+```bash
+#!/bin/bash
+# .git/hooks/pre-commit
+
+# Get staged Swift files
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.swift$')
+
+if [ -z "$STAGED_FILES" ]; then
+    exit 0
+fi
+
+echo "Running SwiftFormat on staged files..."
+echo "$STAGED_FILES" | xargs swiftformat --config .swiftformat
+
+echo "Running SwiftLint on staged files..."
+echo "$STAGED_FILES" | xargs swiftlint lint --strict --config .swiftlint.yml
+
+LINT_STATUS=$?
+
+# Re-stage formatted files
+echo "$STAGED_FILES" | xargs git add
+
+if [ $LINT_STATUS -ne 0 ]; then
+    echo "SwiftLint found violations. Please fix them before committing."
+    exit 1
+fi
+
+exit 0
+```
+
+Make executable: `chmod +x .git/hooks/pre-commit`
+
+For team-wide hooks, use a shared hooks directory:
+
+```bash
+# Set hooks path for the repo
+git config core.hooksPath .githooks/
+
+# Place pre-commit in .githooks/pre-commit (committed to repo)
+```
+
+### Danger-Swift for PR Automation
+---
+
+```swift
+// Dangerfile.swift
+import Danger
+
+let danger = Danger()
+
+// Warn if PR is too large
+let bigPRThreshold = 500
+if (danger.github.pullRequest.additions ?? 0) + (danger.github.pullRequest.deletions ?? 0) > bigPRThreshold {
+    warn("This PR is quite large. Consider breaking it into smaller PRs.")
+}
+
+// Check for SwiftLint violations
+SwiftLint.lint(inline: true, configFile: ".swiftlint.yml")
+
+// Ensure tests are updated when source changes
+let sourceChanges = danger.git.modifiedFiles.filter { $0.hasPrefix("Sources/") }
+let testChanges = danger.git.modifiedFiles.filter { $0.hasPrefix("Tests/") }
+if !sourceChanges.isEmpty && testChanges.isEmpty {
+    warn("Source files were modified but no tests were updated. Please add or update tests.")
+}
+
+// Check for TODO/FIXME in diff
+let diffTodos = danger.git.modifiedFiles
+    .filter { $0.hasSuffix(".swift") }
+    .compactMap { danger.utils.readFile($0) }
+    .filter { $0.contains("TODO") || $0.contains("FIXME") }
+if !diffTodos.isEmpty {
+    message("This PR contains TODO/FIXME comments. Consider resolving them.")
+}
+```
+
+
+## Xcode Build Settings for Quality
+
+### Strict Concurrency Checking
+---
+
+```
+// Build Settings > Swift Compiler - Upcoming Features
+SWIFT_STRICT_CONCURRENCY = complete       // Full Swift 6 concurrency checking
+```
+
+This enables compile-time data race safety. Set to `targeted` for gradual migration, `complete` for full enforcement.
+
+### Treat Warnings as Errors
+---
+
+```
+// For release builds — prevents shipping code with warnings
+SWIFT_TREAT_WARNINGS_AS_ERRORS = YES      // Swift warnings
+GCC_TREAT_WARNINGS_AS_ERRORS = YES        // C/ObjC warnings
+
+// Apply only to release configuration in xcconfig:
+// Release.xcconfig
+SWIFT_TREAT_WARNINGS_AS_ERRORS = YES
+GCC_TREAT_WARNINGS_AS_ERRORS = YES
+```
+
+Rules:
+- Enable treat-warnings-as-errors for Release configurations only.
+- In Debug, keep as warnings to avoid blocking development.
+- Fix all warnings before merging to main — enforce via CI.
+
+### Other Recommended Build Settings
+---
+
+```
+// Enable testability for test targets
+ENABLE_TESTING_SEARCH_PATHS = YES         // On test targets only
+
+// Enable module stability for frameworks
+BUILD_LIBRARY_FOR_DISTRIBUTION = YES      // For distributed frameworks only
+
+// Optimization
+SWIFT_COMPILATION_MODE = wholemodule      // Release — better optimization
+SWIFT_COMPILATION_MODE = singlefile       // Debug — faster incremental builds
+
+// Warnings
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES
+CLANG_WARN_SUSPICIOUS_MOVE = YES
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE
+```
+
+### Xcode Configuration Files (`.xcconfig`)
+---
+
+```
+// Shared.xcconfig — common settings across all configurations
+SWIFT_VERSION = 6.0
+IPHONEOS_DEPLOYMENT_TARGET = 17.0
+SWIFT_STRICT_CONCURRENCY = complete
+
+// Debug.xcconfig
+#include "Shared.xcconfig"
+SWIFT_COMPILATION_MODE = singlefile
+SWIFT_TREAT_WARNINGS_AS_ERRORS = NO
+ENABLE_TESTABILITY = YES
+
+// Release.xcconfig
+#include "Shared.xcconfig"
+SWIFT_COMPILATION_MODE = wholemodule
+SWIFT_TREAT_WARNINGS_AS_ERRORS = YES
+GCC_TREAT_WARNINGS_AS_ERRORS = YES
+SWIFT_OPTIMIZATION_LEVEL = -O
+```
+
+
+## Common Pitfalls
+
+| Pitfall | Fix |
+|---|---|
+| Over-configuring linting (too many rules enabled) | Start with defaults, enable opt-in rules incrementally. If developers routinely disable rules inline, the rule is too strict |
+| Inconsistent configs across modules | Use a single root `.swiftlint.yml` with nested overrides only where necessary (e.g., relaxed test rules) |
+| Not auto-fixing what can be auto-fixed | Run `swiftlint lint --fix` and `swiftformat` before linting. Reduces noise and developer friction |
+| Running linters before formatters | Always run SwiftFormat first, then SwiftLint. Formatting changes may resolve lint violations |
+| SwiftLint and SwiftFormat conflicting on the same rules | Disable formatting rules in SwiftLint, let SwiftFormat handle them exclusively |
+| Ignoring Periphery false positives without investigation | Always verify whether flagged code is truly unused before adding `// periphery:ignore` |
+| Enabling all sanitizers simultaneously | Address Sanitizer and Thread Sanitizer cannot coexist. Use separate test plan configurations |
+| Running sanitizers in every CI build | Sanitizers add 5-15x overhead. Run in a scheduled nightly job or a separate CI stage |
+| Not pinning tool versions | Different SwiftLint/SwiftFormat versions may produce different results. Pin versions via SPM plugins or Mint |
+| Treat-warnings-as-errors in Debug | Blocks development. Enable only for Release builds |
+| Skipping static analysis entirely | Run Xcode Analyze at least before releases. Catches memory bugs that compiler warnings miss |
+| Not configuring `excluded` paths | Generated code, vendored code, and build artifacts produce irrelevant violations. Always exclude them |
+
+## Related References
+
+- **`references/testing.md`** — Test plans, test configurations, and CI/CD test commands. Sanitizers configured here are enabled in test plans described there.
+- **`references/project-structure.md`** — Build configurations, schemes, and xcconfig setup referenced in the build settings section above.

--- a/registry/skills/apple-app-development/references/code-quality.md
+++ b/registry/skills/apple-app-development/references/code-quality.md
@@ -145,7 +145,7 @@ Periphery scans your Xcode project for unused declarations: classes, structs, en
 
 ```bash
 # Install
-brew install peripheryapp/periphery/periphery
+brew install periphery
 
 # Scan an Xcode project
 periphery scan --project MyApp.xcodeproj --schemes MyApp --targets MyApp
@@ -272,7 +272,7 @@ for file in danger.git.modifiedFiles.filter({ $0.hasSuffix(".swift") }) {
       - uses: actions/checkout@v4
 
       - name: Install Periphery
-        run: brew install peripheryapp/periphery/periphery
+        run: brew install periphery
 
       - name: Scan for unused code
         run: |

--- a/registry/skills/apple-app-development/references/code-quality.md
+++ b/registry/skills/apple-app-development/references/code-quality.md
@@ -232,7 +232,7 @@ let danger = Danger()
 
 // Warn if PR is too large
 let bigPRThreshold = 500
-if danger.github.pullRequest.additions + danger.github.pullRequest.deletions > bigPRThreshold {
+if (danger.github.pullRequest.additions ?? 0) + (danger.github.pullRequest.deletions ?? 0) > bigPRThreshold {
     warn("This PR is quite large. Consider breaking it into smaller PRs.")
 }
 
@@ -246,13 +246,11 @@ if !sourceChanges.isEmpty && testChanges.isEmpty {
     warn("Source files were modified but no tests were updated. Please add or update tests.")
 }
 
-// Check for TODO/FIXME in added lines
+// Check for TODO/FIXME in modified Swift files
 for file in danger.git.modifiedFiles.filter({ $0.hasSuffix(".swift") }) {
-    for line in danger.utils.diff(for: file)?.hunks.flatMap(\.lines) ?? [] where line.type == .addition {
-        if line.text.contains("TODO") || line.text.contains("FIXME") {
-            message("New TODO/FIXME found in \(file). Consider resolving before merge.")
-            break
-        }
+    let lines = danger.utils.readFile(file).components(separatedBy: .newlines)
+    if lines.contains(where: { $0.contains("TODO") || $0.contains("FIXME") }) {
+        message("New TODO/FIXME found in \(file). Consider resolving before merge.")
     }
 }
 ```

--- a/registry/skills/apple-app-development/references/code-quality.md
+++ b/registry/skills/apple-app-development/references/code-quality.md
@@ -44,7 +44,7 @@ The Xcode Static Analyzer performs deep analysis of control flow and memory mana
 
 #### Build Settings
 
-```
+```text
 // Enable static analysis during builds (slows build — use selectively)
 RUN_CLANG_STATIC_ANALYZER = YES              // Analyze During 'Build'
 CLANG_STATIC_ANALYZER_MODE = deep            // shallow (faster) or deep (thorough)
@@ -55,11 +55,11 @@ CLANG_STATIC_ANALYZER_MODE_ON_ANALYZE_ACTION = deep
 
 Sanitizers are runtime tools that detect bugs during test execution. Enable them in your scheme or test plan.
 
-#### Address Sanitizer (ASan)
+### Address Sanitizer (ASan)
 
 Detects memory corruption: buffer overflows, use-after-free, stack overflow, heap overflow.
 
-```
+```text
 // Scheme > Test > Diagnostics > Address Sanitizer
 ENABLE_ADDRESS_SANITIZER = YES
 
@@ -67,11 +67,11 @@ ENABLE_ADDRESS_SANITIZER = YES
 CLANG_ADDRESS_SANITIZER_CONTAINER_OVERFLOW = YES
 ```
 
-#### Thread Sanitizer (TSan)
+### Thread Sanitizer (TSan)
 
 Detects data races — concurrent access to shared mutable state without synchronization.
 
-```
+```text
 // Scheme > Test > Diagnostics > Thread Sanitizer
 ENABLE_THREAD_SANITIZER = YES
 ```
@@ -81,11 +81,11 @@ Rules:
 - Thread Sanitizer adds ~5-15x slowdown — run in CI on a dedicated test plan.
 - Thread Sanitizer is especially valuable when migrating to Swift 6 strict concurrency.
 
-#### Undefined Behavior Sanitizer (UBSan)
+### Undefined Behavior Sanitizer (UBSan)
 
 Detects undefined behavior: integer overflow, misaligned pointers, null reference.
 
-```
+```text
 // Scheme > Test > Diagnostics > Undefined Behavior Sanitizer
 ENABLE_UNDEFINED_BEHAVIOR_SANITIZER = YES
 CLANG_UNDEFINED_BEHAVIOR_SANITIZER_INTEGER = YES

--- a/registry/skills/apple-app-development/references/concurrency.md
+++ b/registry/skills/apple-app-development/references/concurrency.md
@@ -10,6 +10,7 @@
 - AsyncSequence and AsyncStream (building, consuming, bridging)
 - Migrating from GCD
 - Migrating from Combine
+- Swift 6.2 — Approachable Concurrency (`defaultIsolation`, `nonisolated(nonsending)`, `@concurrent`)
 - Common pitfalls (data races, reentrancy, deadlocks)
 - Testing async code
 
@@ -913,6 +914,125 @@ class SearchViewModel {
 | Multi-subscriber reactive streams | Combine (`CurrentValueSubject`, `PassthroughSubject`) |
 | Complex stream operators (`combineLatest`, `debounce`, etc.) | Combine |
 | Cross-platform async sequences | `AsyncSequence` + Swift Async Algorithms |
+
+## Swift 6.2 — Approachable Concurrency
+
+Swift 6.2 (Xcode 26) introduces **Approachable Concurrency** — a set of defaults that dramatically reduce annotation burden while preserving data-race safety. The key idea: most app code is UI code and should run on `MainActor` by default; only code that genuinely needs concurrency opts into it explicitly.
+
+### `defaultIsolation` build setting
+
+New projects created in Xcode 26 default to `MainActor` isolation for all code. This means every function, property, and type is implicitly `@MainActor` unless explicitly opted out. `@MainActor` annotations on view models, views, and App types become unnecessary — they are already on MainActor.
+
+Enable in **Package.swift**:
+
+```swift
+// swift-tools-version: 6.2
+let package = Package(
+    name: "MyApp",
+    targets: [
+        .executableTarget(
+            name: "MyApp",
+            swiftSettings: [
+                .defaultIsolation(MainActor.self)
+            ]
+        )
+    ]
+)
+```
+
+In Xcode, set the **Default Isolation** build setting to `MainActor` (the default for new Xcode 26 projects).
+
+With `defaultIsolation(MainActor.self)` enabled, this:
+
+```swift
+// Before — explicit annotation required
+@MainActor
+@Observable
+class ProfileViewModel {
+    var name: String = ""
+    func load() async { /* … */ }
+}
+```
+
+becomes:
+
+```swift
+// After — already on MainActor by default, no annotation needed
+@Observable
+class ProfileViewModel {
+    var name: String = ""
+    func load() async { /* … */ }
+}
+```
+
+### `nonisolated(nonsending)` (SE-0461)
+
+Under Approachable Concurrency, `nonisolated async` functions default to running on the **caller's actor** instead of hopping to the global concurrent executor. The compiler applies `nonisolated(nonsending)` semantics automatically — the function inherits the caller's isolation context.
+
+```swift
+// Under Swift 6.2 Approachable Concurrency, this function stays
+// on whatever actor the caller is running on (e.g. MainActor).
+nonisolated func processUserInput(_ text: String) async -> String {
+    // No actor hop — runs on the caller's executor
+    return text.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+@MainActor
+func handleInput() async {
+    // processUserInput runs on MainActor — no hop to global executor
+    let cleaned = await processUserInput(rawInput)
+    label.text = cleaned
+}
+```
+
+This eliminates a major source of unexpected thread hops in Swift 5.x / 6.0 code, where every `nonisolated async` call silently moved to a background thread.
+
+### `@concurrent` attribute
+
+When you **do** want a function to leave the caller's actor and run on the global concurrent executor, mark it `@concurrent`. This is the explicit opt-in that replaces the old implicit behavior of `nonisolated async`.
+
+```swift
+@concurrent
+func compressImage(_ data: Data) async -> Data {
+    // Runs on the global concurrent executor — off MainActor.
+    // Safe for CPU-intensive work that should not block UI.
+    return HeavyImageProcessor.compress(data)
+}
+
+@MainActor
+func uploadPhoto() async {
+    let raw = selectedPhotoData
+    // Hops off MainActor into the concurrent pool
+    let compressed = await compressImage(raw)
+    // Back on MainActor
+    await api.upload(compressed)
+}
+```
+
+Use `@concurrent` for CPU-bound work (image processing, parsing large payloads, cryptographic operations) that would block the main thread.
+
+### `nonisolated` on types and extensions (Swift 6.1+)
+
+Starting in Swift 6.1, you can apply `nonisolated` to an entire type or extension to opt all members out of the enclosing default isolation:
+
+```swift
+// Opts the entire struct out of MainActor default isolation
+nonisolated struct MathUtilities {
+    static func fibonacci(_ n: Int) -> Int {
+        n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2)
+    }
+}
+
+// Opts all members in this extension out of default isolation
+nonisolated extension DataParser {
+    func parse(_ data: Data) throws -> ParsedResult {
+        // No actor isolation — can be called from any context
+        try JSONDecoder().decode(ParsedResult.self, from: data)
+    }
+}
+```
+
+This is particularly useful in codebases with `defaultIsolation(MainActor.self)` where utility types, pure-logic modules, or model layers should remain actor-independent.
 
 ## Common Pitfalls
 

--- a/registry/skills/apple-app-development/references/concurrency.md
+++ b/registry/skills/apple-app-development/references/concurrency.md
@@ -829,15 +829,18 @@ Task {
 
 ### When to keep Combine
 
+Combine is not deprecated and remains the right tool for specific patterns. AsyncStream is **unicast** (single consumer), while Combine subjects are **multicast** (multiple subscribers with backpressure). They are complementary, not interchangeable.
+
+- **Multi-subscriber reactive streams** — `CurrentValueSubject`, `PassthroughSubject` with multiple observers. AsyncStream cannot replicate this without manual fan-out.
+- **Complex stream operators** — `debounce`, `throttle`, `combineLatest`, `merge`, `scan`, `switchToLatest` with backpressure. AsyncSequence operators are more limited.
 - **SwiftUI `@Published` with `ObservableObject`** — if targeting iOS 16 or earlier.
-- **Complex stream operators** — `debounce`, `throttle`, `combineLatest`, `merge` with backpressure. AsyncSequence operators are more limited.
 - **KVO observation** — Combine's `publisher(for:)` is still convenient for observing UIKit properties.
 
-### When to replace with async/await
+### When to use async/await instead
 
 - **Single-shot async work** — API calls, database queries. Use `async throws` instead of `Future`.
-- **Simple data flow** — replace `PassthroughSubject`/`CurrentValueSubject` with `AsyncStream` or actors.
-- **iOS 17+ projects** — `@Observable` replaces `ObservableObject`/`@Published` entirely.
+- **Single-consumer async sequences** — bridging a delegate/callback API for one consumer. Use `AsyncStream`.
+- **iOS 17+ view model state** — `@Observable` replaces `ObservableObject`/`@Published` entirely, no Combine needed.
 
 ### Bridging: `values` property (AsyncPublisher)
 
@@ -900,48 +903,16 @@ class SearchViewModel {
 }
 ```
 
-### Replacing `CurrentValueSubject` with actor + AsyncStream
+### Choosing the right tool
 
-```swift
-// Before
-class SettingsStore {
-    let theme = CurrentValueSubject<Theme, Never>(.system)
-}
-
-// After
-actor SettingsStore {
-    private var _theme: Theme = .system
-    private var continuations: [UUID: AsyncStream<Theme>.Continuation] = [:]
-
-    var theme: Theme { _theme }
-
-    func setTheme(_ theme: Theme) {
-        _theme = theme
-        for (_, continuation) in continuations {
-            continuation.yield(theme)
-        }
-    }
-
-    func themeUpdates() -> AsyncStream<Theme> {
-        AsyncStream { continuation in
-            let id = UUID()
-            continuation.yield(_theme) // Emit current value
-            Task { await storeContinuation(continuation, id: id) }
-            continuation.onTermination = { _ in
-                Task { await self.removeContinuation(id: id) }
-            }
-        }
-    }
-
-    private func storeContinuation(_ continuation: AsyncStream<Theme>.Continuation, id: UUID) {
-        continuations[id] = continuation
-    }
-
-    private func removeContinuation(id: UUID) {
-        continuations[id] = nil
-    }
-}
-```
+| Need | Recommended tool |
+|---|---|
+| SwiftUI view model state (iOS 17+) | `@Observable` |
+| Single-shot async data fetching | `async/await` |
+| Single-consumer async sequence | `AsyncStream` / `AsyncSequence` |
+| Multi-subscriber reactive streams | Combine (`CurrentValueSubject`, `PassthroughSubject`) |
+| Complex stream operators (`combineLatest`, `debounce`, etc.) | Combine |
+| Cross-platform async sequences | `AsyncSequence` + Swift Async Algorithms |
 
 ## Common Pitfalls
 

--- a/registry/skills/apple-app-development/references/concurrency.md
+++ b/registry/skills/apple-app-development/references/concurrency.md
@@ -1,7 +1,7 @@
 # Swift Concurrency Reference (Apple Platforms)
 
 ## Contents
-- async/await fundamentals, typed throws (Swift 6+)
+- async/await fundamentals, typed throws (Swift 6+), Result-based error handling for async
 - Structured concurrency (`async let`, `TaskGroup`, cancellation)
 - Actors (custom, `@MainActor`, global actors, isolation, `nonisolated`)
 - Sendable (protocol, `@Sendable` closures, `sending` parameter)
@@ -59,7 +59,7 @@ func fetchData(from url: URL) async throws(NetworkError) -> Data {
     }
 }
 
-// Caller gets exhaustive switch on NetworkError — no catch-all needed
+// Single typed-throws call — error type is inferred correctly
 do {
     let data = try await fetchData(from: url)
 } catch .timeout {
@@ -71,8 +71,50 @@ do {
 }
 ```
 
+**Caveat — async inference gaps:** Typed throws has known compiler limitations in async contexts (as of Swift 6.1). Error type inference breaks with `async let` ([swift#76169](https://github.com/swiftlang/swift/issues/76169)), nested `do`-`catch` ([swift#75260](https://github.com/swiftlang/swift/issues/75260)), and generic error type parameters. Exhaustive pattern-matching in `catch` clauses is also not supported ([swift#74555](https://github.com/swiftlang/swift/issues/74555)) — you must use `catch { switch error { ... } }` instead.
+
+### Result-based error handling for async
+
+When combining multiple async calls with custom error types, prefer `Result<Success, Failure>`. Typed throws loses error type propagation when multiple `async throws(E)` calls appear in the same `do`-`catch` block — the compiler widens to `any Error`. `Result` preserves per-call error typing and allows callers to handle each error independently:
+
+```swift
+func fetchData(from url: URL) async -> Result<Data, NetworkError> {
+    let data: Data
+    let response: URLResponse
+    do {
+        (data, response) = try await URLSession.shared.data(from: url)
+    } catch {
+        return .failure(.timeout)
+    }
+    guard let http = response as? HTTPURLResponse else {
+        return .failure(.serverError(statusCode: 0))
+    }
+    switch http.statusCode {
+    case 200...299: return .success(data)
+    case 401: return .failure(.unauthorized)
+    default: return .failure(.serverError(statusCode: http.statusCode))
+    }
+}
+
+// Each call preserves its error type — no compiler inference issues
+let dataResult = await fetchData(from: url)
+let configResult = await fetchConfig(from: configURL)
+
+switch dataResult {
+case .success(let data):
+    process(data)
+case .failure(.timeout):
+    showRetryPrompt()
+case .failure(.unauthorized):
+    navigateToLogin()
+case .failure(.serverError(let code)):
+    showServerError(code)
+}
+```
+
 Rules:
-- Use typed throws for domain-specific APIs where callers benefit from exhaustive handling.
+- Use typed throws for simple, single-call async contexts or synchronous code where callers benefit from exhaustive handling.
+- Prefer `Result<Success, Failure>` when combining multiple async calls with custom error types — typed throws inference breaks in this scenario.
 - Continue using untyped `throws` at module boundaries or when errors are heterogeneous.
 - Typed throws compose — `throws(NetworkError)` inside `throws(AppError)` requires mapping.
 

--- a/registry/skills/apple-app-development/references/concurrency.md
+++ b/registry/skills/apple-app-development/references/concurrency.md
@@ -1029,31 +1029,48 @@ struct ChatView: View {
 }
 ```
 
-### 5. Reference cycles with Task closures
+### 5. `[weak self]` in Task closures
 
-`Task { }` closures capture `self` strongly. This is usually fine for `@MainActor` view models held by a view (the view owns the model, the model does not own the view), but can cause leaks in other contexts.
+`Task { }` closures capture `self` strongly, but a strong capture alone is **not** a retain cycle. A cycle requires a mutual strong reference — `self` must also hold the `Task`. A fire-and-forget Task completes and releases `self` naturally.
+
+Do not cargo-cult `[weak self]` from GCD/completion handlers into Task closures — it adds unnecessary optionality without solving a real problem.
 
 ```swift
-// Potential leak: mutual strong reference
-class Coordinator {
-    var onComplete: (() -> Void)?
+// No cycle — Task holds self, but self does NOT hold Task
+func start() {
+    Task {
+        await self.doWork() // Fine — released on Task completion
+    }
+}
 
-    func start() {
-        Task {
-            await doWork()
-            self.onComplete?() // Strong capture of self
+// Cycle — self stores Task, Task captures self
+class Poller {
+    private var pollingTask: Task<Void, Never>?  // self -> Task
+
+    func startPolling() {
+        pollingTask = Task {                      // Task -> self
+            while !Task.isCancelled {
+                await self.fetchData()            // CYCLE: self -> pollingTask -> self
+                try? await Task.sleep(for: .seconds(30))
+            }
+        }
+    }
+
+    // Fix: [weak self] because self stores the Task
+    func startPollingFixed() {
+        pollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.fetchData()
+                try? await Task.sleep(for: .seconds(30))
+            }
         }
     }
 }
-
-// Fix: use [weak self]
-func start() {
-    Task { [weak self] in
-        await self?.doWork()
-        self?.onComplete?()
-    }
-}
 ```
+
+Use `[weak self]` only when:
+- `self` stores the `Task` in a property (mutual strong reference — actual retain cycle).
+- Long-running Task (e.g., async sequence iteration) where you want to stop work if the owning object is deallocated — a correctness choice, not a memory leak fix.
 
 ### 6. Using Task.detached when Task suffices
 
@@ -1079,7 +1096,7 @@ Task {
 | Actor reentrancy changes state | Re-check state after every `await` inside actors |
 | Blocking main thread on async work | Make the function `async`, never use semaphores/locks to bridge |
 | Task runs after view disappears | Use `.task` modifier instead of `Task { }` in `onAppear` |
-| Strong reference cycle in Task | Use `[weak self]` in long-lived Task closures |
+| Retain cycle when self stores Task | Use `[weak self]` only when self holds the Task in a property |
 | Unnecessary `Task.detached` | Prefer `Task { }` — it inherits context and is simpler |
 | Silent cancellation (no checking) | Check `Task.isCancelled` or call `try Task.checkCancellation()` in loops |
 

--- a/registry/skills/apple-app-development/references/concurrency.md
+++ b/registry/skills/apple-app-development/references/concurrency.md
@@ -1180,7 +1180,8 @@ class Poller {
     func startPollingFixed() {
         pollingTask = Task { [weak self] in
             while !Task.isCancelled {
-                await self?.fetchData()
+                guard let self else { return }   // stop the loop once the owner is gone
+                await self.fetchData()
                 try? await Task.sleep(for: .seconds(30))
             }
         }

--- a/registry/skills/apple-app-development/references/ipados-patterns.md
+++ b/registry/skills/apple-app-development/references/ipados-patterns.md
@@ -807,50 +807,52 @@ struct PresentationApp: App {
 
 ```swift
 @Observable
+// NOTE: UIScreen.screens, UIScreen.didConnectNotification, and UIScreen.didDisconnectNotification
+// are deprecated since iOS 16. Use UIScene-based detection instead (see Scene-based section below).
+// This legacy pattern is shown only for apps targeting iOS 15 and earlier.
 class ExternalDisplayManager {
-    var externalScreen: UIScreen?
     var externalWindow: UIWindow?
 
     init() {
-        observeScreenConnections()
+        observeSceneConnections()
     }
 
-    private func observeScreenConnections() {
+    private func observeSceneConnections() {
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(screenDidConnect),
-            name: UIScreen.didConnectNotification,
+            selector: #selector(sceneDidConnect),
+            name: UIScene.willConnectNotification,
             object: nil
         )
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(screenDidDisconnect),
-            name: UIScreen.didDisconnectNotification,
+            selector: #selector(sceneDidDisconnect),
+            name: UIScene.didDisconnectNotification,
             object: nil
         )
 
-        // Check for already-connected screens
-        if let screen = UIScreen.screens.dropFirst().first {
-            configureExternalScreen(screen)
+        // Check for already-connected external scenes
+        for scene in UIApplication.shared.connectedScenes {
+            if let windowScene = scene as? UIWindowScene,
+               windowScene.session.role == .externalDisplayNonInteractive {
+                configureExternalDisplay(windowScene)
+            }
         }
     }
 
-    @objc private func screenDidConnect(_ notification: Notification) {
-        guard let screen = notification.object as? UIScreen else { return }
-        configureExternalScreen(screen)
+    @objc private func sceneDidConnect(_ notification: Notification) {
+        guard let windowScene = notification.object as? UIWindowScene,
+              windowScene.session.role == .externalDisplayNonInteractive else { return }
+        configureExternalDisplay(windowScene)
     }
 
-    @objc private func screenDidDisconnect(_ notification: Notification) {
+    @objc private func sceneDidDisconnect(_ notification: Notification) {
         externalWindow?.isHidden = true
         externalWindow = nil
-        externalScreen = nil
     }
 
-    private func configureExternalScreen(_ screen: UIScreen) {
-        externalScreen = screen
-        let window = UIWindow(frame: screen.bounds)
-        window.screen = screen
-
+    private func configureExternalDisplay(_ windowScene: UIWindowScene) {
+        let window = UIWindow(windowScene: windowScene)
         let hostingController = UIHostingController(
             rootView: ExternalDisplayView()
         )
@@ -888,3 +890,59 @@ Rules:
 - Handle connect/disconnect gracefully. The external display can be removed at any time.
 - External displays have no touch input. Ensure all interaction happens on the iPad screen.
 - Test with both wired (USB-C/HDMI) and wireless (AirPlay) external displays.
+
+
+## iPadOS 18+ Features
+
+### Floating Tab Bar / Sidebar Adaptable
+
+iPadOS 18 introduced a new tab bar that floats at the top of the app, morphs into a sidebar, and supports user customization. Use `.tabViewStyle(.sidebarAdaptable)` and `TabSection` for grouping:
+
+```swift
+TabView {
+    Tab("Home", systemImage: "house") {
+        HomeView()
+    }
+
+    Tab("Search", systemImage: "magnifyingglass") {
+        SearchView()
+    }
+
+    TabSection("Library") {
+        Tab("Favorites", systemImage: "heart") {
+            FavoritesView()
+        }
+        Tab("Downloads", systemImage: "arrow.down.circle") {
+            DownloadsView()
+        }
+    }
+}
+.tabViewStyle(.sidebarAdaptable) // Floating tab bar + sidebar toggle
+```
+
+The tab bar collapses into a compact pill on scroll. Users can customize which tabs appear. In compact size classes, it falls back to a standard tab bar.
+
+### Apple Pencil Pro (iPadOS 18+)
+
+Apple Pencil Pro introduces hardware-driven gestures and haptics:
+
+```swift
+// Squeeze gesture — show custom tool palette
+let pencilInteraction = UIPencilInteraction()
+pencilInteraction.delegate = self // UIPencilInteractionDelegate
+
+// In delegate:
+func pencilInteraction(_ interaction: UIPencilInteraction,
+                       didReceiveSqueeze squeeze: UIPencilInteraction.Squeeze) {
+    showToolPalette()
+}
+
+// Barrel roll — rotation angle available in PKStrokePoint
+// Access via PKStrokePoint.rollAngle for rotation-aware brush shapes
+
+// Haptic feedback — trigger custom haptics through the Pencil
+let generator = UIImpactFeedbackGenerator(style: .light)
+generator.impactOccurred() // Felt through Pencil Pro when in contact with screen
+```
+
+Features: squeeze gesture (custom tool palette), barrel roll (gyroscope rotation for shaped tools), haptic feedback engine, hover distance detection (iPad Pro M2+).

--- a/registry/skills/apple-app-development/references/ipados-patterns.md
+++ b/registry/skills/apple-app-development/references/ipados-patterns.md
@@ -835,7 +835,7 @@ class ExternalDisplayManager {
         // Check for already-connected external scenes
         for scene in UIApplication.shared.connectedScenes {
             if let windowScene = scene as? UIWindowScene,
-               windowScene.session.role == .externalDisplayNonInteractive {
+               windowScene.session.role == .windowExternalDisplayNonInteractive {
                 configureExternalDisplay(windowScene)
             }
         }
@@ -843,11 +843,14 @@ class ExternalDisplayManager {
 
     @objc private func sceneDidConnect(_ notification: Notification) {
         guard let windowScene = notification.object as? UIWindowScene,
-              windowScene.session.role == .externalDisplayNonInteractive else { return }
+              windowScene.session.role == .windowExternalDisplayNonInteractive else { return }
         configureExternalDisplay(windowScene)
     }
 
     @objc private func sceneDidDisconnect(_ notification: Notification) {
+        // Only tear down for the external display scene, not any disconnecting scene.
+        guard let windowScene = notification.object as? UIWindowScene,
+              windowScene.session.role == .windowExternalDisplayNonInteractive else { return }
         externalWindow?.isHidden = true
         externalWindow = nil
     }

--- a/registry/skills/apple-app-development/references/ipados-patterns.md
+++ b/registry/skills/apple-app-development/references/ipados-patterns.md
@@ -807,9 +807,10 @@ struct PresentationApp: App {
 
 ```swift
 @Observable
-// NOTE: UIScreen.screens, UIScreen.didConnectNotification, and UIScreen.didDisconnectNotification
-// are deprecated since iOS 16. Use UIScene-based detection instead (see Scene-based section below).
-// This legacy pattern is shown only for apps targeting iOS 15 and earlier.
+// NOTE: This is the canonical iOS 16+ approach using UIScene-based detection.
+// The older UIScreen.screens / UIScreen.didConnectNotification / UIScreen.didDisconnectNotification
+// APIs are deprecated since iOS 16 — Apple's deprecation notice points to
+// UIScene.willConnectNotification (used below) as the replacement.
 class ExternalDisplayManager {
     var externalWindow: UIWindow?
 

--- a/registry/skills/apple-app-development/references/localization.md
+++ b/registry/skills/apple-app-development/references/localization.md
@@ -1,0 +1,61 @@
+# Localization
+
+Best practices for localizing user-facing text in Apple platform apps.
+
+## Core Rules
+
+When writing or modifying user-facing text:
+
+- Never use explicit string literals for user-facing text (e.g., `"Welcome back"`, `Text("Sign in")`).
+- Always use whichever localization solution is already in use in the project (e.g., String Catalogs, `.strings` files, a custom localization layer). Do not migrate to a different solution unless explicitly asked.
+- Apply this to all user-visible surfaces: labels, buttons, alerts, placeholders, accessibility labels, and error messages.
+- When you encounter an existing explicit string that should be localized, flag it and suggest the appropriate key name and parameter names, but do not migrate it unless asked.
+
+## String Catalogs (.xcstrings)
+
+If the project uses String Catalogs with code generation, reference the generated Swift accessor. `Localizable` is the default table name and must be omitted — do not write `.Localizable.keyName`. Only include a table name prefix when the string belongs to a non-default, custom table (e.g., `.Settings.keyName` for `Settings.xcstrings`).
+
+### Code Generation Accessors
+
+Xcode generates type-safe accessors automatically from String Catalog entries:
+
+```swift
+// Default table (Localizable.xcstrings) — no prefix
+String(localized: .welcomeMessage(name: user.name))
+String(localized: .itemCount(count: items.count))
+String(localized: .lastUpdated(date: formattedDate))
+
+// Custom tables — use table name as namespace prefix
+String(localized: .Settings.sectionTitle)                  // Settings.xcstrings
+String(localized: .Accessibility.itemDescription(name: …)) // Accessibility.xcstrings
+```
+
+### Named Parameter Format
+
+When a string has interpolated values, use the named argument format `%<index>$(<name>)<type>` directly in the string value (e.g., `%1$(name)@`, `%2$(count)d`). Name each parameter to reflect its role in the string — not generic names like `param1` or `value`.
+
+Always include the positional index, even for strings with a single parameter. This ensures consistency and avoids ambiguity when translators reorder parameters.
+
+**Single parameter:**
+
+```
+"Hello, %1$(name)@!"
+"You have %1$(count)lld unread messages."
+"Last updated on %1$(date)@."
+```
+
+**Multiple parameters:**
+
+```
+"Hello, %1$(name)@! You have %2$(count)lld new notifications."
+"Showing %1$(current)lld of %2$(total)lld results."
+"Transfer %1$(amount)@ from %2$(source)@ to %3$(destination)@."
+```
+
+### Parameter Naming Guidelines
+
+| Pattern | Example | Avoid |
+|---|---|---|
+| Descriptive role-based names | `%1$(name)@`, `%2$(count)d` | `%1$(param1)@`, `%2$(value)d` |
+| Match the Swift accessor parameter name | `%1$(name)@` → `.welcomeMessage(name:)` | `%1$(str)@` |
+| Use the domain term | `%1$(minLength)lld` for character limits | `%1$(num)lld` |

--- a/registry/skills/apple-app-development/references/localization.md
+++ b/registry/skills/apple-app-development/references/localization.md
@@ -59,3 +59,150 @@ Always include the positional index, even for strings with a single parameter. T
 | Descriptive role-based names | `%1$(name)@`, `%2$(count)d` | `%1$(param1)@`, `%2$(value)d` |
 | Match the Swift accessor parameter name | `%1$(name)@` → `.welcomeMessage(name:)` | `%1$(str)@` |
 | Use the domain term | `%1$(minLength)lld` for character limits | `%1$(num)lld` |
+
+## Localization APIs
+
+### String(localized:) API (iOS 15+)
+
+`String(localized:)` is the modern replacement for `NSLocalizedString`. It provides compile-time safety and cleaner syntax for runtime string resolution.
+
+Key parameters: `table:` (which `.xcstrings` file; defaults to `Localizable`), `bundle:` (defaults to `.main`; use `.module` for packages), `defaultValue:` (fallback and source-language value), `comment:` (context for translators, visible in `.xcloc` exports).
+
+```swift
+// Basic lookup from Localizable.xcstrings
+let welcome = String(localized: "welcome_message",
+                     defaultValue: "Welcome back, \(name)")
+
+// Lookup from a custom table
+let settings = String(localized: "tab_settings",
+                      table: "Settings",
+                      comment: "Settings tab title")
+
+// Lookup from a framework bundle
+let label = String(localized: "premium_badge",
+                   bundle: .module,
+                   comment: "Badge shown on premium content")
+```
+
+In SwiftUI, `Text` and `Label` accept `LocalizedStringKey` directly, so string literals inside these views are automatically localized against the default table without calling `String(localized:)`.
+
+### Pluralization and Device Variations
+
+String Catalogs natively handle **plural rules** and **device variations**, replacing the legacy `.stringsdict` XML format entirely.
+
+**Plural categories** (per CLDR): `zero`, `one`, `two`, `few`, `many`, `other`. Not every language uses every category — String Catalogs only show categories relevant to each target locale.
+
+To define a plural string, create a key in the String Catalog and set its type to **Plural** in the Xcode editor. Each category then gets its own translation. In code, pass an integer using the `%lld` format specifier:
+
+```swift
+// String Catalog key: "unread_count"
+// English variations:
+//   one  → "%lld unread message"
+//   other → "%lld unread messages"
+
+let label = String(localized: "unread_count \(unreadCount)")
+```
+
+With code-generated accessors:
+
+```swift
+String(localized: .unreadCount(count: unreadCount))
+```
+
+**Device variations** allow a single key to resolve differently on iPhone, iPad, Mac, Apple Watch, and Apple TV. Set the variation type to **Device** in the String Catalog editor. This is useful for platform-appropriate terminology (e.g., "tap" vs. "click", "screen" vs. "window").
+
+A key can combine both plural and device variations — Xcode's editor shows a matrix of device × plural category.
+
+### LocalizedStringResource (iOS 16+)
+
+`LocalizedStringResource` stores a reference to a localized string **without resolving it immediately**. Resolution happens when the string is displayed. Essential for:
+
+- **App Intents / Shortcuts** — intent parameter summaries and display names require `LocalizedStringResource`.
+- **Widgets** — timeline entries that may render in different locales.
+- **SwiftUI modifiers** that accept deferred localization.
+
+```swift
+// Creating a resource
+let title = LocalizedStringResource("settings_title",
+                                    table: "Settings",
+                                    comment: "Navigation title for settings screen")
+
+// Resolving later
+let resolved = String(localized: title)
+
+// In App Intents
+struct OpenSettings: AppIntent {
+    static var title: LocalizedStringResource = "open_settings_title"
+}
+```
+
+`LocalizedStringResource` also supports `defaultValue:` and `bundle:` parameters, matching the `String(localized:)` API.
+
+### Translator Comments
+
+Comments give translators context about where and how a string appears. This reduces translation errors and avoids ambiguity (e.g., "Post" as a noun vs. a verb).
+
+**Adding comments:**
+
+1. **In code** — Use the `comment:` parameter on `String(localized:)` or `LocalizedStringResource`:
+
+```swift
+String(localized: "post_action",
+       comment: "Verb — button that publishes a new post")
+```
+
+2. **In Xcode's String Catalog editor** — Select a key and fill in the Comment field in the inspector panel. This is visible in exported `.xcloc` files.
+
+3. **In SwiftUI views** — `Text` accepts a `comment:` parameter:
+
+```swift
+Text("delete_confirmation",
+     comment: "Alert title when user deletes an item")
+```
+
+**Best practices:**
+
+- Describe the UI context: what element the string appears in, what action it triggers.
+- Clarify ambiguous words (noun vs. verb, formal vs. informal).
+- Mention character constraints if the string must fit a narrow layout.
+- Comments with visual context (screenshots via `.xcloc`) significantly reduce translation errors.
+
+### Migration from .strings / .stringsdict
+
+Xcode provides a built-in migration path to String Catalogs:
+
+1. In the Project Navigator, right-click an existing `.strings` or `.stringsdict` file.
+2. Select **Migrate to String Catalog**.
+3. Xcode creates a new `.xcstrings` file, merges all existing translations and plural rules, and removes the old files.
+
+Migration preserves all keys, values, comments, and plural variations. If both `.strings` and `.stringsdict` exist for the same table, Xcode merges them into one `.xcstrings` file. After migration, build and check for "missing key" warnings. String Catalogs require **Xcode 15+** — defer migration if older Xcode versions are needed for CI.
+
+### Testing Localization
+
+**Pseudo-languages** (Edit Scheme → Run → Options → App Language):
+
+- **Double-Length** — doubles strings to test truncation and overflow.
+- **Right-to-Left** — mirrors UI for RTL layout validation.
+- **Accented** — replaces ASCII with accented variants to verify encoding.
+- **Bounded String** — wraps strings in brackets to spot unlocalized text.
+
+**Export / Import `.xcloc` for translators:**
+
+```
+Product → Export Localizations…
+```
+
+This generates `.xcloc` bundles per locale with all strings, screenshots, and comments. Translators edit in Xcode or any XLIFF-compatible tool. Import back:
+
+```
+Product → Import Localizations…
+```
+
+**Runtime locale override** — add launch arguments in the scheme to force a locale without changing device settings:
+
+```
+-AppleLanguages (ja)
+-AppleLocale ja_JP
+```
+
+**Automated checks** — use `xcodebuild -exportLocalizations` in CI to verify translations exist for required locales. Enable the **Missing Localizability** static analyzer (`CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED`) to catch hardcoded strings at build time.

--- a/registry/skills/apple-app-development/references/localization.md
+++ b/registry/skills/apple-app-development/references/localization.md
@@ -38,7 +38,7 @@ Always include the positional index, even for strings with a single parameter. T
 
 **Single parameter:**
 
-```
+```text
 "Hello, %1$(name)@!"
 "You have %1$(count)lld unread messages."
 "Last updated on %1$(date)@."
@@ -46,7 +46,7 @@ Always include the positional index, even for strings with a single parameter. T
 
 **Multiple parameters:**
 
-```
+```text
 "Hello, %1$(name)@! You have %2$(count)lld new notifications."
 "Showing %1$(current)lld of %2$(total)lld results."
 "Transfer %1$(amount)@ from %2$(source)@ to %3$(destination)@."
@@ -92,7 +92,7 @@ String Catalogs natively handle **plural rules** and **device variations**, repl
 
 **Plural categories** (per CLDR): `zero`, `one`, `two`, `few`, `many`, `other`. Not every language uses every category — String Catalogs only show categories relevant to each target locale.
 
-To define a plural string, create a key in the String Catalog and set its type to **Plural** in the Xcode editor. Each category then gets its own translation. In code, pass an integer using the `%lld` format specifier:
+To define a plural string, create a key in the String Catalog and set its type to **Plural** in the Xcode editor. Each category's translation references the count with the `%lld` format specifier (shown in the variations below). In code you don't write `%lld` yourself — pass the integer via Swift string interpolation, or use the generated accessor:
 
 ```swift
 // String Catalog key: "unread_count"

--- a/registry/skills/apple-app-development/references/macos-patterns.md
+++ b/registry/skills/apple-app-development/references/macos-patterns.md
@@ -48,7 +48,7 @@ struct MyApp: App {
         }
         .defaultSize(width: 400, height: 300)
         .windowResizability(.contentMinSize)
-        .defaultPosition(.trailing)
+        .defaultPosition(.trailing) // UnitPoint — positions window at trailing edge of screen
     }
 }
 ```

--- a/registry/skills/apple-app-development/references/macos-patterns.md
+++ b/registry/skills/apple-app-development/references/macos-patterns.md
@@ -684,7 +684,7 @@ struct DrawingApp: App {
 }
 
 struct DrawingCanvas: View {
-    @ObservedObject var document: DrawingDocument
+    var document: DrawingDocument
     @Environment(\.undoManager) var undoManager
 
     func addShape(_ shape: Shape) {

--- a/registry/skills/apple-app-development/references/networking.md
+++ b/registry/skills/apple-app-development/references/networking.md
@@ -83,7 +83,7 @@ struct Endpoint {
     }
 }
 
-final class URLSessionAPIClient: APIClient {
+final class URLSessionAPIClient: APIClient, Sendable {
     private let session: URLSession
     private let baseURL: URL
     private let decoder: JSONDecoder
@@ -456,7 +456,7 @@ Use `NWPathMonitor` (Network framework) instead of deprecated `SCNetworkReachabi
 ```swift
 import Network
 
-@Observable
+@MainActor @Observable
 class NetworkMonitor {
     var isConnected = true
     var isExpensive = false
@@ -527,18 +527,12 @@ class AuthInterceptor: RequestInterceptor {
         self.tokenManager = tokenManager
     }
 
-    func adapt(_ urlRequest: URLRequest, for session: Session,
-               completion: @escaping (Result<URLRequest, Error>) -> Void) {
+    // Alamofire 5.10+ supports async adapt — prefer this over wrapping Task in completion handler
+    func adapt(_ urlRequest: URLRequest, for session: Session) async throws -> URLRequest {
         var request = urlRequest
-        Task {
-            do {
-                let token = try await tokenManager.validToken()
-                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-                completion(.success(request))
-            } catch {
-                completion(.failure(error))
-            }
-        }
+        let token = try await tokenManager.validToken()
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        return request
     }
 
     func retry(_ request: Request, for session: Session, dueTo error: Error,

--- a/registry/skills/apple-app-development/references/networking.md
+++ b/registry/skills/apple-app-development/references/networking.md
@@ -392,30 +392,26 @@ func urlSession(_ session: URLSession, task: URLSessionTask,
 actor TokenManager {
     private var accessToken: String?
     private var refreshToken: String?
-    private var isRefreshing = false
+    private var refreshTask: Task<String, Error>?
 
     func validToken() async throws -> String {
         if let token = accessToken, !isExpired(token) {
             return token
         }
-        return try await refreshAccessToken()
-    }
-
-    private func refreshAccessToken() async throws -> String {
-        guard !isRefreshing else {
-            // Wait for ongoing refresh
-            try await Task.sleep(for: .milliseconds(100))
-            return try await validToken()
+        // All concurrent callers share a single refresh task
+        if let existingTask = refreshTask {
+            return try await existingTask.value
         }
-        isRefreshing = true
-        defer { isRefreshing = false }
-
-        // Perform refresh
-        guard let refreshToken else { throw AuthError.noRefreshToken }
-        let newTokens = try await authService.refresh(refreshToken)
-        accessToken = newTokens.access
-        refreshToken = newTokens.refresh
-        return newTokens.access
+        let task = Task { [self] () throws -> String in
+            defer { refreshTask = nil }
+            guard let refreshToken else { throw AuthError.noRefreshToken }
+            let newTokens = try await authService.refresh(refreshToken)
+            accessToken = newTokens.access
+            self.refreshToken = newTokens.refresh
+            return newTokens.access
+        }
+        refreshTask = task
+        return try await task.value
     }
 }
 
@@ -491,7 +487,7 @@ Add Alamofire when you need interceptors, automatic retry, or cleaner certificat
 
 ```swift
 // Package.swift
-.package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.10.0")
+.package(url: "https://github.com/Alamofire/Alamofire.git", from: "<latest-stable>")
 ```
 
 ### Basic Requests

--- a/registry/skills/apple-app-development/references/networking.md
+++ b/registry/skills/apple-app-development/references/networking.md
@@ -549,7 +549,7 @@ class AuthInterceptor: RequestInterceptor {
 
         Task {
             do {
-                _ = try await tokenManager.refreshAccessToken()
+                _ = try await tokenManager.validToken()
                 completion(.retry)
             } catch {
                 completion(.doNotRetryWithError(error))

--- a/registry/skills/apple-app-development/references/networking.md
+++ b/registry/skills/apple-app-development/references/networking.md
@@ -83,7 +83,10 @@ struct Endpoint {
     }
 }
 
-final class URLSessionAPIClient: APIClient, Sendable {
+// @unchecked because JSONDecoder isn't formally Sendable, yet this client is immutable
+// (all `let`) and never mutates the decoder's configuration after init, so sharing it
+// across concurrency domains is safe. URLSession and URL are already Sendable.
+final class URLSessionAPIClient: APIClient, @unchecked Sendable {
     private let session: URLSession
     private let baseURL: URL
     private let decoder: JSONDecoder

--- a/registry/skills/apple-app-development/references/objc-interop.md
+++ b/registry/skills/apple-app-development/references/objc-interop.md
@@ -557,6 +557,9 @@ actor SessionManager {
 ```
 
 ```swift
+// Use @MainActor to ensure thread-safe access to continuations dictionary.
+// Without isolation, delegate callbacks and download(from:) could race on the dictionary.
+@MainActor
 class DownloadService: NSObject, ABCDownloadDelegate {
     private var continuations: [String: CheckedContinuation<Data, Error>] = [:]
 
@@ -572,16 +575,20 @@ class DownloadService: NSObject, ABCDownloadDelegate {
 
     // MARK: - ABCDownloadDelegate
 
-    func download(_ download: ABCDownload, didFinishWith data: Data) {
+    nonisolated func download(_ download: ABCDownload, didFinishWith data: Data) {
         let key = download.url.absoluteString
-        continuations[key]?.resume(returning: data)
-        continuations[key] = nil
+        Task { @MainActor in
+            continuations[key]?.resume(returning: data)
+            continuations[key] = nil
+        }
     }
 
-    func download(_ download: ABCDownload, didFailWith error: Error) {
+    nonisolated func download(_ download: ABCDownload, didFailWith error: Error) {
         let key = download.url.absoluteString
-        continuations[key]?.resume(throwing: error)
-        continuations[key] = nil
+        Task { @MainActor in
+            continuations[key]?.resume(throwing: error)
+            continuations[key] = nil
+        }
     }
 }
 ```
@@ -760,6 +767,39 @@ Swift and Objective-C have different naming conventions. Conflicts appear when:
 let swiftRouter = MyApp.Router()
 let objcRouter = LegacyModule.ABCRouter()
 ```
+
+### Swift 6 Strict Concurrency and ObjC Interop
+
+Swift 6 strict concurrency significantly impacts Objective-C bridging:
+
+```swift
+// 1. Suppress concurrency warnings for pre-concurrency ObjC modules
+@preconcurrency import LegacyObjCFramework
+
+// 2. Completion handlers imported from ObjC are now @Sendable by default
+//    when async variants exist. If the ObjC code isn't actually thread-safe,
+//    use @preconcurrency import to suppress warnings.
+
+// 3. ObjC headers can opt out of Sendable checking:
+//    __attribute__((swift_attr("@Sendable")))     — mark a type as Sendable
+//    __attribute__((swift_attr("@nonSendable")))   — opt out of Sendable
+
+// 4. Actor-wrapped ObjC singletons — all calls become async from outside
+actor SafeObjCWrapper {
+    private let legacy = LegacyManager.shared()
+
+    func fetchData() -> Data {
+        legacy.getData()  // Safe: runs on actor's serial executor
+    }
+}
+// ObjC code cannot call actor methods directly — provide @objc nonisolated bridge if needed.
+```
+
+Rules:
+- Use `@preconcurrency import` for ObjC modules that haven't been audited for concurrency.
+- When wrapping ObjC singletons in actors, remember all calls become `async` from outside the actor.
+- Completion-handler-based ObjC APIs are automatically imported as `async` — verify thread safety before using.
+- Under Swift 6.2 default MainActor isolation, all ObjC interop code runs on MainActor unless explicitly marked `nonisolated` or `@concurrent`.
 
 ### Swift-Only Features Unavailable in Bridged Code
 

--- a/registry/skills/apple-app-development/references/persistence.md
+++ b/registry/skills/apple-app-development/references/persistence.md
@@ -10,7 +10,7 @@ Comprehensive guide to data persistence on Apple platforms. Covers Core Data (ma
 | **Boilerplate** | Minimal (`@Model` macro) | Significant (`.xcdatamodeld`, codegen) |
 | **SwiftUI integration** | Native (`@Query`, `.modelContainer`) | Workable (`@FetchRequest`) |
 | **UIKit support** | Possible but awkward | First-class (`NSFetchedResultsController`) |
-| **Undo/Redo** | Not built-in | Built-in (`NSUndoManager`) |
+| **Undo/Redo** | Supported via `ModelContext.undoManager` (set `isUndoEnabled: true` on `ModelContainer`) | Built-in (`NSUndoManager`) |
 | **Complex predicates** | `#Predicate` (limited composition) | `NSCompoundPredicate` (flexible) |
 | **Batch operations** | Limited | `NSBatchInsertRequest`, etc. |
 | **CloudKit** | Supported (with constraints) | `NSPersistentCloudKitContainer` (mature) |
@@ -19,7 +19,7 @@ Comprehensive guide to data persistence on Apple platforms. Covers Core Data (ma
 | **Custom data stores** | iOS 18+ `DataStore` protocol | N/A |
 
 **Guidance:**
-- **New SwiftUI-only projects (iOS 17+):** Start with SwiftData unless you need batch operations, undo/redo, or complex predicate composition.
+- **New SwiftUI-only projects (iOS 17+):** Start with SwiftData unless you need batch operations or complex predicate composition.
 - **Existing Core Data apps:** Migrate strategically. SwiftData and Core Data can coexist — they share the same SQLite backing store.
 - **Apps requiring UIKit + advanced features:** Core Data remains the stronger choice.
 - **Widgets/extensions for Core Data apps:** Consider using SwiftData in the extension while the main app stays on Core Data, sharing the same store via App Groups.
@@ -142,8 +142,8 @@ await MainActor.run {
 
 #### Swift 6 Strict Concurrency
 
-Swift 6 flags `NSManagedObject` and `NSManagedObjectContext` as non-`Sendable`. Strategies:
-- Use `@preconcurrency import CoreData` as a transitional measure.
+Swift 6 flags `NSManagedObject` as non-`Sendable`. In Xcode 26 (Swift 6.2), `NSManagedObjectContext` is now annotated `NS_SWIFT_SENDABLE` — but this does **not** make it thread-safe without `perform {}`. You must still use `perform {}` / `performAndWait {}` for all context operations. Strategies:
+- Use `@preconcurrency import CoreData` as a transitional measure for `NSManagedObject`.
 - Pass only `NSManagedObjectID` (which is `Sendable`) across isolation boundaries.
 - Wrap Core Data access behind an actor that owns a private-queue context.
 

--- a/registry/skills/apple-app-development/references/project-structure.md
+++ b/registry/skills/apple-app-development/references/project-structure.md
@@ -761,6 +761,14 @@ struct MyCodeGenPlugin: BuildToolPlugin {
 
 ## CI/CD Considerations
 
+### Options
+
+| Tool | Type | Best For |
+|------|------|----------|
+| **Xcode Cloud** | Apple's first-party CI/CD (25 free compute hours/month) | Simple pipelines, tight Xcode integration, TestFlight distribution |
+| **Fastlane** | Open-source automation | Complex workflows, multi-lane builds, custom signing |
+| **GitHub Actions** | GitHub-native CI | Teams already on GitHub, matrix testing, custom runners |
+
 ### xcodebuild commands
 
 ```bash
@@ -894,20 +902,21 @@ fastlane match development
 ### TestFlight distribution
 
 ```bash
-# Using xcodebuild + altool (legacy)
+# Using altool (still works for App Store Connect uploads, but deprecated for notarization)
 xcrun altool --upload-app \
     --type ios \
     --file build/export/MyApp.ipa \
     --apiKey YOUR_KEY_ID \
     --apiIssuer YOUR_ISSUER_ID
 
-# Using notarytool / Apple Transporter (modern)
-xcrun notarytool submit build/export/MyApp.ipa \
-    --key ~/.private_keys/AuthKey_XXXX.p8 \
-    --key-id YOUR_KEY_ID \
-    --issuer YOUR_ISSUER_ID \
-    --wait
+# Using Apple Transporter (modern, recommended for CI)
+xcrun iTMSTransporter -m upload \
+    -assetFile build/export/MyApp.ipa \
+    -apiKey ~/.private_keys/AuthKey_XXXX.p8 \
+    -apiIssuer YOUR_ISSUER_ID
 ```
+
+> **Note:** `notarytool` is for **macOS app notarization only** — do not use it for iOS/tvOS/watchOS TestFlight uploads. For iOS uploads, use `altool`, Apple Transporter (`iTMSTransporter`), Fastlane, or Xcode Cloud.
 
 Prefer the App Store Connect API key (`.p8` file) over Apple ID credentials for CI authentication.
 

--- a/registry/skills/apple-app-development/references/project-structure.md
+++ b/registry/skills/apple-app-development/references/project-structure.md
@@ -171,7 +171,7 @@ let package = Package(
         .library(name: "Core", targets: ["Core"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-algorithms.git", from: "<latest-stable>"),
     ],
     targets: [
         .target(
@@ -207,7 +207,7 @@ let package = Package(
         .library(name: "UIComponents", targets: ["UIComponents"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-algorithms.git", from: "<latest-stable>"),
     ],
     targets: [
         .target(name: "Core"),

--- a/registry/skills/apple-app-development/references/project-structure.md
+++ b/registry/skills/apple-app-development/references/project-structure.md
@@ -1046,6 +1046,61 @@ Rules for multi-platform:
 - Use `#if os()` sparingly and only in leaf views. Extract platform differences into dedicated types when the conditional logic grows beyond a few lines.
 - Test shared logic on one platform; test platform-specific code on its target platform.
 
+### Multi-target apps (same platform, different brands/products)
+
+When a project has multiple app targets (e.g., different branded apps sharing a codebase), **never use `#if` compiler directives or custom build flags to branch behavior between targets.** `#if` is designed to exclude code from compilation entirely (e.g., `#if DEBUG`, `#if os(iOS)`), not to implement polymorphism between app variants.
+
+Instead, use one of these approaches:
+
+**1. Dependency injection (preferred)** — define a protocol for the varying behavior, provide a per-target conformance, and inject at the composition root:
+
+```swift
+// Shared protocol
+protocol AppConfiguration {
+    var appName: String { get }
+    var primaryColor: Color { get }
+    var featureFlags: FeatureFlags { get }
+}
+
+// Target A implementation (in Target A's file membership)
+struct TargetAConfiguration: AppConfiguration {
+    let appName = "App A"
+    let primaryColor = Color.blue
+    let featureFlags = FeatureFlags(showPremium: true)
+}
+
+// Target B implementation (in Target B's file membership)
+struct TargetBConfiguration: AppConfiguration {
+    let appName = "App B"
+    let primaryColor = Color.green
+    let featureFlags = FeatureFlags(showPremium: false)
+}
+
+// Inject at app entry point
+@main
+struct MyApp: App {
+    let config: AppConfiguration = TargetAConfiguration() // per-target
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(\.appConfig, config)
+        }
+    }
+}
+```
+
+**2. Separate files per target** — create one file per target with the same type name, and assign each file to the correct target membership in Xcode. The linker resolves the right implementation at build time.
+
+```
+MyApp/
+├── Config/
+│   ├── AppConfig+TargetA.swift    # target membership: Target A only
+│   └── AppConfig+TargetB.swift    # target membership: Target B only
+```
+
+This keeps code clean, testable, and avoids the maintenance burden of scattered `#if` blocks that are hard to audit and easy to break.
+
 ## Dependency Management
 
 ### SPM (preferred for new projects)

--- a/registry/skills/apple-app-development/references/project-structure.md
+++ b/registry/skills/apple-app-development/references/project-structure.md
@@ -1105,7 +1105,7 @@ struct MyApp: App {
 
 **2. Separate files per target** — create one file per target with the same type name, and assign each file to the correct target membership in Xcode. The linker resolves the right implementation at build time.
 
-```
+```text
 MyApp/
 ├── Config/
 │   ├── AppConfig+TargetA.swift    # target membership: Target A only

--- a/registry/skills/apple-app-development/references/project-structure.md
+++ b/registry/skills/apple-app-development/references/project-structure.md
@@ -910,9 +910,13 @@ xcrun altool --upload-app \
     --apiIssuer YOUR_ISSUER_ID
 
 # Using Apple Transporter (modern, recommended for CI)
-xcrun iTMSTransporter -m upload \
+# iTMSTransporter ships with the standalone Transporter app (Mac App Store), not Xcode —
+# its binary lives at /Applications/Transporter.app/Contents/itms/bin/iTMSTransporter.
+# -apiKey takes the alphanumeric Key ID; the matching AuthKey_<KEY_ID>.p8 must sit in a
+# search path such as ~/.appstoreconnect/private_keys/.
+/Applications/Transporter.app/Contents/itms/bin/iTMSTransporter -m upload \
     -assetFile build/export/MyApp.ipa \
-    -apiKey ~/.private_keys/AuthKey_XXXX.p8 \
+    -apiKey YOUR_KEY_ID \
     -apiIssuer YOUR_ISSUER_ID
 ```
 

--- a/registry/skills/apple-app-development/references/project-structure.md
+++ b/registry/skills/apple-app-development/references/project-structure.md
@@ -1160,8 +1160,8 @@ platform :ios, '17.0'
 use_frameworks!
 
 target 'MyApp' do
-  pod 'FirebaseAnalytics', '~> 11.0'
-  pod 'GoogleMaps', '~> 9.0'
+  pod 'FirebaseAnalytics', '~> <latest-stable>'
+  pod 'GoogleMaps', '~> <latest-stable>'
 
   target 'MyAppTests' do
     inherit! :search_paths

--- a/registry/skills/apple-app-development/references/storekit.md
+++ b/registry/skills/apple-app-development/references/storekit.md
@@ -1,6 +1,6 @@
 # StoreKit Reference (In-App Purchases & Subscriptions)
 
-Comprehensive guide to monetization on Apple platforms using StoreKit 2. Covers product loading, purchase flows, transaction management, subscriptions, StoreKit SwiftUI views, testing, and server-side verification. StoreKit 2 is the modern Swift-native API (iOS 15+) — do not use the original StoreKit API for new code.
+Comprehensive guide to monetization on Apple platforms using StoreKit 2. Covers product loading, purchase flows, transaction management, subscriptions, StoreKit SwiftUI views, testing, and server-side verification. StoreKit 2 is the modern Swift-native API (iOS 15+). The original StoreKit API (`SKPaymentQueue`, `SKProduct`, etc.) is formally **deprecated** as of iOS 18 — do not use it for new code.
 
 ## Architecture Overview
 
@@ -109,11 +109,18 @@ let result = try await product.purchase(options: [
 ])
 ```
 
-#### Purchase with Confirmation Scene (iOS 17+)
+#### Purchase with UI Context
 
 ```swift
-// Specify where to present the purchase confirmation
-let result = try await product.purchase(confirmIn: windowScene)
+// iOS 18.2+: Requires a UIViewController context to present the purchase sheet reliably.
+// Without it, the payment sheet may fail to appear ("Could not get confirmation scene ID").
+let result = try await product.purchase(confirmIn: viewController) // UIViewController on iOS
+
+// iOS 17–18.1: UIWindowScene context (still works but deprecated in favor of UIViewController)
+// let result = try await product.purchase(confirmIn: windowScene)
+
+// macOS: Use NSWindow as the confirmation context
+// let result = try await product.purchase(confirmIn: window)
 ```
 
 

--- a/registry/skills/apple-app-development/references/swiftui-patterns.md
+++ b/registry/skills/apple-app-development/references/swiftui-patterns.md
@@ -138,6 +138,29 @@ struct AsyncContentView<T, Loading: View, Loaded: View, Failed: View>: View {
 }
 ```
 
+### Custom Container APIs (iOS 18+)
+---
+
+iOS 18 introduced `ForEach(subviewOf:)` and `Group(subviews:)` for building custom container views that can introspect and rearrange their children — something previously impossible without workarounds.
+
+```swift
+struct TwoColumn: View {
+    @ViewBuilder var content: some View
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 16) {
+            Group(subviews: content) { subviews in
+                // Access subviews as a RandomAccessCollection
+                VStack { ForEach(subviews.prefix(2)) { $0 } }
+                VStack { ForEach(subviews.dropFirst(2)) { $0 } }
+            }
+        }
+    }
+}
+```
+
+These APIs let containers inspect child count, apply per-child styling, and implement layouts like multi-column or card stacks declaratively.
+
 
 ## Property Wrappers
 
@@ -1110,6 +1133,17 @@ struct DynamicHeader: View {
 }
 ```
 
+> **iOS 18+:** For many geometry-reading use cases, `onGeometryChange(for:of:action:)` (back-deployed to iOS 16) is a simpler alternative that avoids the `PreferenceKey` boilerplate entirely:
+>
+> ```swift
+> headerContent
+>     .onGeometryChange(for: CGFloat.self) { proxy in
+>         proxy.size.height
+>     } action: { height in
+>         headerHeight = height
+>     }
+> ```
+
 
 ## Animations
 
@@ -1475,6 +1509,18 @@ struct PhotoActionView: View {
 ---
 
 Define a custom key to inject dependencies through the SwiftUI view hierarchy.
+
+> **iOS 18 / Xcode 16+:** The `@Entry` macro eliminates the boilerplate below and is back-deployed to iOS 13:
+>
+> ```swift
+> extension EnvironmentValues {
+>     @Entry var apiClient: APIClient = LiveAPIClient()
+> }
+> // Use: .environment(\.apiClient, MockAPIClient())
+> // Read: @Environment(\.apiClient) private var apiClient
+> ```
+>
+> The classic `EnvironmentKey` pattern shown below remains valid but is more verbose.
 
 ```swift
 // 1. Define the key

--- a/registry/skills/apple-app-development/references/swiftui-patterns.md
+++ b/registry/skills/apple-app-development/references/swiftui-patterns.md
@@ -186,6 +186,8 @@ struct ProfileView: View {
 }
 ```
 
+**Caveat:** Unlike `@StateObject`, `@State` re-evaluates the initializer expression on every view struct recreation (SwiftUI discards the new instance, but `init()` still runs). Avoid side effects in `@Observable` class initializers — use `.task` for deferred setup.
+
 ### @Binding
 ---
 

--- a/registry/skills/apple-app-development/references/swiftui-patterns.md
+++ b/registry/skills/apple-app-development/references/swiftui-patterns.md
@@ -1133,7 +1133,7 @@ struct DynamicHeader: View {
 }
 ```
 
-> **iOS 18+:** For many geometry-reading use cases, `onGeometryChange(for:of:action:)` (back-deployed to iOS 16) is a simpler alternative that avoids the `PreferenceKey` boilerplate entirely:
+> **iOS 16+ (back-deployed):** For many geometry-reading use cases, `onGeometryChange(for:of:action:)` is a simpler alternative that avoids the `PreferenceKey` boilerplate entirely:
 >
 > ```swift
 > headerContent

--- a/registry/skills/apple-app-development/references/testing.md
+++ b/registry/skills/apple-app-development/references/testing.md
@@ -1,0 +1,1347 @@
+# Testing Reference (Swift Testing, XCTest, XCUITest)
+
+Comprehensive guide to testing on Apple platforms. Swift Testing is the modern framework — use it for all new test targets (Xcode 16+, Swift 6). XCTest remains essential for UI automation (XCUITest), performance benchmarks, and existing test suites. Both frameworks coexist in the same target.
+
+## Contents
+- When to use which framework
+- Swift Testing (@Test, @Suite, #expect, #require, traits, parameterized tests)
+- XCTest unit tests (XCTestCase, assertions, expectations, performance)
+- XCUITest UI tests (element queries, accessibility identifiers, Page Object pattern)
+- Test doubles and dependency injection (protocols, mocks, spies, stubs)
+- Testing @Observable and SwiftUI
+- Test plans and configuration
+- CI/CD testing (xcodebuild, result bundles, parallel testing)
+- TDD workflow
+- Common pitfalls
+
+## When to Use Which
+
+| Scenario | Recommendation |
+|---|---|
+| New test target (Xcode 16+) | Swift Testing |
+| Existing XCTest target | XCTest — migrate incrementally |
+| UI automation | XCUITest |
+| Performance benchmarks | XCTest (`measure { }`) |
+| Integration tests | Swift Testing or XCTest |
+| Snapshot / preview tests | swift-snapshot-testing |
+| Parameterized test cases | Swift Testing (`@Test(arguments:)`) |
+| Async event confirmation | Swift Testing (`confirmation()`) |
+| Testing on CI with older Xcode | XCTest |
+
+**Rule:** Default to Swift Testing for new code. Use XCTest when you need UI testing, performance measurement, or must support Xcode 15 and earlier. Both frameworks can coexist in a single test target — no need to choose one exclusively.
+
+
+## Swift Testing Framework
+
+Swift Testing is Apple's modern test framework (Xcode 16+, Swift 6). It replaces XCTest for unit and integration tests with a cleaner, expression-based API.
+
+### @Test and Basic Assertions
+---
+
+```swift
+import Testing
+
+@Test("User full name combines first and last name")
+func userFullName() {
+    let user = User(firstName: "Alice", lastName: "Smith")
+    #expect(user.fullName == "Alice Smith")
+}
+
+@Test func decodingValidJSON() throws {
+    let json = """
+    {"id": "550e8400-e29b-41d4-a716-446655440000", "name": "Alice"}
+    """.data(using: .utf8)!
+
+    let user = try JSONDecoder().decode(User.self, from: json)
+    #expect(user.name == "Alice")
+    #expect(user.id == UUID(uuidString: "550e8400-e29b-41d4-a716-446655440000"))
+}
+```
+
+#### #expect vs #require
+
+`#expect` records a failure and continues. `#require` throws on failure, stopping the test immediately — use it when subsequent assertions depend on the result.
+
+```swift
+@Test func loadConfiguration() throws {
+    let config = try #require(ConfigLoader.load("settings.json"))
+    // If load returns nil, test stops here with a clear failure message
+    #expect(config.apiBaseURL.host == "api.example.com")
+    #expect(config.maxRetries == 3)
+}
+
+@Test func parseResponse() throws {
+    let data = try #require(loadFixture("users_response.json"))
+    let response = try JSONDecoder().decode(UsersResponse.self, from: data)
+    #expect(response.users.count == 5)
+    #expect(response.hasMore == true)
+}
+```
+
+### Traits
+---
+
+Traits configure test behavior — disable tests, set time limits, tag for filtering, and more.
+
+```swift
+// Disabled test with reason
+@Test(.disabled("Server migration in progress — re-enable after v2 API launch"))
+func fetchLegacyEndpoint() async throws {
+    // ...
+}
+
+// Conditional execution
+@Test(.enabled(if: ProcessInfo.processInfo.environment["CI"] != nil))
+func integrationTest() async throws {
+    // Runs only on CI
+}
+
+// Time limit — test fails if it exceeds the duration
+@Test(.timeLimit(.minutes(1)))
+func longRunningSync() async throws {
+    let result = try await heavyDataMigration()
+    #expect(result.migratedCount > 0)
+}
+
+// Bug reference — links to a known issue
+@Test(.bug("https://github.com/org/repo/issues/42", "Flaky on iOS 17.0"))
+func widgetRefresh() async throws {
+    // ...
+}
+
+// Multiple traits combine naturally
+@Test(
+    "Upload retries on transient failure",
+    .tags(.networking),
+    .timeLimit(.seconds(30)),
+    .bug("https://jira.example.com/PROJ-123")
+)
+func uploadRetry() async throws {
+    // ...
+}
+```
+
+### Custom Tags
+---
+
+Tags let you filter and organize tests across suites.
+
+```swift
+extension Tag {
+    @Tag static var networking: Self
+    @Tag static var persistence: Self
+    @Tag static var authentication: Self
+    @Tag static var slow: Self
+}
+
+@Test(.tags(.networking, .authentication))
+func tokenRefreshOnExpiry() async throws {
+    let client = APIClient(tokenManager: FakeTokenManager(expired: true))
+    let user: User = try await client.request(.getProfile)
+    #expect(user.name == "Alice")
+}
+
+@Test(.tags(.persistence))
+func saveAndRetrieveOrder() async throws {
+    let store = InMemoryOrderStore()
+    let order = Order.sample
+    try await store.save(order)
+    let retrieved = try await store.fetch(order.id)
+    #expect(retrieved == order)
+}
+```
+
+Run tagged tests from Xcode by selecting tags in the Test Navigator, or filter in test plans. From CLI, use `swift test --filter` with test name patterns — tag-based filtering is supported through Xcode Test Plans.
+
+### Parameterized Tests
+---
+
+Run the same test logic across multiple inputs — each argument produces a separate test case in the results.
+
+```swift
+@Test("Email validation rejects invalid formats", arguments: [
+    "",
+    "plaintext",
+    "@missing-local.com",
+    "missing-domain@",
+    "spaces in@email.com",
+    "double@@at.com"
+])
+func invalidEmails(email: String) {
+    #expect(EmailValidator.isValid(email) == false)
+}
+
+@Test("Currency formatting", arguments: [
+    (amount: 1000, locale: Locale(identifier: "en_US"), expected: "$1,000.00"),
+    (amount: 1000, locale: Locale(identifier: "de_DE"), expected: "1.000,00 €"),
+    (amount: 1000, locale: Locale(identifier: "ja_JP"), expected: "￥1,000"),
+])
+func currencyFormatting(amount: Int, locale: Locale, expected: String) {
+    let formatted = CurrencyFormatter.format(amount, locale: locale)
+    #expect(formatted == expected)
+}
+
+// Two-dimensional: tests every combination of arguments
+@Test(arguments: HTTPMethod.allCases, [200, 401, 500])
+func responseHandling(method: HTTPMethod, statusCode: Int) async throws {
+    let client = MockHTTPClient(stubbedStatusCode: statusCode)
+    let result = await client.handleResponse(method: method)
+    if statusCode == 200 {
+        #expect(result.isSuccess)
+    } else {
+        #expect(result.isFailure)
+    }
+}
+```
+
+### @Suite — Test Organization
+---
+
+Group related tests into suites. Suites can nest and share setup via `init`/`deinit`.
+
+```swift
+@Suite("Authentication Flow")
+struct AuthenticationTests {
+    let authService: AuthService
+    let tokenStore: FakeTokenStore
+
+    init() {
+        tokenStore = FakeTokenStore()
+        authService = AuthService(
+            apiClient: FakeAPIClient(),
+            tokenStore: tokenStore
+        )
+    }
+
+    @Test func loginWithValidCredentials() async throws {
+        let session = try await authService.login(email: "alice@example.com", password: "secure123")
+        #expect(session.isAuthenticated)
+        #expect(tokenStore.storedAccessToken != nil)
+    }
+
+    @Test func loginWithInvalidPassword() async throws {
+        await #expect(throws: AuthError.invalidCredentials) {
+            try await authService.login(email: "alice@example.com", password: "wrong")
+        }
+    }
+
+    @Test func logoutClearsTokens() async throws {
+        try await authService.login(email: "alice@example.com", password: "secure123")
+        await authService.logout()
+        #expect(tokenStore.storedAccessToken == nil)
+        #expect(tokenStore.storedRefreshToken == nil)
+    }
+}
+```
+
+#### Nested Suites
+
+```swift
+@Suite("Order Management")
+struct OrderTests {
+    @Suite("Creation")
+    struct CreationTests {
+        @Test func createOrderWithValidItems() async throws {
+            let service = OrderService(repository: FakeOrderRepository())
+            let order = try await service.createOrder(items: [.sample])
+            #expect(order.status == .pending)
+            #expect(order.items.count == 1)
+        }
+    }
+
+    @Suite("Cancellation")
+    struct CancellationTests {
+        @Test func cancelPendingOrder() async throws {
+            let repository = FakeOrderRepository(existingOrders: [.pending])
+            let service = OrderService(repository: repository)
+            try await service.cancel(orderId: Order.pending.id)
+            let updated = try await repository.fetch(Order.pending.id)
+            #expect(updated.status == .cancelled)
+        }
+
+        @Test func cannotCancelShippedOrder() async throws {
+            let repository = FakeOrderRepository(existingOrders: [.shipped])
+            let service = OrderService(repository: repository)
+            await #expect(throws: OrderError.cannotCancel) {
+                try await service.cancel(orderId: Order.shipped.id)
+            }
+        }
+    }
+}
+```
+
+### Lifecycle: init/deinit Instead of setUp/tearDown
+---
+
+Swift Testing uses the struct/class lifecycle — no `setUp`/`tearDown` methods. Use `init` for setup and `deinit` for cleanup.
+
+```swift
+@Suite struct DatabaseTests {
+    let database: TestDatabase
+
+    init() async throws {
+        database = try await TestDatabase.createEmpty()
+        try await database.runMigrations()
+    }
+
+    // Cleanup happens when the struct goes out of scope
+    // For explicit cleanup, use a class-based suite:
+
+    @Test func insertAndQuery() async throws {
+        try await database.insert(User.sample)
+        let users = try await database.fetchAllUsers()
+        #expect(users.count == 1)
+    }
+}
+```
+
+### Confirmation for Async Events
+---
+
+`confirmation()` waits for an expected async event — the modern replacement for `XCTExpectation`.
+
+```swift
+@Test func notificationPostedOnSave() async throws {
+    let store = DocumentStore()
+
+    await confirmation("Document saved notification") { confirm in
+        NotificationCenter.default.addObserver(
+            forName: .documentDidSave, object: nil, queue: nil
+        ) { _ in
+            confirm()
+        }
+        try await store.save(Document.sample)
+    }
+}
+
+// Expected count — confirm must be called exactly N times
+@Test func batchProcessingNotifiesPerItem() async throws {
+    let processor = BatchProcessor()
+    let items = [Item.sample1, Item.sample2, Item.sample3]
+
+    await confirmation("Item processed", expectedCount: 3) { confirm in
+        processor.onItemProcessed = { _ in confirm() }
+        await processor.processAll(items)
+    }
+}
+```
+
+### Parallel Execution
+---
+
+Swift Testing runs tests in parallel by default. Each `@Test` function runs independently. Use `.serialized` trait on a `@Suite` when tests share mutable state that cannot be isolated.
+
+```swift
+@Suite(.serialized)
+struct FileSystemTests {
+    @Test func writeFile() throws {
+        try FileManager.default.createFile(at: tempPath, contents: testData)
+        #expect(FileManager.default.fileExists(atPath: tempPath))
+    }
+
+    @Test func deleteFile() throws {
+        try FileManager.default.removeItem(atPath: tempPath)
+        #expect(!FileManager.default.fileExists(atPath: tempPath))
+    }
+}
+```
+
+Rules:
+- Prefer parallel execution. Design tests to be independent.
+- Use `.serialized` only when tests have unavoidable ordering dependencies (shared file system, shared database).
+- Each `@Test` gets a fresh `init` of the containing `@Suite` struct — instance properties are not shared.
+
+### Migration from XCTest
+---
+
+| XCTest | Swift Testing |
+|---|---|
+| `XCTestCase` subclass | `@Suite struct` |
+| `func test...()` | `@Test func ...()` |
+| `setUpWithError()` | `init() throws` |
+| `tearDown()` | `deinit` (class suite) |
+| `XCTAssertEqual(a, b)` | `#expect(a == b)` |
+| `XCTAssertNil(x)` | `#expect(x == nil)` |
+| `XCTAssertThrowsError(expr)` | `#expect(throws: ErrorType.self) { try expr }` |
+| `XCTExpectation` + `wait` | `confirmation()` |
+| `XCTSkipIf(condition)` | `@Test(.enabled(if: !condition))` |
+| `measure { }` | No equivalent — keep in XCTest |
+| `XCUITest` | No equivalent — keep in XCTest |
+
+
+## XCTest — Unit Tests
+
+XCTest is Apple's established testing framework. It remains necessary for UI tests, performance measurement, and targets that must support Xcode 15 or earlier.
+
+### XCTestCase Pattern
+---
+
+```swift
+import XCTest
+@testable import MyApp
+
+final class UserServiceTests: XCTestCase {
+    private var sut: UserService!
+    private var mockRepository: MockUserRepository!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        mockRepository = MockUserRepository()
+        sut = UserService(repository: mockRepository)
+    }
+
+    override func tearDown() async throws {
+        sut = nil
+        mockRepository = nil
+        try await super.tearDown()
+    }
+
+    func test_fetchUser_returnsDecodedUser() async throws {
+        mockRepository.stubbedUser = User(id: UUID(), name: "Alice", email: "alice@example.com")
+
+        let user = try await sut.fetchUser(id: mockRepository.stubbedUser!.id)
+
+        XCTAssertEqual(user.name, "Alice")
+        XCTAssertEqual(user.email, "alice@example.com")
+    }
+
+    func test_fetchUser_throwsOnNotFound() async {
+        mockRepository.stubbedError = UserError.notFound
+
+        do {
+            _ = try await sut.fetchUser(id: UUID())
+            XCTFail("Expected UserError.notFound")
+        } catch {
+            XCTAssertTrue(error is UserError)
+        }
+    }
+}
+```
+
+### Assertions Quick Reference
+---
+
+```swift
+// Equality
+XCTAssertEqual(actual, expected)
+XCTAssertEqual(price, 9.99, accuracy: 0.01) // Floating point
+
+// Boolean
+XCTAssertTrue(user.isActive)
+XCTAssertFalse(order.isCancelled)
+
+// Nil
+XCTAssertNil(error)
+XCTAssertNotNil(response)
+
+// Throwing
+XCTAssertThrowsError(try parser.parse(invalidJSON)) { error in
+    XCTAssertEqual(error as? ParseError, .invalidSyntax)
+}
+XCTAssertNoThrow(try config.validate())
+
+// Comparison
+XCTAssertGreaterThan(results.count, 0)
+XCTAssertLessThanOrEqual(latency, 1.0)
+```
+
+### XCTExpectation for Async Callbacks
+---
+
+Use expectations when testing callback-based (non-async) APIs:
+
+```swift
+func test_delegateReceivesUpdate() {
+    let expectation = expectation(description: "Delegate called with update")
+
+    let delegate = SpyDelegate()
+    delegate.onUpdate = { value in
+        XCTAssertEqual(value, 42)
+        expectation.fulfill()
+    }
+
+    let service = EventService(delegate: delegate)
+    service.start()
+
+    waitForExpectations(timeout: 5)
+}
+
+// Multiple expectations
+func test_batchProcessing_notifiesCompletion() {
+    let started = expectation(description: "Processing started")
+    let completed = expectation(description: "Processing completed")
+
+    let processor = BatchProcessor()
+    processor.onStart = { started.fulfill() }
+    processor.onComplete = { completed.fulfill() }
+
+    processor.process(items: testItems)
+
+    wait(for: [started, completed], timeout: 10, enforceOrder: true)
+}
+
+// Inverted expectation — asserts something does NOT happen
+func test_debounce_doesNotFireImmediately() {
+    let fired = expectation(description: "Should not fire")
+    fired.isInverted = true
+
+    let debouncer = Debouncer(delay: 1.0)
+    debouncer.onFire = { fired.fulfill() }
+    debouncer.trigger()
+
+    waitForExpectations(timeout: 0.5) // Passes if NOT fulfilled within 0.5s
+}
+```
+
+### addTeardownBlock
+---
+
+Register cleanup that runs after each test, even on failure. Useful for cleaning up resources created during a test.
+
+```swift
+func test_tempFileCreation() throws {
+    let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    FileManager.default.createFile(atPath: tempURL.path, contents: Data())
+
+    addTeardownBlock {
+        try? FileManager.default.removeItem(at: tempURL)
+    }
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: tempURL.path))
+}
+```
+
+### Performance Measurement
+---
+
+```swift
+func test_jsonDecoding_performance() throws {
+    let largeJSON = try loadFixture("large_response.json")
+
+    measure {
+        _ = try? JSONDecoder().decode([User].self, from: largeJSON)
+    }
+}
+
+// With metrics and options
+func test_imageProcessing_performance() {
+    let metrics: [XCTMetric] = [
+        XCTClockMetric(),
+        XCTMemoryMetric(),
+        XCTCPUMetric()
+    ]
+
+    let options = XCTMeasureOptions()
+    options.iterationCount = 10
+
+    measure(metrics: metrics, options: options) {
+        _ = ImageProcessor.resize(largeImage, to: CGSize(width: 100, height: 100))
+    }
+}
+```
+
+Rules:
+- `measure` runs the block multiple times and reports average/deviation.
+- Set baselines in Xcode to detect performance regressions.
+- Performance tests are best kept in a separate test plan to avoid slowing down the main test suite.
+
+
+## XCUITest — UI Tests
+
+XCUITest automates the app's UI through accessibility elements. It launches the app in a separate process and interacts with it like a user would.
+
+### Application Launch
+---
+
+```swift
+import XCTest
+
+final class LoginUITests: XCTestCase {
+    let app = XCUIApplication()
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+
+        // Launch arguments to configure app for testing
+        app.launchArguments = ["--uitesting", "--reset-state"]
+        app.launchEnvironment = [
+            "API_BASE_URL": "http://localhost:8080",
+            "DISABLE_ANIMATIONS": "1"
+        ]
+        app.launch()
+    }
+
+    override func tearDown() {
+        app.terminate()
+        super.tearDown()
+    }
+}
+```
+
+### Element Queries
+---
+
+```swift
+func test_loginFlow() {
+    // Text fields
+    let emailField = app.textFields["emailTextField"]
+    let passwordField = app.secureTextFields["passwordTextField"]
+
+    emailField.tap()
+    emailField.typeText("alice@example.com")
+
+    passwordField.tap()
+    passwordField.typeText("secure123")
+
+    // Buttons
+    app.buttons["loginButton"].tap()
+
+    // Verify navigation to home screen
+    let welcomeLabel = app.staticTexts["welcomeLabel"]
+    XCTAssertTrue(welcomeLabel.waitForExistence(timeout: 5))
+    XCTAssertEqual(welcomeLabel.label, "Welcome, Alice")
+}
+```
+
+### Accessibility Identifiers
+---
+
+Accessibility identifiers are the foundation of reliable UI tests. Set them in your production code:
+
+```swift
+// In SwiftUI
+struct LoginView: View {
+    @State private var email = ""
+    @State private var password = ""
+
+    var body: some View {
+        VStack {
+            TextField("Email", text: $email)
+                .accessibilityIdentifier("emailTextField")
+
+            SecureField("Password", text: $password)
+                .accessibilityIdentifier("passwordTextField")
+
+            Button("Log In") { login() }
+                .accessibilityIdentifier("loginButton")
+        }
+    }
+}
+
+// In UIKit
+emailTextField.accessibilityIdentifier = "emailTextField"
+passwordField.accessibilityIdentifier = "passwordTextField"
+loginButton.accessibilityIdentifier = "loginButton"
+```
+
+Rules:
+- Always use `accessibilityIdentifier` — not `accessibilityLabel` — for test queries. Labels are user-facing and change with localization.
+- Use a consistent naming convention (e.g., `screenName_elementType` or `camelCase` descriptors).
+- Define identifiers as constants in a shared enum to avoid string drift between production and test code.
+
+### Waiting for Elements
+---
+
+```swift
+func test_searchResults_appear() {
+    let searchField = app.searchFields["searchField"]
+    searchField.tap()
+    searchField.typeText("Swift")
+
+    // Wait for results to load
+    let firstResult = app.cells["searchResult_0"]
+    let exists = firstResult.waitForExistence(timeout: 10)
+    XCTAssertTrue(exists, "Search results did not appear within timeout")
+}
+
+// Custom predicate-based waiting
+func test_loadingIndicator_disappears() {
+    app.buttons["refreshButton"].tap()
+
+    let spinner = app.activityIndicators["loadingIndicator"]
+    let disappeared = NSPredicate(format: "exists == false")
+    let expectation = XCTNSPredicateExpectation(predicate: disappeared, object: spinner)
+    let result = XCTWaiter.wait(for: [expectation], timeout: 10)
+    XCTAssertEqual(result, .completed)
+}
+```
+
+### Page Object Pattern
+---
+
+Encapsulate screen interactions to keep tests readable and reduce duplication:
+
+```swift
+// Page object
+struct LoginPage {
+    let app: XCUIApplication
+
+    var emailField: XCUIElement { app.textFields["emailTextField"] }
+    var passwordField: XCUIElement { app.secureTextFields["passwordTextField"] }
+    var loginButton: XCUIElement { app.buttons["loginButton"] }
+    var errorLabel: XCUIElement { app.staticTexts["errorLabel"] }
+
+    @discardableResult
+    func typeEmail(_ email: String) -> Self {
+        emailField.tap()
+        emailField.typeText(email)
+        return self
+    }
+
+    @discardableResult
+    func typePassword(_ password: String) -> Self {
+        passwordField.tap()
+        passwordField.typeText(password)
+        return self
+    }
+
+    func tapLogin() -> HomePage {
+        loginButton.tap()
+        return HomePage(app: app)
+    }
+
+    func tapLoginExpectingError() -> Self {
+        loginButton.tap()
+        return self
+    }
+}
+
+struct HomePage {
+    let app: XCUIApplication
+
+    var welcomeLabel: XCUIElement { app.staticTexts["welcomeLabel"] }
+
+    func waitForLoad(timeout: TimeInterval = 5) -> Bool {
+        welcomeLabel.waitForExistence(timeout: timeout)
+    }
+}
+
+// Tests become concise and readable
+func test_successfulLogin() {
+    let homePage = LoginPage(app: app)
+        .typeEmail("alice@example.com")
+        .typePassword("secure123")
+        .tapLogin()
+
+    XCTAssertTrue(homePage.waitForLoad())
+}
+
+func test_invalidCredentials_showsError() {
+    let loginPage = LoginPage(app: app)
+        .typeEmail("alice@example.com")
+        .typePassword("wrong")
+        .tapLoginExpectingError()
+
+    XCTAssertTrue(loginPage.errorLabel.waitForExistence(timeout: 5))
+    XCTAssertEqual(loginPage.errorLabel.label, "Invalid email or password")
+}
+```
+
+### Screenshots and Attachments
+---
+
+```swift
+func test_onboarding_screenshots() {
+    let onboarding = OnboardingPage(app: app)
+
+    // Capture screenshot at each step
+    let step1 = XCTAttachment(screenshot: app.screenshot())
+    step1.name = "Onboarding - Step 1"
+    step1.lifetime = .keepAlways
+    add(step1)
+
+    onboarding.tapNext()
+
+    let step2 = XCTAttachment(screenshot: app.screenshot())
+    step2.name = "Onboarding - Step 2"
+    step2.lifetime = .keepAlways
+    add(step2)
+}
+
+// Automatic screenshot on failure (in setUp)
+override func setUp() {
+    super.setUp()
+    continueAfterFailure = false
+    // Xcode automatically captures screenshots on failure — find them in .xcresult
+}
+```
+
+
+## Test Doubles & Dependency Injection
+
+Effective testing requires controlling dependencies. Use protocol-based injection to substitute real implementations with test doubles.
+
+### Protocol-Based Mocking
+---
+
+```swift
+// Define a protocol for the dependency
+protocol UserRepository: Sendable {
+    func fetch(id: UUID) async throws -> User
+    func save(_ user: User) async throws
+    func delete(id: UUID) async throws
+}
+
+// Production implementation
+final class RemoteUserRepository: UserRepository {
+    private let apiClient: APIClient
+
+    init(apiClient: APIClient) {
+        self.apiClient = apiClient
+    }
+
+    func fetch(id: UUID) async throws -> User {
+        try await apiClient.request(.getUser(id: id))
+    }
+
+    func save(_ user: User) async throws {
+        try await apiClient.request(.updateUser(user))
+    }
+
+    func delete(id: UUID) async throws {
+        try await apiClient.request(.deleteUser(id: id))
+    }
+}
+
+// Test double — stub
+final class StubUserRepository: UserRepository {
+    var stubbedUser: User?
+    var stubbedError: Error?
+
+    func fetch(id: UUID) async throws -> User {
+        if let error = stubbedError { throw error }
+        guard let user = stubbedUser else { throw UserError.notFound }
+        return user
+    }
+
+    func save(_ user: User) async throws {
+        if let error = stubbedError { throw error }
+    }
+
+    func delete(id: UUID) async throws {
+        if let error = stubbedError { throw error }
+    }
+}
+```
+
+### Spy Pattern
+---
+
+A spy records interactions for later verification.
+
+```swift
+final class SpyUserRepository: UserRepository {
+    private(set) var fetchCallCount = 0
+    private(set) var fetchedIds: [UUID] = []
+    private(set) var savedUsers: [User] = []
+    private(set) var deletedIds: [UUID] = []
+
+    var stubbedUser: User?
+
+    func fetch(id: UUID) async throws -> User {
+        fetchCallCount += 1
+        fetchedIds.append(id)
+        return stubbedUser ?? User.sample
+    }
+
+    func save(_ user: User) async throws {
+        savedUsers.append(user)
+    }
+
+    func delete(id: UUID) async throws {
+        deletedIds.append(id)
+    }
+}
+
+// Usage in test
+@Test func updateProfile_savesUser() async throws {
+    let spy = SpyUserRepository()
+    spy.stubbedUser = User.sample
+    let service = ProfileService(repository: spy)
+
+    try await service.updateName("Bob", for: User.sample.id)
+
+    #expect(spy.savedUsers.count == 1)
+    #expect(spy.savedUsers.first?.name == "Bob")
+    #expect(spy.fetchCallCount == 1)
+}
+```
+
+### Dependency Injection for Testability
+---
+
+Structure your app so dependencies are injected, never created internally.
+
+```swift
+// View model accepts dependencies via init
+@MainActor
+@Observable
+class OrderListViewModel {
+    var orders: [Order] = []
+    var isLoading = false
+
+    private let orderRepository: OrderRepository
+    private let analytics: AnalyticsService
+
+    init(orderRepository: OrderRepository, analytics: AnalyticsService) {
+        self.orderRepository = orderRepository
+        self.analytics = analytics
+    }
+
+    func loadOrders() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            orders = try await orderRepository.fetchAll()
+            analytics.track(.ordersLoaded(count: orders.count))
+        } catch {
+            analytics.track(.ordersLoadFailed(error: error))
+        }
+    }
+}
+
+// Test with injected doubles
+@Test @MainActor
+func loadOrders_setsOrdersAndTracksAnalytics() async {
+    let stubRepo = StubOrderRepository(orders: [.sample1, .sample2])
+    let spyAnalytics = SpyAnalyticsService()
+    let viewModel = OrderListViewModel(orderRepository: stubRepo, analytics: spyAnalytics)
+
+    await viewModel.loadOrders()
+
+    #expect(viewModel.orders.count == 2)
+    #expect(viewModel.isLoading == false)
+    #expect(spyAnalytics.trackedEvents.contains(.ordersLoaded(count: 2)))
+}
+```
+
+### SwiftUI Environment-Based Injection
+---
+
+```swift
+// Define environment key
+private struct UserRepositoryKey: EnvironmentKey {
+    static let defaultValue: UserRepository = RemoteUserRepository(apiClient: .shared)
+}
+
+extension EnvironmentValues {
+    var userRepository: UserRepository {
+        get { self[UserRepositoryKey.self] }
+        set { self[UserRepositoryKey.self] = newValue }
+    }
+}
+
+// Use in view
+struct UserProfileView: View {
+    @Environment(\.userRepository) private var repository
+    @State private var user: User?
+
+    var body: some View {
+        // ...
+    }
+}
+
+// Override in tests or previews
+#Preview {
+    UserProfileView()
+        .environment(\.userRepository, StubUserRepository(stubbedUser: .sample))
+}
+```
+
+
+## Testing with @Observable and SwiftUI
+
+### Testing @Observable ViewModels
+---
+
+```swift
+@MainActor
+@Observable
+class ProductSearchViewModel {
+    var query = ""
+    var products: [Product] = []
+    var isSearching = false
+    var errorMessage: String?
+
+    private let searchService: ProductSearchService
+    private let clock: any Clock<Duration>
+    private var searchTask: Task<Void, Never>?
+
+    init(searchService: ProductSearchService, clock: any Clock<Duration> = ContinuousClock()) {
+        self.searchService = searchService
+        self.clock = clock
+    }
+
+    func search() {
+        searchTask?.cancel()
+        guard !query.isEmpty else {
+            products = []
+            return
+        }
+        searchTask = Task {
+            isSearching = true
+            defer { isSearching = false }
+            do {
+                try await clock.sleep(for: .milliseconds(300))
+                guard !Task.isCancelled else { return }
+                products = try await searchService.search(query: query)
+            } catch is CancellationError {
+                // Expected — ignore
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}
+
+// Tests — inject ImmediateClockProtocol to skip debounce delay
+@Suite("Product Search ViewModel")
+struct ProductSearchViewModelTests {
+    // A test clock that returns immediately, eliminating timing flakiness
+    struct ImmediateClock: Clock {
+        typealias Duration = Swift.Duration
+        typealias Instant = ContinuousClock.Instant
+        var now: Instant { ContinuousClock.now }
+        var minimumResolution: Duration { .zero }
+        func sleep(until deadline: Instant, tolerance: Duration?) async throws {
+            try Task.checkCancellation()
+        }
+    }
+
+    @Test @MainActor
+    func search_populatesProducts() async throws {
+        let stub = StubProductSearchService(results: [.sample1, .sample2])
+        let vm = ProductSearchViewModel(searchService: stub, clock: ImmediateClock())
+
+        vm.query = "shoes"
+        vm.search()
+
+        // ImmediateClock skips the debounce — no Task.sleep needed
+        try await Task.yield()
+
+        #expect(vm.products.count == 2)
+        #expect(vm.isSearching == false)
+    }
+
+    @Test @MainActor
+    func search_emptyQuery_clearsResults() async {
+        let stub = StubProductSearchService(results: [.sample1])
+        let vm = ProductSearchViewModel(searchService: stub, clock: ImmediateClock())
+
+        vm.query = ""
+        vm.search()
+
+        #expect(vm.products.isEmpty)
+    }
+
+    @Test @MainActor
+    func search_failure_setsErrorMessage() async throws {
+        let stub = StubProductSearchService(error: SearchError.serviceUnavailable)
+        let vm = ProductSearchViewModel(searchService: stub, clock: ImmediateClock())
+
+        vm.query = "shoes"
+        vm.search()
+
+        try await Task.yield()
+
+        #expect(vm.errorMessage != nil)
+        #expect(vm.products.isEmpty)
+    }
+}
+```
+
+Rules:
+- Inject `Clock` protocol to make time-dependent code testable without `Task.sleep` in tests.
+- Use an `ImmediateClock` test double that returns instantly — eliminates flakiness from timing.
+- `Task.yield()` gives the spawned task a chance to run without introducing arbitrary delays.
+- In production, `ContinuousClock()` is the default — no behavioral change.
+
+### Snapshot Testing with swift-snapshot-testing
+---
+
+Verify UI appearance by comparing rendered views against reference images.
+
+```swift
+// Package.swift dependency
+// .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0")
+
+import SnapshotTesting
+import SwiftUI
+import XCTest
+@testable import MyApp
+
+final class ProductCardSnapshotTests: XCTestCase {
+    func test_productCard_defaultState() {
+        let view = ProductCardView(product: .sample)
+            .frame(width: 320)
+
+        assertSnapshot(of: view, as: .image(layout: .sizeThatFits))
+    }
+
+    func test_productCard_soldOut() {
+        let product = Product.sample(availableStock: 0)
+        let view = ProductCardView(product: product)
+            .frame(width: 320)
+
+        assertSnapshot(of: view, as: .image(layout: .sizeThatFits))
+    }
+
+    // Test multiple device sizes
+    func test_productList_iPhoneSE() {
+        let view = NavigationStack {
+            ProductListView(products: Product.sampleList)
+        }
+
+        assertSnapshot(of: view, as: .image(layout: .device(config: .iPhoneSe)))
+    }
+
+    func test_productList_iPhone15Pro() {
+        let view = NavigationStack {
+            ProductListView(products: Product.sampleList)
+        }
+
+        assertSnapshot(of: view, as: .image(layout: .device(config: .iPhone15Pro)))
+    }
+}
+```
+
+Rules:
+- First run generates reference snapshots (test "fails" to create them). Commit these to the repo.
+- Subsequent runs compare against references. Differences cause failure with a diff image.
+- Run `record: true` parameter or set `isRecording = true` to update references after intentional UI changes.
+- Snapshot tests are fragile across OS versions and simulators — pin to a specific device/OS in CI.
+
+
+## Test Plans & Configuration
+
+### Xcode Test Plans (.xctestplan)
+---
+
+Test plans define which tests to run, with which configuration. They replace scheme-level test settings.
+
+A test plan is a JSON file (`.xctestplan`) configured in Xcode:
+
+```
+MyApp.xctestplan
+├── Configuration: "Default"
+│   ├── Language: en
+│   ├── Region: US
+│   ├── Sanitizers: none
+│   └── Tests: all enabled
+├── Configuration: "German"
+│   ├── Language: de
+│   ├── Region: DE
+│   └── Tests: UI tests only
+├── Configuration: "Memory Check"
+│   ├── Address Sanitizer: enabled
+│   ├── Zombie Objects: enabled
+│   └── Tests: all enabled
+└── Configuration: "Thread Safety"
+    ├── Thread Sanitizer: enabled
+    └── Tests: unit tests only
+```
+
+#### Key settings per configuration
+
+- **Application Language / Region**: Test localization without changing simulator settings.
+- **Address Sanitizer (ASan)**: Detects memory corruption (buffer overflows, use-after-free).
+- **Thread Sanitizer (TSan)**: Detects data races — critical for concurrency testing.
+- **Undefined Behavior Sanitizer (UBSan)**: Catches undefined behavior (integer overflow, null dereference).
+- **Code Coverage**: Enable/disable per configuration.
+- **Test Repetitions**: Run each test multiple times to catch flaky tests.
+
+### Test Repetitions
+---
+
+Available in test plans and xcodebuild:
+
+| Mode | Behavior |
+|---|---|
+| Fixed repetitions | Run each test N times |
+| Until failure | Repeat until a test fails (finds flaky tests) |
+| Retry on failure | Retry failed tests up to N times (stabilizes CI) |
+
+```bash
+# xcodebuild repetition modes
+xcodebuild test \
+    -scheme MyApp \
+    -testPlan MyApp \
+    -test-iterations 5 \
+    -retry-tests-on-failure
+
+xcodebuild test \
+    -scheme MyApp \
+    -test-iterations 100 \
+    -run-tests-until-failure
+```
+
+### Code Coverage
+---
+
+Enable in the test plan or scheme. Xcode generates coverage data in the `.xcresult` bundle.
+
+- Set coverage targets per module (e.g., 80% for core business logic).
+- Exclude generated code, third-party code, and UI layers from coverage requirements.
+- Coverage is a guide, not a goal — 100% coverage does not mean 100% correctness.
+
+
+## CI/CD Testing
+
+### xcodebuild Commands
+---
+
+```bash
+# Run all tests
+xcodebuild test \
+    -project MyApp.xcodeproj \
+    -scheme MyApp \
+    -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0' \
+    -resultBundlePath TestResults.xcresult
+
+# Run with a test plan
+xcodebuild test \
+    -project MyApp.xcodeproj \
+    -scheme MyApp \
+    -testPlan CITestPlan \
+    -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0' \
+    -resultBundlePath TestResults.xcresult
+
+# Run specific test suite or method
+xcodebuild test \
+    -scheme MyApp \
+    -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0' \
+    -only-testing:MyAppTests/AuthenticationTests/testLoginWithValidCredentials
+
+# Skip specific tests
+xcodebuild test \
+    -scheme MyApp \
+    -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0' \
+    -skip-testing:MyAppUITests/OnboardingUITests
+```
+
+### Parallel Testing on CI
+---
+
+```bash
+# Parallel testing across multiple simulators
+xcodebuild test \
+    -scheme MyApp \
+    -parallel-testing-enabled YES \
+    -maximum-concurrent-test-simulator-destinations 4 \
+    -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0' \
+    -resultBundlePath TestResults.xcresult
+```
+
+Rules:
+- Parallel testing distributes test classes across simulator clones.
+- Tests must be independent — no shared mutable state between test classes.
+- UI tests often need serial execution — separate them into their own test plan.
+
+### Result Bundles (.xcresult)
+---
+
+```bash
+# Export test results as JSON
+xcrun xcresulttool get test-results summary \
+    --path TestResults.xcresult
+
+# Export code coverage
+xcrun xcresulttool get code-coverage \
+    --path TestResults.xcresult \
+    --output-format json > coverage.json
+
+# List attachments (screenshots, logs)
+xcrun xcresulttool get test-results attachments \
+    --path TestResults.xcresult
+```
+
+Result bundles contain:
+- Test pass/fail status and duration
+- Code coverage data
+- Screenshots (automatic on UI test failure)
+- Console logs and diagnostics
+- Performance metrics
+
+
+## TDD Workflow
+
+### Red-Green-Refactor
+---
+
+1. **Red** — Write a failing test that defines the desired behavior.
+2. **Green** — Write the minimum code to make the test pass.
+3. **Refactor** — Clean up the code while keeping all tests green.
+
+```swift
+// 1. RED — Write the test first
+@Test func discountCalculator_applyPercentDiscount() {
+    let calculator = DiscountCalculator()
+    let result = calculator.apply(.percent(20), to: 100.00)
+    #expect(result == 80.00)
+}
+
+// 2. GREEN — Minimal implementation
+struct DiscountCalculator {
+    enum Discount {
+        case percent(Double)
+    }
+
+    func apply(_ discount: Discount, to price: Double) -> Double {
+        switch discount {
+        case .percent(let value):
+            return price * (1 - value / 100)
+        }
+    }
+}
+
+// 3. REFACTOR — Add more cases, improve naming, extract if needed
+// Then write the next failing test:
+@Test func discountCalculator_applyFixedDiscount() {
+    let calculator = DiscountCalculator()
+    let result = calculator.apply(.fixed(15.00), to: 100.00)
+    #expect(result == 85.00)
+}
+
+@Test func discountCalculator_neverGoesBelowZero() {
+    let calculator = DiscountCalculator()
+    let result = calculator.apply(.fixed(150.00), to: 100.00)
+    #expect(result == 0.00)
+}
+```
+
+### When TDD is Most Valuable
+
+| Scenario | TDD Value |
+|---|---|
+| Business logic / domain rules | High — correctness is critical |
+| Data parsing / transformation | High — edge cases are common |
+| Algorithm implementation | High — incremental approach clarifies design |
+| State machine transitions | High — defines valid transitions |
+| UI layout / styling | Low — prefer snapshot tests or previews |
+| Networking integration | Low — prefer integration tests |
+| Rapid prototyping | Low — design is still fluid |
+
+
+## Common Pitfalls
+
+| Pitfall | Fix |
+|---|---|
+| Flaky tests from timing issues | Use `confirmation()` or `XCTExpectation` with appropriate timeouts — never use `Task.sleep` as the sole synchronization |
+| Tests depend on execution order | Each test must be independent. Use `init`/`setUp` to create fresh state |
+| Over-mocking hides real bugs | Mock at the boundary (network, disk, system), not between your own classes |
+| Testing implementation, not behavior | Test observable outputs (return values, state changes, side effects), not internal method calls |
+| `@MainActor` isolation in tests | Annotate test functions with `@MainActor` when testing MainActor-isolated types |
+| UI tests break on text changes | Use `accessibilityIdentifier`, not `accessibilityLabel` or visible text, for element queries |
+| Snapshot tests fail across environments | Pin CI to a specific simulator and OS version. Use tolerance for minor rendering differences |
+| Slow test suite | Separate fast unit tests from slow integration/UI tests using test plans. Run fast tests on every PR, slow tests on merge |
+| No test isolation for singletons | Inject dependencies via protocols instead of accessing singletons directly |
+| `XCTExpectation` fulfilled multiple times | Set `expectedFulfillmentCount` or use `assertForOverFulfill = true` to catch unexpected extra calls |
+| Testing async code without awaiting | Mark test `async`, use `await` on async calls. Unawaited tasks may complete after the test ends |
+| Performance tests in the main suite | Move `measure { }` tests to a dedicated test plan — they slow down the feedback loop |
+
+## Related References
+
+- **`references/code-quality.md`** — SwiftLint, SwiftFormat, sanitizers (ASan, TSan, UBSan), and CI/CD quality gates. Sanitizers are configured in test plans alongside test configurations described here.
+- **`references/concurrency.md`** — async/await, actors, `@MainActor` — essential context for testing concurrent code.
+- **`references/project-structure.md`** — test target organization, schemes, and multi-module test setup.

--- a/registry/skills/apple-app-development/references/testing.md
+++ b/registry/skills/apple-app-development/references/testing.md
@@ -1342,6 +1342,7 @@ struct DiscountCalculator {
 
 ## Related References
 
-- **`references/code-quality.md`** — SwiftLint, SwiftFormat, sanitizers (ASan, TSan, UBSan), and CI/CD quality gates. Sanitizers are configured in test plans alongside test configurations described here.
+- **`references/code-quality.md`** — Xcode Static Analyzer, sanitizers (ASan, TSan, UBSan), Periphery, Xcode build settings. Sanitizers are configured in test plans alongside test configurations described here.
+- **`swift-development` skill's `references/static-analysis.md`** — SwiftLint, SwiftFormat configuration and CI integration.
 - **`references/concurrency.md`** — async/await, actors, `@MainActor` — essential context for testing concurrent code.
 - **`references/project-structure.md`** — test target organization, schemes, and multi-module test setup.

--- a/registry/skills/apple-app-development/references/testing.md
+++ b/registry/skills/apple-app-development/references/testing.md
@@ -1109,8 +1109,22 @@ final class ProductCardSnapshotTests: XCTestCase {
 Rules:
 - First run generates reference snapshots (test "fails" to create them). Commit these to the repo.
 - Subsequent runs compare against references. Differences cause failure with a diff image.
-- Run `record: true` parameter or set `isRecording = true` to update references after intentional UI changes.
+- To update references: use `withSnapshotTesting(record: .all) { ... }` (scoped, preferred) or `isRecording = true` (global, legacy).
 - Snapshot tests are fragile across OS versions and simulators — pin to a specific device/OS in CI.
+
+#### Swift Testing Support (swift-snapshot-testing 1.17+)
+
+```swift
+import Testing
+import SnapshotTesting
+
+@Test func productCard_renders() {
+    let view = ProductCardView(product: .sample).frame(width: 320)
+    withSnapshotTesting(record: .missing) {
+        assertSnapshot(of: view, as: .image(layout: .sizeThatFits))
+    }
+}
+```
 
 
 ## Test Plans & Configuration

--- a/registry/skills/apple-app-development/references/testing.md
+++ b/registry/skills/apple-app-development/references/testing.md
@@ -1064,7 +1064,7 @@ Verify UI appearance by comparing rendered views against reference images.
 
 ```swift
 // Package.swift dependency
-// .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0")
+// .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "<latest-stable>")
 
 import SnapshotTesting
 import SwiftUI

--- a/registry/skills/apple-app-development/references/testing.md
+++ b/registry/skills/apple-app-development/references/testing.md
@@ -304,7 +304,7 @@ Swift Testing uses the struct/class lifecycle — no `setUp`/`tearDown` methods.
 @Test func notificationPostedOnSave() async throws {
     let store = DocumentStore()
 
-    await confirmation("Document saved notification") { confirm in
+    try await confirmation("Document saved notification") { confirm in
         NotificationCenter.default.addObserver(
             forName: .documentDidSave, object: nil, queue: nil
         ) { _ in

--- a/registry/skills/apple-app-development/references/testing.md
+++ b/registry/skills/apple-app-development/references/testing.md
@@ -1136,7 +1136,7 @@ Test plans define which tests to run, with which configuration. They replace sch
 
 A test plan is a JSON file (`.xctestplan`) configured in Xcode:
 
-```
+```text
 MyApp.xctestplan
 ├── Configuration: "Default"
 │   ├── Language: en

--- a/registry/skills/apple-app-development/references/testing.md
+++ b/registry/skills/apple-app-development/references/testing.md
@@ -113,7 +113,7 @@ func widgetRefresh() async throws {
 @Test(
     "Upload retries on transient failure",
     .tags(.networking),
-    .timeLimit(.seconds(30)),
+    .timeLimit(.minutes(1)),
     .bug("https://jira.example.com/PROJ-123")
 )
 func uploadRetry() async throws {

--- a/registry/skills/apple-app-development/references/tvos-patterns.md
+++ b/registry/skills/apple-app-development/references/tvos-patterns.md
@@ -299,8 +299,8 @@ tvOS apps render on large screens. Design for the living room viewing distance.
 
 | Resolution | When Used |
 |---|---|
-| 1920x1080 (1080p) | Apple TV HD |
-| 3840x2160 (4K) | Apple TV 4K |
+| 1920x1080 (1080p) | Apple TV HD (discontinued Oct 2022) |
+| 3840x2160 (4K) | Apple TV 4K (current, 3rd gen 2022+) |
 
 SwiftUI uses points, so the coordinate space is always **1920x1080** regardless of device. The system handles pixel doubling for 4K.
 
@@ -473,7 +473,7 @@ struct MyTVApp: App {
 
 ## TVMLKit
 
-TVMLKit is the JavaScript/XML-based framework for building tvOS UIs using TVML templates. It is a legacy approach.
+TVMLKit is the JavaScript/XML-based framework for building tvOS UIs using TVML templates. It is **deprecated** as of tvOS 18 (WWDC24). See Apple's "Migrate your TVML app to SwiftUI" session (WWDC24-10207) for migration guidance.
 
 ### When to Use
 
@@ -481,10 +481,10 @@ TVMLKit is the JavaScript/XML-based framework for building tvOS UIs using TVML t
 |---|---|---|
 | New apps | Yes | No |
 | Server-driven UI needed | SwiftUI + JSON config | Maybe (but consider alternatives) |
-| Existing TVMLKit codebase | Migrate when practical | Maintain if stable |
+| Existing TVMLKit codebase | Migrate (TVMLKit deprecated in tvOS 18) | Maintain if stable, plan migration |
 | Complex custom interactions | Yes | Limited |
 
-TVMLKit was useful when tvOS first launched (tvOS 9) for quickly building catalog-style apps with server-driven templates. For new development, SwiftUI is the clear choice. Apple has not significantly updated TVMLKit in recent years.
+TVMLKit was useful when tvOS first launched (tvOS 9) for quickly building catalog-style apps with server-driven templates. Apple officially deprecated TVMLKit in tvOS 18. For all new development, use SwiftUI.
 
 ### Basic Setup (Legacy Reference)
 

--- a/registry/skills/apple-app-development/references/tvos-patterns.md
+++ b/registry/skills/apple-app-development/references/tvos-patterns.md
@@ -34,12 +34,15 @@ struct MenuView: View {
 }
 ```
 
-Any view can opt in to focus with `.focusable()`:
+Any view can opt in to focus with `.focusable()`. Use `@FocusState` with `onChange(of:)` to react to focus changes:
 
 ```swift
+@FocusState private var isFocused: Bool
+
 Text("Focusable label")
     .focusable()
-    .onFocusChange { isFocused in
+    .focused($isFocused)
+    .onChange(of: isFocused) { _, newValue in
         // react to focus gain/loss
     }
 ```

--- a/registry/skills/apple-app-development/references/uikit-interop.md
+++ b/registry/skills/apple-app-development/references/uikit-interop.md
@@ -544,16 +544,18 @@ class ProfileViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        // Note: iOS 26+ provides updateProperties() for automatic @Observable tracking.
+        // For pre-iOS 26, use withObservationTracking with continuation-based re-registration:
         observationTask = Task { [weak self] in
-            // Use withObservationTracking for UIKit
             while !Task.isCancelled {
                 guard let self else { return }
-                withObservationTracking {
-                    self.updateUI(with: self.viewModel.user)
-                } onChange: {
-                    // Re-run on next change
+                await withCheckedContinuation { continuation in
+                    withObservationTracking {
+                        self.updateUI(with: self.viewModel.user)
+                    } onChange: {
+                        continuation.resume()
+                    }
                 }
-                try? await Task.sleep(for: .milliseconds(50))
             }
         }
         Task { await viewModel.load() }
@@ -794,7 +796,7 @@ struct FocusableTextField: UIViewRepresentable {
 // UIHostingController respects safe areas by default.
 // To disable safe area behavior (e.g., edge-to-edge content):
 let hosting = UIHostingController(rootView: contentView)
-hosting.safeAreaRegions = []  // iOS 16+ -- removes all safe area insets
+hosting.safeAreaRegions = []  // iOS 16.4+ -- removes all safe area insets
 
 // When embedding a UIView in SwiftUI, the UIKit view receives
 // safe area insets from SwiftUI's container. If your UIKit view

--- a/registry/skills/apple-app-development/references/uikit-interop.md
+++ b/registry/skills/apple-app-development/references/uikit-interop.md
@@ -16,6 +16,8 @@ makeUIView  -->  updateUIView (called on every SwiftUI state change)  -->  disma
 
 ### Basic Example
 
+> **Note:** For maps specifically, iOS 17+ provides native SwiftUI MapKit (`Map`, `Marker`, `Annotation`, `MapStyle`, etc.) that covers most use cases. Wrap `MKMapView` only when you need features SwiftUI MapKit lacks (custom overlay renderers, certain delegate callbacks). This example demonstrates the `UIViewRepresentable` lifecycle pattern.
+
 ```swift
 import SwiftUI
 import MapKit
@@ -673,6 +675,29 @@ window.contentViewController = hostingController
 | `UIView` | `NSView` | -- |
 | `UIViewController` | `NSViewController` | -- |
 
+
+## Swift 6 Concurrency and Representables
+
+With Swift 6 strict concurrency, `UIViewRepresentable` and `UIViewControllerRepresentable` protocol methods are `@MainActor`-isolated. Key implications:
+
+- **Coordinator delegate callbacks** that arrive on background threads need explicit `@MainActor` hopping or must be marked `nonisolated` with manual dispatch.
+- Under **Swift 6.2 default MainActor isolation**, most of this is handled automatically — code runs on MainActor unless opted out with `@concurrent` or `nonisolated`.
+- **`@Sendable` closure requirements**: Closures passed across isolation boundaries (e.g., from UIKit delegates to SwiftUI state updates) must be `@Sendable`.
+
+```swift
+// Coordinator with Swift 6 concurrency
+class Coordinator: NSObject, MKMapViewDelegate {
+    var parent: MapView
+
+    // This delegate method may be called on any thread by MapKit.
+    // Under strict concurrency, update @MainActor state explicitly.
+    nonisolated func mapView(_ mapView: MKMapView, didSelect annotation: any MKAnnotation) {
+        Task { @MainActor in
+            parent.selectedAnnotation = annotation
+        }
+    }
+}
+```
 
 ## Common Pitfalls
 

--- a/registry/skills/apple-app-development/references/visionos-patterns.md
+++ b/registry/skills/apple-app-development/references/visionos-patterns.md
@@ -802,12 +802,18 @@ struct LODComponent: Component {
 struct LODSystem: System {
     static let query = EntityQuery(where: .has(LODComponent.self))
 
-    init(scene: RealityKit.Scene) {}
+    // On visionOS, use WorldTrackingProvider.deviceAnchor for user position.
+    // PerspectiveCameraComponent is for non-visionOS RealityKit (iOS/macOS).
+    private var worldTracking: WorldTrackingProvider?
+
+    init(scene: RealityKit.Scene) {
+        // WorldTrackingProvider should be started in your ImmersiveSpace setup
+        // and passed to this system or stored in a shared location.
+    }
 
     func update(context: SceneUpdateContext) {
-        guard let cameraTransform = context.scene.performQuery(
-            EntityQuery(where: .has(PerspectiveCameraComponent.self))
-        ).first?.transform else { return }
+        guard let deviceAnchor = worldTracking?.queryDeviceAnchor(atTimestamp: CACurrentMediaTime()) else { return }
+        let headPosition = deviceAnchor.originFromAnchorTransform.columns.3
 
         for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
             guard let lod = entity.components[LODComponent.self],
@@ -815,7 +821,7 @@ struct LODSystem: System {
 
             let distance = simd_distance(
                 entity.position(relativeTo: nil),
-                cameraTransform.translation
+                SIMD3(headPosition.x, headPosition.y, headPosition.z)
             )
             let targetMesh = distance > lod.switchDistance ? lod.lowDetail : lod.highDetail
             if model.mesh !== targetMesh {
@@ -851,3 +857,43 @@ struct LODSystem: System {
 - Disable components (physics, collision) on entities that do not need them.
 - Use `async` loading for models to avoid blocking the main actor during scene setup.
 - Prefer static meshes over animated ones when motion is not required.
+
+
+## visionOS 2+ Features
+
+### Object Tracking (visionOS 2)
+
+Track real-world objects using `ObjectTrackingProvider`:
+
+```swift
+let session = ARKitSession()
+let objectTracking = ObjectTrackingProvider(
+    referenceObjects: ReferenceObject.loadReferenceObjects(inGroupNamed: "TrackedObjects")
+)
+
+try await session.run([objectTracking])
+
+for await update in objectTracking.anchorUpdates {
+    switch update.event {
+    case .added, .updated:
+        let anchor = update.anchor
+        // Position virtual content relative to tracked object
+        entity.transform = Transform(matrix: anchor.originFromAnchorTransform)
+    case .removed:
+        break
+    }
+}
+```
+
+### TabletopKit (visionOS 2)
+
+Framework for building tabletop experiences (board games, collaborative tools). Manages player seating, game pieces, and table surface interactions.
+
+### visionOS 26 Features
+
+- **ManipulationComponent** — Built-in component for object manipulation, replacing much custom gesture code. Add to entities for drag, rotate, and scale behaviors.
+- **Persistence APIs** — Content can be locked to physical surfaces and persist across app sessions using spatial anchors.
+- **ImagePresentationComponent** — New component for displaying 2D, spatial photos, and spatial scenes in RealityKit.
+- **Unified Coordinate Conversion** — Simplifies moving between SwiftUI, RealityKit, and ARKit coordinate spaces.
+- **WidgetKit on visionOS** — Widgets are now available on visionOS 26.
+- **Spatial accessories** — Support for PlayStation VR2 Sense controllers and Logitech Muse.

--- a/registry/skills/apple-app-development/references/visionos-patterns.md
+++ b/registry/skills/apple-app-development/references/visionos-patterns.md
@@ -799,20 +799,37 @@ struct LODComponent: Component {
     let switchDistance: Float
 }
 
+// WorldTrackingProvider must be started once via ARKitSession.run(_:) before any
+// System can query it. RealityKit instantiates Systems for you, so expose the
+// already-running provider through a shared @MainActor holder rather than init injection.
+@MainActor
+enum WorldTracking {
+    static let provider = WorldTrackingProvider()
+    private static let session = ARKitSession()
+
+    // Call once during ImmersiveSpace setup, e.g.:
+    //   RealityView { ... }.task { await WorldTracking.start() }
+    static func start() async {
+        guard WorldTrackingProvider.isSupported else { return }
+        do {
+            try await session.run([provider])
+        } catch {
+            print("World tracking failed to start: \(error)")
+        }
+    }
+}
+
 struct LODSystem: System {
     static let query = EntityQuery(where: .has(LODComponent.self))
 
-    // On visionOS, use WorldTrackingProvider.deviceAnchor for user position.
-    // PerspectiveCameraComponent is for non-visionOS RealityKit (iOS/macOS).
-    private var worldTracking: WorldTrackingProvider?
-
-    init(scene: RealityKit.Scene) {
-        // WorldTrackingProvider should be started in your ImmersiveSpace setup
-        // and passed to this system or stored in a shared location.
-    }
+    init(scene: RealityKit.Scene) {}
 
     func update(context: SceneUpdateContext) {
-        guard let deviceAnchor = worldTracking?.queryDeviceAnchor(atTimestamp: CACurrentMediaTime()) else { return }
+        // On visionOS, read the user's head position from the device anchor.
+        // (PerspectiveCameraComponent is for non-visionOS RealityKit on iOS/macOS.)
+        guard let deviceAnchor = WorldTracking.provider.queryDeviceAnchor(
+            atTimestamp: CACurrentMediaTime()
+        ) else { return }
         let headPosition = deviceAnchor.originFromAnchorTransform.columns.3
 
         for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {

--- a/registry/skills/apple-app-development/references/watchos-patterns.md
+++ b/registry/skills/apple-app-development/references/watchos-patterns.md
@@ -17,7 +17,7 @@
 
 ### Standalone vs companion
 
-watchOS 10+ apps are standalone by default. A companion iPhone app is optional. The watch app has its own bundle identifier, lifecycle, and App Store presence.
+watchOS apps have supported standalone mode since watchOS 6 (via `WKRunsIndependentlyOfCompanionApp`). New Xcode watchOS project templates create standalone apps by default. A companion iPhone app is optional. The watch app has its own bundle identifier, lifecycle, and App Store presence.
 
 ```swift
 // Standalone watchOS app entry point
@@ -75,9 +75,9 @@ enum Route: Hashable {
 
 ## Complications
 
-### WidgetKit-based complications (watchOS 10+)
+### WidgetKit-based complications (watchOS 9+)
 
-watchOS 10 migrated complications to WidgetKit. ClockKit is deprecated.
+ClockKit was deprecated in watchOS 9. Complications are now built with WidgetKit using the same `TimelineProvider` pattern as home screen widgets.
 
 ```swift
 import WidgetKit

--- a/registry/skills/apple-app-development/references/watchos-patterns.md
+++ b/registry/skills/apple-app-development/references/watchos-patterns.md
@@ -506,12 +506,8 @@ final class AppDelegate: NSObject, WKApplicationDelegate {
                 // Handle background URL session completion
                 urlTask.setTaskCompletedWithSnapshot(false)
 
-            case let snapshotTask as WKSnapshotRefreshBackgroundTask:
-                snapshotTask.setTaskCompleted(
-                    restoredDefaultState: true,
-                    estimatedSnapshotExpiration: .distantFuture,
-                    userInfo: nil
-                )
+            // WKSnapshotRefreshBackgroundTask is deprecated since watchOS 7.
+            // The snapshot-based dock was replaced by Smart Stack in watchOS 10.
 
             default:
                 task.setTaskCompletedWithSnapshot(false)
@@ -780,6 +776,57 @@ Key points:
 - The system uses relevance alongside user behavior to rank widgets.
 - Widgets can also provide a `duration` to indicate how long the relevance score applies.
 
+## watchOS 11+ Features
+
+### Live Activities on Apple Watch
+
+Live Activities from iPhone automatically appear in the Smart Stack on Apple Watch (watchOS 11). Customize the watch presentation with `supplementalActivityFamilies`:
+
+```swift
+struct MyWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        ActivityConfiguration(for: DeliveryAttributes.self) { context in
+            // Lock Screen / Dynamic Island
+            DeliveryLiveActivityView(context: context)
+        } dynamicIsland: { context in
+            // Dynamic Island views
+        }
+        .supplementalActivityFamilies([.small]) // Enable Apple Watch Smart Stack
+    }
+}
+```
+
+Without customization, the Dynamic Island compact views are used on Apple Watch. Add `supplementalActivityFamilies([.small])` and provide a dedicated view for the watch-sized presentation.
+
+### Interactive Widgets (watchOS 11+)
+
+Widgets on watchOS now support `Button` and `Toggle` backed by App Intents, allowing up to 3 actionable buttons per widget without launching the app:
+
+```swift
+struct QuickActionsWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "QuickActions", provider: Provider()) { entry in
+            VStack {
+                Text(entry.status)
+                Button(intent: ToggleStatusIntent()) {
+                    Label("Toggle", systemImage: "arrow.triangle.2.circlepath")
+                }
+            }
+        }
+        .supportedFamilies([.accessoryRectangular])
+    }
+}
+```
+
+### Double Tap Gesture (watchOS 11+)
+
+Designate a primary action for the Double Tap gesture in your app, widgets, and Live Activities:
+
+```swift
+Button("Start Timer", action: startTimer)
+    .handGestureShortcut(.primaryAction) // Triggered by Double Tap
+```
+
 ## Limitations
 
 ### Memory budget
@@ -806,8 +853,10 @@ watchOS apps typically have 30-50 MB of usable memory depending on the device. T
 |---|---|---|
 | Apple Watch SE (40mm) | 162pt | 324 x 394 |
 | Apple Watch SE (44mm) | 176pt | 352 x 430 |
-| Apple Watch Series 9/10 (41mm) | 170pt | 352 x 430 |
-| Apple Watch Series 9/10 (45mm) | 185pt | 396 x 484 |
+| Apple Watch Series 9 (41mm) | 170pt | 352 x 430 |
+| Apple Watch Series 9 (45mm) | 185pt | 396 x 484 |
+| Apple Watch Series 10 (42mm) | 176pt | 374 x 446 |
+| Apple Watch Series 10 (46mm) | 191pt | 416 x 496 |
 | Apple Watch Ultra 2 (49mm) | 205pt | 410 x 502 |
 
 - Always use dynamic type and scalable layouts.

--- a/registry/skills/apple-app-development/references/widgets-app-intents.md
+++ b/registry/skills/apple-app-development/references/widgets-app-intents.md
@@ -999,6 +999,135 @@ struct MediumWidgetView: View {
 }
 ```
 
+### ControlWidget (iOS 18+)
+
+Controls are a new WidgetKit mechanism that places app actions in Control Center, the Lock Screen controls gallery, and the Action button. They use `ControlWidget` instead of `Widget` and are powered by App Intents.
+
+```swift
+import WidgetKit
+import AppIntents
+
+struct CaffeinateToggle: ControlWidget {
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(kind: "CaffeinateToggle") {
+            ControlWidgetToggle(
+                "Caffeinate",
+                isOn: CaffeinateManager.shared.isActive,
+                action: ToggleCaffeinateIntent()
+            ) { isOn in
+                Label(isOn ? "Active" : "Off", systemImage: isOn ? "cup.and.saucer.fill" : "cup.and.saucer")
+            }
+            .tint(.brown)
+        }
+        .displayName("Caffeinate Toggle")
+        .description("Toggle caffeinate mode from Control Center.")
+    }
+}
+
+struct ToggleCaffeinateIntent: SetValueIntent {
+    static var title: LocalizedStringResource = "Toggle Caffeinate"
+    typealias Value = Bool
+
+    @Parameter(title: "Enabled")
+    var value: Bool
+
+    func perform() async throws -> some IntentResult {
+        await CaffeinateManager.shared.setActive(value)
+        return .result()
+    }
+}
+```
+
+Use `ControlWidgetButton` for one-shot actions instead of toggles. Both `StaticControlConfiguration` and `AppIntentControlConfiguration` (for user-configurable controls) are available.
+
+### Apple Intelligence / AssistantSchemas (iOS 18+)
+
+App Intents can integrate directly with Siri and Apple Intelligence by conforming to an `AssistantSchema`. This allows the system to understand app actions semantically and surface them in intelligent suggestions, Siri conversations, and on-screen awareness.
+
+Apple defines **12 App Intent Domains**: Books, Browser, Camera, Documents, File Management, Journal, Mail, Photos, Presentations, Spreadsheets, WhiteBoard, and Word Processor. Each domain provides a set of schemas that describe common actions.
+
+```swift
+import AppIntents
+import AssistantSchemas
+
+struct OpenMailIntent: AppIntent, OpenMailboxIntent {
+    static var title: LocalizedStringResource = "Open Mailbox"
+
+    @Parameter(title: "Mailbox")
+    var target: MailboxEntity?
+
+    func perform() async throws -> some IntentResult {
+        await NavigationManager.shared.openMailbox(target?.id)
+        return .result()
+    }
+}
+```
+
+The philosophy shift with Apple Intelligence is: **anything your app does should be an app intent**. Conforming to `AssistantSchema` protocols tells the system what the intent does in a domain-specific way, enabling Siri and Apple Intelligence to orchestrate actions across apps without requiring explicit Siri phrases.
+
+### Live Activities on Apple Watch (watchOS 11+)
+
+Starting with watchOS 11, Live Activities from a paired iPhone appear automatically in the Smart Stack on Apple Watch. By default, the system uses the Dynamic Island compact views to render the activity.
+
+To provide a custom watch layout, add the `supplementalActivityFamilies` modifier to your `ActivityConfiguration`:
+
+```swift
+struct DeliveryLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: DeliveryAttributes.self) { context in
+            // Lock Screen presentation (iOS)
+            DeliveryLockScreenView(context: context)
+        } dynamicIsland: { context in
+            // Dynamic Island presentation (iOS)
+            DeliveryDynamicIsland(context: context)
+        }
+        .supplementalActivityFamilies([.small])
+    }
+}
+```
+
+When `.small` is specified, provide a dedicated watchOS layout using `WidgetFamily.accessoryRectangular`-like sizing. Without the modifier, the system falls back to the Dynamic Island compact leading/trailing views to compose the Smart Stack card automatically.
+
+### Broadcast Push Notifications for Live Activities (iOS 18+)
+
+Prior to iOS 18, updating a Live Activity via push required sending individual notifications to each device's unique push token. Broadcast push notifications solve this scalability problem by allowing a single push to a **channel ID** that reaches all subscribers.
+
+```swift
+// Start a Live Activity with a channel for broadcast push
+let activity = try Activity.request(
+    attributes: attributes,
+    content: content,
+    pushType: .token
+)
+
+// Observe the push-to-start token for channel-based delivery
+Task {
+    for await token in Activity<DeliveryAttributes>.pushToStartTokenUpdates {
+        let tokenString = token.map { String(format: "%02x", $0) }.joined()
+        await registerBroadcastToken(tokenString, channelID: "delivery-\(orderID)")
+    }
+}
+```
+
+Configure your APNs payload with the channel ID rather than individual device tokens. The server sends one push, and Apple's infrastructure fans it out to all devices subscribed to that channel. This is especially useful for events with many simultaneous viewers (sports scores, ride-sharing, etc.) where per-device token management is impractical.
+
+### WidgetKit Push Notifications
+
+Widgets can be updated via APNs push notifications, reducing the need for frequent timeline reloads and improving data freshness.
+
+To configure push-based widget updates:
+1. Enable the `WidgetKit Extension` push notification capability in your widget extension target.
+2. Implement `onBackgroundURLSessionEvents` or rely on the system to trigger a timeline reload when the push arrives.
+3. Send a push notification with the `content-available` flag and include your widget kind in the payload.
+
+The system wakes the widget extension upon receiving the push and invokes `getTimeline` for the specified widget kind. Push-driven reloads do not count against the daily reload budget, making them ideal for widgets that need real-time data without polling.
+
+### Platform Availability Update
+
+> **visionOS 26**: WidgetKit is now supported on visionOS, allowing widgets to appear in the Home View alongside app icons. Existing iOS widgets can run with minimal adaptation — ensure your widget supports appropriate families and test with the visionOS simulator.
+
+> **CarPlay (iOS 26)**: CarPlay widgets are being introduced, enabling glanceable information on the CarPlay dashboard. CarPlay widgets use a constrained set of families and emphasize large, readable text with minimal interactivity for driver safety. Adopt `.systemSmall` as the primary family for CarPlay and follow the CarPlay Human Interface Guidelines for layout.
+
 ### Common Pitfalls
 
 | Pitfall | Fix |

--- a/registry/skills/apple-app-development/references/widgets-app-intents.md
+++ b/registry/skills/apple-app-development/references/widgets-app-intents.md
@@ -71,26 +71,30 @@ struct MyTimelineProvider: TimelineProvider {
 }
 ```
 
-### Async TimelineProvider (preferred for iOS 17+)
+### AppIntentTimelineProvider (preferred for iOS 17+)
+
+For configurable widgets (iOS 17+), use `AppIntentTimelineProvider` which has native async methods (`snapshot`/`timeline`):
 
 ```swift
-struct MyAsyncProvider: TimelineProvider {
+struct MyAsyncProvider: AppIntentTimelineProvider {
     func placeholder(in context: Context) -> MyEntry {
         MyEntry(date: .now, title: "Placeholder", value: 0)
     }
 
-    func getSnapshot(in context: Context) async -> MyEntry {
+    func snapshot(for configuration: MyWidgetIntent, in context: Context) async -> MyEntry {
         let data = await fetchLatestData()
         return MyEntry(date: .now, title: data.title, value: data.value)
     }
 
-    func getTimeline(in context: Context) async -> Timeline<MyEntry> {
+    func timeline(for configuration: MyWidgetIntent, in context: Context) async -> Timeline<MyEntry> {
         let data = await fetchLatestData()
         let entry = MyEntry(date: .now, title: data.title, value: data.value)
         return Timeline(entries: [entry], policy: .after(.now.addingTimeInterval(3600)))
     }
 }
 ```
+
+Note: `TimelineProvider` (for `StaticConfiguration`) uses completion-handler methods. Swift provides an implicit async bridge, but `AppIntentTimelineProvider` is the canonical async-first API.
 
 ### WidgetFamily Sizes
 

--- a/registry/skills/apple-app-development/references/widgets-app-intents.md
+++ b/registry/skills/apple-app-development/references/widgets-app-intents.md
@@ -1062,14 +1062,15 @@ Apple defines **12 App Intent Domains**: Books, Browser, Camera, Documents, File
 ```swift
 import AppIntents
 
-struct OpenMailIntent: AppIntent, OpenMailboxIntent {
-    static var title: LocalizedStringResource = "Open Mailbox"
-
-    @Parameter(title: "Mailbox")
-    var target: MailboxEntity?
+// Tag an existing or new app intent with @AssistantIntent(schema:) so Siri and
+// Apple Intelligence can invoke it for a known domain action. The macro enforces
+// the schema's required conformance and parameters at compile time.
+@AssistantIntent(schema: .books.openBook)
+struct OpenBookIntent: OpenIntent {
+    var target: BookEntity
 
     func perform() async throws -> some IntentResult {
-        await NavigationManager.shared.openMailbox(target?.id)
+        await NavigationManager.shared.openBook(target.id)
         return .result()
     }
 }
@@ -1105,39 +1106,33 @@ When `.small` is specified, provide a dedicated watchOS layout using `WidgetFami
 Prior to iOS 18, updating a Live Activity via push required sending individual notifications to each device's unique push token. Broadcast push notifications solve this scalability problem by allowing a single push to a **channel ID** that reaches all subscribers.
 
 ```swift
-// Start a Live Activity with a channel for broadcast push
+// Start a Live Activity subscribed to a broadcast channel (iOS 18+).
+// The channel ID is a base64-encoded string your server obtains from APNs
+// (see "Sending channel management requests to APNs").
 let activity = try Activity.request(
     attributes: attributes,
     content: content,
-    pushType: .token
+    pushType: .channel(channelID)   // e.g. "c29tZUNoYW5uZWw="
 )
-
-// Observe the push-to-start token for channel-based delivery
-Task {
-    for await token in Activity<DeliveryAttributes>.pushToStartTokenUpdates {
-        let tokenString = token.map { String(format: "%02x", $0) }.joined()
-        await registerBroadcastToken(tokenString, channelID: "delivery-\(orderID)")
-    }
-}
 ```
 
 Configure your APNs payload with the channel ID rather than individual device tokens. The server sends one push, and Apple's infrastructure fans it out to all devices subscribed to that channel. This is especially useful for events with many simultaneous viewers (sports scores, ride-sharing, etc.) where per-device token management is impractical.
 
 ### WidgetKit Push Notifications
 
-Widgets can be updated via APNs push notifications, reducing the need for frequent timeline reloads and improving data freshness.
+Widgets can be updated via APNs push notifications — useful for server-driven or cross-device data changes without frequent polling.
 
 To configure push-based widget updates:
-1. Enable the `WidgetKit Extension` push notification capability in your widget extension target.
-2. Implement `onBackgroundURLSessionEvents` or rely on the system to trigger a timeline reload when the push arrives.
-3. Send a push notification with the `content-available` flag and include your widget kind in the payload.
+1. Enable push for your widget extension and register the widget's push token with your server.
+2. From your server, send a push with header `apns-push-type: widgets` (topic `<bundleID>.push-type.widgets`) and an `aps` payload containing `"content-changed": true`.
+3. On receipt, WidgetKit reloads your timelines (similar to `WidgetCenter.reloadAllTimelines()`), driving `getTimeline(in:)` for the affected widget kinds.
 
-The system wakes the widget extension upon receiving the push and invokes `getTimeline` for the specified widget kind. Push-driven reloads do not count against the daily reload budget, making them ideal for widgets that need real-time data without polling.
+WidgetKit push updates are budgeted and delivered opportunistically — they supplement the system's refresh budget rather than bypassing it, so they aren't guaranteed to be immediate.
 
 ### Platform Availability Update
 
 > **visionOS 26**: WidgetKit is now supported on visionOS, allowing widgets to appear in the Home View alongside app icons. Existing iOS widgets can run with minimal adaptation — ensure your widget supports appropriate families and test with the visionOS simulator.
-
+>
 > **CarPlay (iOS 26)**: CarPlay widgets are being introduced, enabling glanceable information on the CarPlay dashboard. CarPlay widgets use a constrained set of families and emphasize large, readable text with minimal interactivity for driver safety. Adopt `.systemSmall` as the primary family for CarPlay and follow the CarPlay Human Interface Guidelines for layout.
 
 ### Common Pitfalls

--- a/registry/skills/apple-app-development/references/widgets-app-intents.md
+++ b/registry/skills/apple-app-development/references/widgets-app-intents.md
@@ -1009,10 +1009,15 @@ import AppIntents
 
 struct CaffeinateToggle: ControlWidget {
     var body: some ControlWidgetConfiguration {
-        StaticControlConfiguration(kind: "CaffeinateToggle") {
+        // A value provider supplies the current state; without it, isOn would be a
+        // snapshot captured at view-build time and wouldn't reflect external changes.
+        StaticControlConfiguration(
+            kind: "CaffeinateToggle",
+            provider: CaffeinateValueProvider()
+        ) { isActive in
             ControlWidgetToggle(
                 "Caffeinate",
-                isOn: CaffeinateManager.shared.isActive,
+                isOn: isActive,
                 action: ToggleCaffeinateIntent()
             ) { isOn in
                 Label(isOn ? "Active" : "Off", systemImage: isOn ? "cup.and.saucer.fill" : "cup.and.saucer")
@@ -1021,6 +1026,14 @@ struct CaffeinateToggle: ControlWidget {
         }
         .displayName("Caffeinate Toggle")
         .description("Toggle caffeinate mode from Control Center.")
+    }
+}
+
+struct CaffeinateValueProvider: ControlValueProvider {
+    var previewValue: Bool { false }
+
+    func currentValue() async throws -> Bool {
+        await CaffeinateManager.shared.isActive
     }
 }
 
@@ -1048,7 +1061,6 @@ Apple defines **12 App Intent Domains**: Books, Browser, Camera, Documents, File
 
 ```swift
 import AppIntents
-import AssistantSchemas
 
 struct OpenMailIntent: AppIntent, OpenMailboxIntent {
     static var title: LocalizedStringResource = "Open Mailbox"

--- a/registry/skills/swift-development/SKILL.md
+++ b/registry/skills/swift-development/SKILL.md
@@ -320,3 +320,4 @@ Prefer Swift Testing (`@Test`, `#expect`) over XCTest for new code. Use XCTest w
 | `Any` / `AnyObject` without reason | Use generics or existentials with constraints |
 | `Double` for money | Use `Decimal` with explicit rounding |
 | Hard-coded dependencies | Protocol-based DI via init injection |
+| `#if` directives for multi-target polymorphism | Use DI or separate file implementations per target; reserve `#if` for `DEBUG`, `os()`, `canImport()` |

--- a/registry/skills/swift-development/SKILL.md
+++ b/registry/skills/swift-development/SKILL.md
@@ -70,7 +70,14 @@ guard let user = fetchUser(id) else { return }  // early exit — preferred
 ### Safe patterns
 
 ```swift
-// Optional binding
+// Shorthand optional binding (Swift 5.7+) — use when binding name matches the variable
+if let name {
+    print(name)
+}
+
+guard let user else { return }
+
+// Explicit binding — only when intentionally binding to a different name
 if let email = user.email {
     sendConfirmation(to: email)
 }
@@ -82,6 +89,8 @@ let nested = fetchUser(id).flatMap { $0.address }        // Address?
 // Coalescing with throwing
 let user = try optionalUser ?? { throw AppError.notFound }()
 ```
+
+Always use shorthand optional binding when the binding name matches the original variable name. Write `if let value { }` instead of `if let value = value { }`. This applies to all optional binding contexts: `if let`, `guard let`, `while let`, and multi-condition bindings (e.g., `guard let foo, let bar else { }`). Only use the explicit `if let renamed = original` form when intentionally binding to a different name.
 
 NEVER use `!` to silence the compiler. Acceptable only with a provable invariant and a comment explaining why.
 
@@ -309,6 +318,7 @@ Prefer Swift Testing (`@Test`, `#expect`) over XCTest for new code. Use XCTest w
 | Mistake | Fix |
 |---|---|
 | Force-unwrapping (`!`) without invariant | Use `guard let`, `if let`, `??`, or optional chaining |
+| `if let value = value { }` when names match | Use shorthand: `if let value { }` (Swift 5.7+) |
 | Catching `Error` broadly | Catch specific error types at appropriate boundaries |
 | `Task { }` without cancellation handling | Check `Task.isCancelled` or use `Task.checkCancellation()` |
 | Using GCD (`DispatchQueue`) in new code | Use Swift Concurrency (`async/await`, actors) |

--- a/registry/skills/swift-development/SKILL.md
+++ b/registry/skills/swift-development/SKILL.md
@@ -16,6 +16,7 @@ Applicable to all Swift targets: Apple platforms, server-side (Vapor, Hummingbir
 - **`references/concurrency.md`** — Actors, task groups, async sequences, Sendable, isolation, GCD migration, Combine interop
 - **`references/patterns.md`** — Property wrappers, result builders, key paths, Codable, extensions, copy-on-write, DSL design
 - **`references/project-structure.md`** — Swift Package Manager setup, multi-target packages, build configurations, plugins, testing setup
+- **`references/static-analysis.md`** — SwiftLint (configuration, rules, custom rules, auto-correct), SwiftFormat (configuration, formatting rules), combined setup, CI/CD integration, pre-commit hooks
 
 ## Code Style
 

--- a/registry/skills/swift-development/references/static-analysis.md
+++ b/registry/skills/swift-development/references/static-analysis.md
@@ -1,0 +1,642 @@
+# Static Analysis Reference (SwiftLint & SwiftFormat)
+
+Covers SwiftLint and SwiftFormat — the two primary Swift static analysis and formatting tools. They are complementary: SwiftLint detects code smells and enforces conventions, SwiftFormat auto-fixes formatting. Use both together. For Apple platform-specific quality tools (Xcode Static Analyzer, sanitizers, Periphery), see the `apple-app-development` skill's `references/code-quality.md`.
+
+## Contents
+- SwiftLint (configuration, rules, custom rules, auto-correct, nested configs)
+- SwiftFormat (configuration, rules, editor integration)
+- Using SwiftLint + SwiftFormat together (conflict avoidance, execution order)
+- CI/CD integration (GitHub Actions, pre-commit hooks)
+- Common pitfalls
+
+
+## SwiftLint
+
+SwiftLint enforces Swift style and conventions via a configurable rule set. It can warn, error, and auto-correct.
+
+### Installation
+
+#### Homebrew
+
+```bash
+brew install swiftlint
+```
+
+#### Mint
+
+```bash
+mint install realm/SwiftLint
+```
+
+#### SPM Build Plugin (recommended for reproducibility)
+
+```swift
+// Package.swift
+let package = Package(
+    name: "MyApp",
+    dependencies: [
+        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.57.0"),
+    ],
+    targets: [
+        .target(
+            name: "MyApp",
+            plugins: [
+                .plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLintPlugins"),
+            ]
+        ),
+    ]
+)
+```
+
+For Xcode projects without SPM, add as a build tool plugin via File > Add Package Dependencies.
+
+### Configuration (`.swiftlint.yml`)
+
+Place `.swiftlint.yml` in the project root. A realistic production configuration:
+
+```yaml
+# .swiftlint.yml
+
+# Only lint project sources, not dependencies or generated code
+included:
+  - Sources
+  - Tests
+
+excluded:
+  - Sources/Generated
+  - Sources/Resources
+  - "**/.build"
+  - "**/DerivedData"
+
+# Disable rules that conflict with SwiftFormat or are too noisy
+disabled_rules:
+  - trailing_comma           # SwiftFormat handles this
+  - opening_brace            # SwiftFormat handles this
+  - vertical_whitespace      # SwiftFormat handles this
+  - todo                     # Useful during development
+
+# Enable recommended opt-in rules
+opt_in_rules:
+  - array_init
+  - attributes
+  - closure_body_length
+  - closure_spacing
+  - collection_alignment
+  - comma_inheritance
+  - contains_over_filter_count
+  - contains_over_first_not_nil
+  - contains_over_range_nil_comparison
+  - convenience_type
+  - discouraged_none_name
+  - discouraged_object_literal
+  - empty_collection_literal
+  - empty_count
+  - empty_string
+  - enum_case_associated_values_count
+  - explicit_init
+  - extension_access_modifier
+  - fallthrough
+  - fatal_error_message
+  - file_name_no_space
+  - first_where
+  - flatmap_over_map_reduce
+  - force_unwrapping
+  - identical_operands
+  - implicit_return
+  - joined_default_parameter
+  - last_where
+  - legacy_multiple
+  - literal_expression_end_indentation
+  - local_doc_comment
+  - lower_acl_than_parent
+  - modifier_order
+  - multiline_arguments
+  - multiline_function_chains
+  - multiline_parameters
+  - number_separator
+  - operator_usage_whitespace
+  - overridden_super_call
+  - override_in_extension
+  - pattern_matching_keywords
+  - prefer_self_in_static_references
+  - prefer_self_type_over_type_of_self
+  - prefer_zero_over_explicit_init
+  - private_action
+  - private_outlet
+  - prohibited_super_call
+  - raw_value_for_camel_cased_codable_enum
+  - reduce_into
+  - redundant_nil_coalescing
+  - redundant_type_annotation
+  - return_value_from_void_function
+  - sorted_first_last
+  - strong_iboutlet
+  - toggle_bool
+  - unavailable_function
+  - unneeded_parentheses_in_closure_argument
+  - unowned_variable_capture
+  - untyped_error_in_catch
+  - vertical_parameter_alignment_on_call
+  - yoda_condition
+
+# Configurable rule thresholds
+line_length:
+  warning: 120
+  error: 200
+  ignores_comments: true
+  ignores_urls: true
+  ignores_interpolated_strings: true
+
+type_body_length:
+  warning: 300
+  error: 500
+
+file_length:
+  warning: 500
+  error: 1000
+  ignore_comment_only_lines: true
+
+function_body_length:
+  warning: 50
+  error: 100
+
+function_parameter_count:
+  warning: 5
+  error: 8
+
+type_name:
+  min_length: 3
+  max_length:
+    warning: 50
+    error: 60
+
+identifier_name:
+  min_length:
+    warning: 2
+    error: 1
+  max_length:
+    warning: 50
+    error: 60
+  excluded:
+    - id
+    - x
+    - y
+    - i
+    - j
+    - to
+
+nesting:
+  type_level:
+    warning: 2
+  function_level:
+    warning: 3
+
+large_tuple:
+  warning: 3
+  error: 4
+
+cyclomatic_complexity:
+  warning: 10
+  error: 20
+
+# Reporter type (xcode, json, csv, checkstyle, codeclimate, github-actions-logging)
+reporter: "xcode"
+```
+
+### Key Rule Categories
+
+#### Style Rules
+
+Rules that enforce consistent code style (indentation, spacing, naming):
+
+- `line_length` — maximum characters per line
+- `identifier_name` — variable/function naming conventions
+- `type_name` — type naming length and format
+- `modifier_order` — consistent ordering of access modifiers
+- `implicit_return` — single-expression returns omit `return`
+
+#### Lint Rules
+
+Rules that detect potential bugs or code smells:
+
+- `force_unwrapping` — flags `!` force unwrap usage
+- `force_cast` — flags `as!` force cast usage
+- `force_try` — flags `try!` usage
+- `unowned_variable_capture` — prefer `weak` over `unowned`
+- `unused_closure_parameter` — replace unused params with `_`
+
+#### Performance Rules
+
+Rules that flag potentially slow patterns:
+
+- `first_where` — use `.first(where:)` instead of `.filter().first`
+- `sorted_first_last` — use `.min()`/`.max()` instead of `.sorted().first`/`.last`
+- `contains_over_filter_count` — use `.contains(where:)` instead of `.filter().count > 0`
+- `reduce_into` — use `reduce(into:)` for reference types
+- `flatmap_over_map_reduce` — use `.flatMap()` instead of `.map().reduce([], +)`
+- `empty_count` — use `.isEmpty` instead of `.count == 0`
+
+#### Idiomatic Rules
+
+Rules that enforce modern Swift idioms:
+
+- `prefer_self_in_static_references` — use `Self` instead of type name in static context
+- `toggle_bool` — use `.toggle()` instead of `x = !x`
+- `legacy_multiple` — use `isMultiple(of:)` instead of `% 2 == 0`
+- `joined_default_parameter` — use `.joined()` instead of `.joined(separator: "")`
+
+### Disabling Rules Inline
+
+```swift
+// Disable a rule for the entire file (place at top)
+// swiftlint:disable force_unwrapping
+
+// Disable for the next line only
+// swiftlint:disable:next force_cast
+let view = object as! UIView
+
+// Disable for the current line
+let url = URL(string: "https://example.com")! // swiftlint:disable:this force_unwrapping
+
+// Disable for a block
+// swiftlint:disable cyclomatic_complexity
+func complexLegacyFunction() {
+    // ... complex logic that cannot be easily refactored
+}
+// swiftlint:enable cyclomatic_complexity
+```
+
+Rules:
+- Prefer fixing the violation over disabling the rule.
+- When disabling, always use the most narrow scope possible (`:next` > `:this` > block > file).
+- Add a comment explaining why the rule is disabled for block-level disables.
+
+### Custom Rules (Regex-Based)
+
+Define project-specific rules directly in `.swiftlint.yml`:
+
+```yaml
+custom_rules:
+  no_print_in_production:
+    name: "No print() in production code"
+    regex: 'print\s*\('
+    match_kinds:
+      - identifier
+    message: "Use os_log or Logger instead of print()"
+    severity: warning
+
+  no_hardcoded_urls:
+    name: "No hardcoded URLs"
+    regex: 'URL\(string:\s*"https?://'
+    message: "Use environment-based URL configuration instead of hardcoded URLs"
+    severity: warning
+
+  no_nslog:
+    name: "No NSLog"
+    regex: 'NSLog\s*\('
+    message: "Use Logger (os.log) instead of NSLog"
+    severity: error
+
+  mark_format:
+    name: "MARK format"
+    regex: '\/\/\s*MARK:\s*[^-\s]'
+    message: "Use '// MARK: - Section Name' with a dash for visual separator"
+    severity: warning
+```
+
+### Auto-Correct
+
+```bash
+# Fix all auto-correctable violations
+swiftlint lint --fix --config .swiftlint.yml
+
+# Fix specific files
+swiftlint lint --fix --path Sources/Models/
+
+# Dry run — show what would be fixed without modifying
+swiftlint lint --config .swiftlint.yml
+```
+
+Rules:
+- Always review auto-correct changes before committing.
+- Run auto-correct before linting in CI to reduce noise.
+- Not all rules are auto-correctable — some require manual fixes.
+
+### Nested Configurations
+
+Place additional `.swiftlint.yml` files in subdirectories to override the root config:
+
+```
+MyProject/
+├── .swiftlint.yml              # Root config
+├── Sources/
+│   └── .swiftlint.yml          # Stricter rules for production code
+└── Tests/
+    └── .swiftlint.yml          # Relaxed rules for test code
+```
+
+```yaml
+# Tests/.swiftlint.yml — relax rules for test code
+disabled_rules:
+  - force_unwrapping       # Acceptable in tests
+  - force_cast             # Acceptable in tests
+  - function_body_length   # Test methods can be longer
+  - type_body_length       # Test classes can be larger
+  - file_length            # Test files can be larger
+  - identifier_name        # Shorter names OK in tests
+
+line_length:
+  warning: 150
+  error: 250
+```
+
+Child configs inherit from the parent and can override any setting.
+
+
+## SwiftFormat
+
+SwiftFormat reformats Swift code automatically. Where SwiftLint detects problems, SwiftFormat fixes formatting without human intervention.
+
+### Installation
+
+#### Homebrew
+
+```bash
+brew install swiftformat
+```
+
+#### Mint
+
+```bash
+mint install nicklockwood/SwiftFormat
+```
+
+#### SPM Build Plugin
+
+```swift
+// Package.swift
+let package = Package(
+    name: "MyApp",
+    dependencies: [
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.55.0"),
+    ],
+    targets: [
+        .target(
+            name: "MyApp",
+            plugins: [
+                .plugin(name: "SwiftFormatPlugin", package: "SwiftFormat"),
+            ]
+        ),
+    ]
+)
+```
+
+### Configuration (`.swiftformat`)
+
+Place `.swiftformat` in the project root. A realistic production configuration:
+
+```
+# .swiftformat
+
+# File options
+--exclude DerivedData,**/.build,Sources/Generated
+
+# Formatting rules
+--indent 4
+--indentcase false
+--trimwhitespace always
+--voidtype void
+--wraparguments before-first
+--wrapparameters before-first
+--wrapcollections before-first
+--wrapconditions after-first
+--wrapreturntype preserve
+--maxwidth 120
+--closingparen balanced
+--commas always
+--decimalgrouping 3
+--exponentcase lowercase
+--extensionacl on-extension
+--fractiongrouping disabled
+--header ignore
+--hexgrouping 4,8
+--hexliteralcase uppercase
+--ifdef indent
+--importgrouping alpha
+--nospaceoperators ..<,...
+--operatorfunc spaced
+--patternlet hoist
+--ranges spaced
+--redundanttype inferred
+--self remove
+--semicolons inline
+--stripunusedargs closure-only
+--swiftversion 6.0
+--typeattributes prev-line
+--varattributes same-line
+--funcattributes prev-line
+--storedvarattrs same-line
+--computedvarattrs same-line
+
+# Disable rules that conflict with SwiftLint or project conventions
+--disable blankLinesAtStartOfScope
+--disable blankLinesAtEndOfScope
+
+# Enable additional rules
+--enable isEmpty
+--enable markTypes
+--enable sortSwitchCases
+--enable wrapMultilineStatementBraces
+--enable docComments
+--enable blockComments
+```
+
+### Key Formatting Rules
+
+| Rule | What It Does |
+|---|---|
+| `redundantSelf` | Removes unnecessary `self.` |
+| `trailingCommas` | Adds/removes trailing commas in collections |
+| `unusedArguments` | Replaces unused closure args with `_` |
+| `redundantReturn` | Removes `return` from single-expression functions |
+| `sortImports` | Alphabetizes import statements |
+| `wrapArguments` | Wraps function arguments consistently |
+| `braces` | Enforces brace placement (K&R style) |
+| `indent` | Normalizes indentation |
+| `blankLinesBetweenScopes` | Adds blank lines between type/function declarations |
+| `markTypes` | Adds `// MARK: -` comments for type extensions |
+| `isEmpty` | Replaces `.count == 0` with `.isEmpty` |
+| `consecutiveSpaces` | Collapses multiple spaces |
+
+### SwiftFormat vs SwiftLint — What Each Handles Best
+
+| Concern | SwiftFormat | SwiftLint |
+|---|---|---|
+| Indentation | Best — auto-fixes | Detects but limited auto-fix |
+| Brace placement | Best — auto-fixes | Detects only |
+| Import sorting | Best — auto-fixes | Not covered |
+| Trailing commas | Best — auto-fixes | Detects only |
+| Redundant code | Good — removes redundant `self`, `return` | Detects broader patterns |
+| Naming conventions | Not covered | Best — configurable rules |
+| Code complexity | Not covered | Best — cyclomatic complexity, body length |
+| Code smells | Not covered | Best — force unwrap, force cast, etc. |
+| Force unwrapping | Not covered | Best — warns/errors |
+| Custom rules | Not supported | Best — regex-based custom rules |
+
+### Editor Integration
+
+Install the SwiftFormat for Xcode extension from the Mac App Store, or run via command palette in VS Code with the SwiftFormat extension. For Xcode:
+
+1. Install SwiftFormat for Xcode from the App Store
+2. Enable in System Settings > Privacy & Security > Extensions > Xcode Source Editor
+3. Use Editor > SwiftFormat > Format File (bind to a keyboard shortcut)
+
+
+## Using SwiftLint + SwiftFormat Together
+
+The key is avoiding conflicts — disable formatting-related rules in SwiftLint and let SwiftFormat handle them.
+
+### Recommended Setup
+
+#### Rules to disable in SwiftLint (let SwiftFormat handle these):
+
+```yaml
+# .swiftlint.yml — disable rules that SwiftFormat handles better
+disabled_rules:
+  - trailing_comma
+  - opening_brace
+  - vertical_whitespace
+  - statement_position
+  - return_arrow_whitespace
+  - colon
+  - comma
+  - leading_whitespace
+  - trailing_newline
+  - trailing_semicolon
+  - trailing_whitespace
+```
+
+#### Rules to keep in SwiftLint (SwiftFormat cannot enforce these):
+
+```yaml
+# These stay in SwiftLint — SwiftFormat has no equivalent
+# Default rules (already enabled, just ensure they are not disabled):
+#   cyclomatic_complexity, function_body_length, type_body_length,
+#   file_length, identifier_name, type_name
+# Opt-in rules to add:
+opt_in_rules:
+  - force_unwrapping
+  - empty_count
+  - first_where
+  - contains_over_filter_count
+  - unowned_variable_capture
+```
+
+#### Execution order:
+
+1. **SwiftFormat first** — auto-fix formatting
+2. **SwiftLint second** — check remaining rules
+
+In build phases, place SwiftFormat before SwiftLint. In CI, run format-check before lint.
+
+
+## CI/CD Integration
+
+### GitHub Actions Workflow
+
+```yaml
+# .github/workflows/swift-quality.yml
+name: Swift Code Quality
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - '**/*.swift'
+      - '.swiftlint.yml'
+      - '.swiftformat'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-format:
+    name: SwiftLint & SwiftFormat
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: |
+          brew install swiftlint swiftformat
+
+      - name: SwiftFormat check (no modifications)
+        run: |
+          swiftformat --lint --config .swiftformat Sources/ Tests/
+
+      - name: SwiftLint
+        run: |
+          swiftlint lint --strict --config .swiftlint.yml --reporter github-actions-logging
+```
+
+Rules:
+- Use `--reporter github-actions-logging` with SwiftLint to annotate PRs inline.
+- Use `swiftformat --lint` (not `swiftformat`) in CI to check without modifying files.
+- Use `--strict` with SwiftLint to treat warnings as errors in CI.
+
+### Pre-Commit Hooks
+
+```bash
+#!/bin/bash
+# .git/hooks/pre-commit
+
+# Get staged Swift files
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.swift$')
+
+if [ -z "$STAGED_FILES" ]; then
+    exit 0
+fi
+
+echo "Running SwiftFormat on staged files..."
+echo "$STAGED_FILES" | xargs swiftformat --config .swiftformat
+
+echo "Running SwiftLint on staged files..."
+echo "$STAGED_FILES" | xargs swiftlint lint --strict --config .swiftlint.yml
+
+LINT_STATUS=$?
+
+# Re-stage formatted files
+echo "$STAGED_FILES" | xargs git add
+
+if [ $LINT_STATUS -ne 0 ]; then
+    echo "SwiftLint found violations. Please fix them before committing."
+    exit 1
+fi
+
+exit 0
+```
+
+Make executable: `chmod +x .git/hooks/pre-commit`
+
+For team-wide hooks, use a shared hooks directory:
+
+```bash
+# Set hooks path for the repo
+git config core.hooksPath .githooks/
+
+# Place pre-commit in .githooks/pre-commit (committed to repo)
+```
+
+
+## Common Pitfalls
+
+| Pitfall | Fix |
+|---|---|
+| Over-configuring linting (too many rules enabled) | Start with defaults, enable opt-in rules incrementally. If developers routinely disable rules inline, the rule is too strict |
+| Inconsistent configs across modules | Use a single root `.swiftlint.yml` with nested overrides only where necessary (e.g., relaxed test rules) |
+| Not auto-fixing what can be auto-fixed | Run `swiftlint lint --fix` and `swiftformat` before linting. Reduces noise and developer friction |
+| Running linters before formatters | Always run SwiftFormat first, then SwiftLint. Formatting changes may resolve lint violations |
+| SwiftLint and SwiftFormat conflicting on the same rules | Disable formatting rules in SwiftLint, let SwiftFormat handle them exclusively |
+| Not pinning tool versions | Different SwiftLint/SwiftFormat versions may produce different results. Pin versions via SPM plugins or Mint |
+| Not configuring `excluded` paths | Generated code, vendored code, and build artifacts produce irrelevant violations. Always exclude them |

--- a/registry/skills/swift-development/references/static-analysis.md
+++ b/registry/skills/swift-development/references/static-analysis.md
@@ -1,6 +1,6 @@
 # Static Analysis Reference (SwiftLint & SwiftFormat)
 
-Covers SwiftLint and SwiftFormat — the two primary Swift static analysis and formatting tools. They are complementary: SwiftLint detects code smells and enforces conventions, SwiftFormat auto-fixes formatting. Use both together. For Apple platform-specific quality tools (Xcode Static Analyzer, sanitizers, Periphery), see the `apple-app-development` skill's `references/code-quality.md`.
+Covers SwiftLint and SwiftFormat — the two primary Swift static analysis and formatting tools. They are complementary: SwiftLint detects code smells and enforces conventions, SwiftFormat auto-fixes formatting. Use both together. Applicable to all Swift targets: Apple platforms, server-side (Vapor, Hummingbird), CLI tools, cross-platform (Linux, Windows).
 
 ## Contents
 - SwiftLint (configuration, rules, custom rules, auto-correct, nested configs)

--- a/registry/skills/swift-development/references/static-analysis.md
+++ b/registry/skills/swift-development/references/static-analysis.md
@@ -319,14 +319,14 @@ swiftlint lint --config .swiftlint.yml
 
 Rules:
 - Always review auto-correct changes before committing.
-- Run auto-correct before linting in CI to reduce noise.
+- Run auto-correct locally before committing; keep CI check-only to avoid mutating the workspace.
 - Not all rules are auto-correctable — some require manual fixes.
 
 ### Nested Configurations
 
 Place additional `.swiftlint.yml` files in subdirectories to override the root config:
 
-```
+```text
 MyProject/
 ├── .swiftlint.yml              # Root config
 ├── Sources/


### PR DESCRIPTION
⏺ ## Summary
  - Add `testing.md` to apple-app-development — Swift Testing, XCTest, XCUITest, test doubles, snapshot testing, test plans, CI/CD, TDD
  - Add `code-quality.md` to apple-app-development — Xcode Static Analyzer, sanitizers (ASan/TSan/UBSan), Periphery, Danger-Swift, Xcode build settings
  - Add `static-analysis.md` to swift-development — SwiftLint, SwiftFormat, combined setup, pre-commit hooks, CI integration
  - Update SKILL.md files with new reference listings and cross-references

  ## Architecture decision
  Language-level linting (SwiftLint/SwiftFormat) lives in `swift-development` skill — applicable to server-side Swift, CLI tools, and Apple platforms alike. Platform-specific quality tools (Xcode
  Analyzer, sanitizers, Periphery) stay in `apple-app-development`. This mirrors the existing Kotlin/Android split (`kotlin-development/static-analysis.md` +
  `google-app-development/code-quality.md`).

  ## New references

  | File | Lines | Scope |
  |------|-------|-------|
  | `apple-app-development/references/testing.md` | 1,348 | Swift Testing, XCTest, XCUITest, test doubles, @Observable testing, snapshot tests, test plans, CI/CD, TDD |
  | `apple-app-development/references/code-quality.md` | 404 | Xcode Static Analyzer, sanitizers, Periphery, Danger-Swift, build settings, xcconfig |
  | `swift-development/references/static-analysis.md` | 642 | SwiftLint config/rules/custom rules, SwiftFormat config, combined setup, GitHub Actions, pre-commit hooks |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Apple-platform and Swift Development guidance across SwiftUI, Swift 6+ concurrency, testing, localization, app lifecycle, networking, persistence, and platform-specific patterns.
  * Added new reference pages for testing, localization, code-quality/static analysis, and consolidated Swift static-analysis tooling.
  * Refreshed examples and rules for modern iOS/iPadOS/watchOS/tvOS/visionOS/macOS practices, including updated StoreKit deprecations, safer async networking patterns, improved external display handling, stricter localization requirements, and updated ObjC interoperability and multi-target guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->