### PR TITLE
Add Confluence publishing reference to docs-that-work skill

### DIFF
--- a/registry/skills/docs-that-work/SKILL.md
+++ b/registry/skills/docs-that-work/SKILL.md
@@ -3,7 +3,8 @@ name: docs-that-work
 description: >-
   Project documentation guidelines. Use when asked to "write documentation",
   "create a CLAUDE.md", "write a README", "document this project",
-  "improve documentation", or when creating/updating CLAUDE.md or README.md files.
+  "improve documentation", "publish to Confluence", or when creating/updating
+  CLAUDE.md or README.md files.
 ---
 
 # Docs That Work
@@ -83,7 +84,8 @@ If you're unsure whether something needs docs, apply the three-question test fro
 
 ## Deep Dives
 
-| Topic                                                  | Reference                       |
-| ------------------------------------------------------ | ------------------------------- |
-| CLAUDE.md and README templates                         | `references/claude-md-guide.md` |
-| Anti-patterns, bloat examples, the three-question test | `references/anti-patterns.md`   |
+| Topic                                                  | Reference                              |
+| ------------------------------------------------------ | -------------------------------------- |
+| CLAUDE.md and README templates                         | `references/claude-md-guide.md`        |
+| Anti-patterns, bloat examples, the three-question test | `references/anti-patterns.md`          |
+| Confluence publishing and sync                         | `references/confluence-publishing.md`  |

--- a/registry/skills/docs-that-work/references/confluence-publishing.md
+++ b/registry/skills/docs-that-work/references/confluence-publishing.md
@@ -1,0 +1,43 @@
+# Confluence Publishing
+
+## Markdown to Confluence Storage Format
+
+| Markdown | Confluence Storage Format |
+|----------|--------------------------|
+| `# Heading` | `<h1>Heading</h1>` |
+| `**bold**` | `<strong>bold</strong>` |
+| `` `code` `` | `<code>code</code>` |
+| Code blocks | `<ac:structured-macro ac:name="code">` |
+| Tables | `<table><tr><th>...</th></tr></table>` |
+| Links | `<a href="...">text</a>` |
+| Images | `<ac:image><ri:url ri:value="..." /></ac:image>` |
+| Info boxes | `<ac:structured-macro ac:name="info">` |
+
+## Page Creation Workflow
+
+1. **Source credentials** — load .env file
+2. **Identify target space** — ask user or use provided `--space` parameter
+3. **Check for existing page** — search by title via API to avoid duplicates
+4. **Convert content** — Markdown to Confluence Storage Format
+5. **Create/update page** — via Confluence MCP server
+6. **Add labels** — auto-generated, auto-docs, repo name, doc type
+7. **Verify publication** — fetch page back and confirm formatting
+8. **Report result** — display page URL, space, and parent location
+
+## Page Update Strategy
+
+- Compare content hash to detect changes
+- Preserve existing page metadata (labels, watchers, restrictions)
+- Increment version number for Confluence versioning
+- Add update note: "Auto-updated from <repo> on <date>"
+
+## Sync with Git
+
+Use `git log --since="<last-sync-date>" --name-only` to detect repo changes since the last sync. Filter for doc-relevant paths (README, docs/, api/, schema, models, routes, controllers).
+
+1. Fetch current Confluence page content via API
+2. Re-analyze repository for changes
+3. Generate updated documentation sections
+4. Diff old vs new content
+5. Update only changed sections — preserve manual edits
+6. Update sync timestamp label


### PR DESCRIPTION
## Summary

Adds Confluence publishing guidance to the existing `docs-that-work` skill rather than creating a separate documentation skill.

**Changes:**
- New `references/confluence-publishing.md` — Markdown-to-Storage-Format conversion table, page creation/update workflow, sync strategy with git change detection
- Updated skill description to include "publish to Confluence" as a trigger
- Added reference link to the Deep Dives table

Replaces the closed PR #42 (`documentation-engineering` skill) which had significant overlap with `docs-that-work`.

## Test plan

- [x] `uv run python -m awos_recruitment_mcp.validate` — all 27 entries valid