### PR TITLE
Add skill for QA API tests generation

### DIFF
--- a/registry/skills/api-test-gen/SKILL.md
+++ b/registry/skills/api-test-gen/SKILL.md
@@ -1,0 +1,357 @@
+---
+name: api-test-gen
+description: >
+  Generate automated API test suites with typed models from OpenAPI/Swagger specs,
+  Postman collections, GraphQL schemas, or plain API descriptions. Produces
+  TypeScript/Playwright or Python/pytest test files, typed request/response models,
+  full project scaffolding, and an HTML report. Trigger for: "generate tests from swagger",
+  "create API tests from OpenAPI", "generate playwright tests from spec", "generate typed
+  models from spec", "create test project from postman collection", "test this API spec",
+  "generate API test project", "show API test report", "write API tests for this endpoint",
+  "generate tests for my REST API". Also trigger if the user uploads or pastes a spec,
+  describes API endpoints, or mentions testing or models in an API context.
+---
+
+# API Test Generator
+
+Full test lifecycle from spec to HTML report — runs entirely inside Claude Code with no external dependencies beyond Node.js/Python.
+
+**Workflow (always follow in order):**
+1. [Ingest spec](#step-1--ingest-spec) — parse and model the API
+2. [Configure env](#step-2--configure-env) — set base URL, auth, output dir
+3. [Generate scenarios](#step-3--generate-scenarios) — happy path + negative + edge cases
+4. [Generate models](#step-3b--generate-models) — typed request/response objects per schema
+5. [Generate test cases](#step-4--generate-test-cases) — write runnable code files using models
+6. [Generate project scaffold](#step-5--generate-project-scaffold) — dependencies, config, runner
+7. [Run tests](#step-6--run-tests) — execute and capture results
+8. [Generate HTML report](#step-7--generate-html-report) — human-readable results
+
+Skip steps 7–8 if the user only wants the generated files, not execution.
+
+---
+
+## Step 1 — Ingest Spec
+
+**Supported input types:**
+- OpenAPI 3.x (JSON or YAML)
+- Swagger 2.0 (JSON or YAML)
+- Postman Collection v2.1 (JSON)
+- GraphQL schema (SDL or introspection JSON) — see `references/graphql.md`
+
+**How to receive the spec:**
+- File path provided → read from filesystem
+- URL provided → fetch with `curl` or Python `requests`
+- Pasted inline → write to temp file first
+- No spec provided → ask the user to describe endpoints (method, path, request/response shape); construct the endpoint model manually from their description
+
+**Parse and extract this model per endpoint:**
+```
+{
+  method, path, operationId, tag, summary,
+  parameters: [{ name, in, required, schema, example }],
+  requestBody: { required, mediaType, schema, example },
+  responses: { "200": { schema }, "400": { schema }, ... },
+  security: [{ type: bearer|apikey|basic|oauth2, name }],
+  deprecated: bool
+}
+```
+
+**$ref resolution:** fully resolve all `$ref` chains before modelling. Handle
+`allOf`/`oneOf`/`anyOf` by flattening to the most concrete representative variant.
+
+**Postman → endpoint model:** map each `request` item in the collection to the same
+endpoint model above. Infer schema from example bodies.
+
+After parsing, print a **summary table:**
+```
+Spec loaded: <title> v<version>
+Endpoints: <N>  |  Tags: <list>  |  Auth schemes: <list>
+Frameworks available: typescript/playwright, python/pytest
+```
+
+---
+
+## Step 2 — Configure Env
+
+Ask the user (or infer from context) for:
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `BASE_URL` | API base URL | prompt user |
+| `auth_bearer` | Bearer token | env var `API_TOKEN` |
+| `auth_apikey` | API key value | env var `API_KEY` |
+| `auth_apikey_header` | API key header name | `X-API-Key` |
+| `auth_basic` | base64 user:pass | env var `API_BASIC` |
+| `OUTPUT_DIR` | where to write files | `./api-tests` |
+| `LANGUAGE` | target framework | ask user |
+| `RUN_LOAD_TESTS` | include load tests | false |
+
+**Never hardcode secrets.** Write a `.env.example` with placeholder values.
+
+---
+
+## Step 3 — Generate Scenarios
+
+For each endpoint, generate scenario objects (not code yet — just structured data):
+
+```json
+{
+  "operationId": "createUser",
+  "method": "POST",
+  "path": "/users",
+  "scenarios": [
+    { "id": "happy_valid_body", "type": "happy", "description": "valid body → 201" },
+    { "id": "neg_missing_email", "type": "negative", "description": "missing required email → 422" },
+    { "id": "neg_wrong_type_age", "type": "negative", "description": "age is string not int → 422" },
+    { "id": "neg_no_auth", "type": "negative", "description": "no auth token → 401" },
+    { "id": "edge_max_name", "type": "edge", "description": "name at maxLength boundary" },
+    { "id": "edge_min_name", "type": "edge", "description": "name at minLength boundary" }
+  ]
+}
+```
+
+**Scenario types to always include:**
+- `happy` — one per endpoint with valid data from spec examples (or synthesized)
+- `negative` — one per required field (missing), one for wrong type, one for no-auth
+- `edge` — one per constraint (`minimum`, `maximum`, `minLength`, `maxLength`, `enum` invalid)
+
+**CRUD workflow detection:** if endpoints match `POST /resource` + `GET /resource/{id}` +
+`PUT|PATCH /resource/{id}` + `DELETE /resource/{id}`, add a `workflow` scenario that chains them.
+
+**Print scenario summary:**
+```
+Scenarios generated: <N total>
+  happy: <N>  |  negative: <N>  |  edge: <N>  |  workflow: <N>
+```
+
+If `include_negative_tests=false` was requested, skip negative/edge scenarios.
+
+---
+
+## Step 3b — Generate Models
+
+Generate typed model classes/interfaces from all schemas in the spec. Models are used
+in test files instead of inline raw dicts — improving readability, reuse, and type safety.
+
+**File location:**
+```
+api-tests/models/          ← one file per OpenAPI tag or schema group
+  user.ts / user.py
+  pet.ts  / pet.py
+  store.ts / store.py
+```
+
+**TypeScript — interfaces:**
+```typescript
+// models/user.ts
+export interface CreateUserRequest {
+  name: string;
+  email: string;
+  age?: number;
+}
+
+export interface CreateUserResponse {
+  id: string;
+  name: string;
+  email: string;
+  createdAt: string;
+}
+
+export interface UserListResponse {
+  items: CreateUserResponse[];
+  total: number;
+}
+```
+
+**Python — dataclasses:**
+```python
+# models/user.py
+from dataclasses import dataclass, field
+from typing import Optional, List
+
+@dataclass
+class CreateUserRequest:
+    name: str
+    email: str
+    age: Optional[int] = None
+
+@dataclass
+class CreateUserResponse:
+    id: str
+    name: str
+    email: str
+    created_at: str
+
+@dataclass
+class UserListResponse:
+    items: List[CreateUserResponse] = field(default_factory=list)
+    total: int = 0
+```
+
+**Naming rules:**
+- Request body schema → `<OperationId>Request`
+- Response body schema → `<OperationId>Response` (per status code if multiple)
+- Reusable component schema → use its `$components/schemas/<Name>` name as-is
+- Path/query parameter objects → `<OperationId>Params`
+
+**Type mapping (OpenAPI → TypeScript / Python):**
+
+| OpenAPI type | TypeScript | Python |
+|---|---|---|
+| `string` | `string` | `str` |
+| `string/date-time` | `string` | `str` |
+| `string/uuid` | `string` | `str` |
+| `integer` | `number` | `int` |
+| `number` | `number` | `float` |
+| `boolean` | `boolean` | `bool` |
+| `array` | `T[]` | `List[T]` |
+| `object` (inline) | nested `interface` | nested `@dataclass` |
+| optional field | `field?: T` | `Optional[T] = None` |
+
+**Models are imported in test files:**
+```typescript
+// TypeScript — import and use in test
+import { CreateUserRequest, CreateUserResponse } from '../models/user';
+
+const payload: CreateUserRequest = { name: 'test-string-name', email: 'test@example.com' };
+const res = await api.post('/users', { data: payload });
+const body = await res.json() as CreateUserResponse;
+expect(body.id).toBeTruthy();
+```
+
+```python
+# Python — import and use in test
+from models.user import CreateUserRequest, CreateUserResponse
+import dacite
+
+payload = CreateUserRequest(name='test-string-name', email='test@example.com')
+res = api.post('/users', json=asdict(payload))
+body = dacite.from_dict(CreateUserResponse, res.json())
+assert body.id
+```
+
+**Edge cases:**
+- `allOf` → merge all fields into one interface/dataclass
+- `oneOf` / `anyOf` → generate a `Union` type (Python) or type alias (TypeScript)
+- Circular references → use `interface` forward reference or `Optional` with string annotation
+- Schema with no properties → generate empty interface/dataclass with a TODO comment
+
+---
+
+## Step 4 — Generate Test Cases
+
+Read the appropriate reference file for the chosen framework:
+- TypeScript + Playwright → `references/playwright-ts.md`
+- Python + pytest → `references/pytest.md`
+
+Then write the actual test files following that reference's conventions exactly.
+
+**File naming:** one file per OpenAPI tag (or `general` if no tags). Example:
+```
+api-tests/tests/users.spec.ts
+api-tests/tests/pets.spec.ts
+```
+
+**Test naming convention (always):**
+`test_<method>_<path_slug>_<scenario_id>`
+Example: `test_post_users_happy_valid_body`
+
+**Data synthesis rules (when no example in spec):**
+- `string` → `"test-string-<field-name>"`
+- `string/email` → `"test@example.com"`
+- `string/uuid` → `"00000000-0000-0000-0000-000000000001"`
+- `integer` → midpoint of min/max range, or `1`
+- `boolean` → `true`
+- `array` → one-element array of the item type
+- `object` → synthesize all required fields recursively
+
+---
+
+## Step 5 — Generate Project Scaffold
+
+Generate a complete runnable project. Read `references/scaffold.md` for the exact file
+structure and templates per framework.
+
+Always include:
+- `package.json` / `requirements.txt` with all dependencies
+- Framework config file (`playwright.config.ts`, `pytest.ini`)
+- `.env.example` with all required variables
+- `README.md` with install + run instructions
+- `models/` directory with generated model files
+- `reports/` directory (empty, for HTML output)
+
+---
+
+## Step 6 — Run Tests
+
+Only run if the user explicitly asks to execute tests AND a `BASE_URL` is configured.
+
+```bash
+cd $OUTPUT_DIR
+
+# TypeScript/Playwright
+npm install
+npx playwright test --reporter=html
+
+# Python/pytest
+pip install -r requirements.txt --break-system-packages
+pytest tests/ -v --json-report --json-report-file=reports/results.json
+```
+
+Capture stdout/stderr. Parse results to extract:
+- total, passed, failed, skipped
+- per-test: name, status, duration, error message if failed
+
+---
+
+## Step 7 — Generate HTML Report
+
+Always generate an HTML report — even if tests weren't run (show "generated, not executed").
+
+Read `references/report-template.md` for the exact HTML template.
+
+The report must include:
+- Summary bar: total / passed / failed / skipped + pass rate %
+- Per-tag sections with expandable test rows
+- Status badges (green/red/grey)
+- Error details inline for failures
+- Timestamp and spec metadata in the header
+- Coverage table: endpoint × scenario type matrix
+
+Write to `$OUTPUT_DIR/reports/index.html` and present it to the user.
+
+---
+
+## Load Testing (optional)
+
+If `RUN_LOAD_TESTS=true` or user asks for load/performance tests, read `references/load-tests.md`.
+Uses `autocannon` (Node) or `locust` (Python) depending on framework choice.
+
+Default load profile: 10 virtual users, 30 seconds, ramp-up 5s.
+
+---
+
+## Edge Cases
+
+| Situation | Handling |
+|---|---|
+| No examples in spec | Synthesize from type + format + constraints |
+| Circular `$ref` | Detect and break; use `{}` placeholder with TODO comment |
+| `oneOf`/`anyOf` request body | Generate one test variant per branch |
+| File upload (`multipart/form-data`) | Generate with mock file path; flag for manual review |
+| OAuth2 flows | Generate token-fetch helper using env vars; note manual step |
+| Deprecated endpoints | Generate tests but mark `@deprecated` in comment |
+| Missing `responses` in spec | Assert only 2xx; add TODO comment |
+| GraphQL | See `references/graphql.md` |
+
+---
+
+## Quality Rules (always apply)
+
+- No hardcoded secrets — all credentials via env vars
+- Test isolation — each test cleans up its own created resources
+- Descriptive names — `test_post_users_neg_missing_email` not `test3`
+- Typed models — always import from `models/` instead of using inline dicts
+- Single assertion focus — one logical assertion per test where possible
+- Idempotent — tests can re-run without side effects
+- Imports only from generated project, no ad-hoc dependencies

--- a/registry/skills/api-test-gen/references/graphql.md
+++ b/registry/skills/api-test-gen/references/graphql.md
@@ -1,0 +1,76 @@
+# GraphQL Reference
+
+## Supported input formats
+- SDL schema file (`.graphql` / `.gql`)
+- Introspection JSON (from `__schema` query)
+
+## Parse model
+For each query/mutation/subscription in the schema extract:
+```
+{
+  operation: query|mutation|subscription,
+  name, arguments: [{ name, type, required }],
+  returnType
+}
+```
+
+## Test framework: Playwright TS (default for GraphQL)
+
+```typescript
+// tests/graphql/<operation>.spec.ts
+import { test, expect } from '../fixtures';
+
+const GQL_ENDPOINT = '/graphql';
+
+test.describe('Query: getUser', () => {
+
+  test('test_query_getUser_happy_valid_id', async ({ api }) => {
+    const res = await api.post(GQL_ENDPOINT, {
+      data: {
+        query: `query GetUser($id: ID!) { getUser(id: $id) { id name email } }`,
+        variables: { id: '00000000-0000-0000-0000-000000000001' }
+      }
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).not.toHaveProperty('errors');
+    expect(body.data.getUser).toHaveProperty('id');
+  });
+
+  test('test_query_getUser_neg_missing_id', async ({ api }) => {
+    const res = await api.post(GQL_ENDPOINT, {
+      data: {
+        query: `query GetUser($id: ID!) { getUser(id: $id) { id } }`,
+        variables: {}
+      }
+    });
+    const body = await res.json();
+    expect(body).toHaveProperty('errors');
+  });
+
+});
+
+test.describe('Mutation: createUser', () => {
+
+  test('test_mutation_createUser_happy_valid_input', async ({ api }) => {
+    const res = await api.post(GQL_ENDPOINT, {
+      data: {
+        query: `mutation CreateUser($input: CreateUserInput!) {
+          createUser(input: $input) { id name email }
+        }`,
+        variables: { input: { name: 'test-string-name', email: 'test@example.com' } }
+      }
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).not.toHaveProperty('errors');
+    expect(body.data.createUser).toHaveProperty('id');
+  });
+
+});
+```
+
+## Notes
+- GraphQL always returns 200; check `body.errors` for failures
+- Auth is handled identically to REST (Bearer/API Key in headers)
+- Load tests: same endpoint `/graphql` for all operations

--- a/registry/skills/api-test-gen/references/load-tests.md
+++ b/registry/skills/api-test-gen/references/load-tests.md
@@ -1,0 +1,100 @@
+# Load Testing Reference
+
+## Default profile
+- Virtual users: 10
+- Duration: 30 seconds
+- Ramp-up: 5 seconds
+- Target: happy-path endpoints only
+
+## Node.js — autocannon
+
+```typescript
+// load-tests/run-load.ts
+import autocannon from 'autocannon';
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+const BASE_URL = process.env.BASE_URL!;
+const AUTH = process.env.auth_bearer
+  ? { Authorization: `Bearer ${process.env.auth_bearer}` }
+  : {};
+
+async function runLoad(path: string, method: string, body?: object) {
+  const result = await autocannon({
+    url: `${BASE_URL}${path}`,
+    connections: 10,        // virtual users
+    duration: 30,           // seconds
+    method: method as any,
+    headers: { 'Content-Type': 'application/json', ...AUTH },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return {
+    path,
+    method,
+    requests: result.requests,
+    latency: result.latency,
+    throughput: result.throughput,
+    errors: result.errors,
+  };
+}
+
+// Generated load test calls — one per happy-path endpoint
+async function main() {
+  const results = [];
+  // results.push(await runLoad('/users', 'GET'));
+  // results.push(await runLoad('/users', 'POST', { name: 'load-user', email: 'load@example.com' }));
+  console.table(results.map(r => ({
+    endpoint: `${r.method} ${r.path}`,
+    'req/sec': r.requests.mean,
+    'p99 latency ms': r.latency.p99,
+    errors: r.errors,
+  })));
+}
+
+main();
+```
+
+## Python — locust
+
+```python
+# load-tests/locustfile.py
+import os
+from locust import HttpUser, task, between
+from dotenv import load_dotenv
+load_dotenv()
+
+class APIUser(HttpUser):
+    wait_time = between(0.1, 0.5)
+    headers = {}
+
+    def on_start(self):
+        if os.getenv("auth_bearer"):
+            self.headers = {"Authorization": f"Bearer {os.getenv('auth_bearer')}"}
+
+    # Generated task per happy-path endpoint
+    # @task
+    # def get_users(self):
+    #     self.client.get("/users", headers=self.headers)
+
+    # @task
+    # def create_user(self):
+    #     self.client.post("/users",
+    #       json={"name": "load-user", "email": "load@example.com"},
+    #       headers=self.headers)
+```
+
+## Run commands
+
+Node autocannon:
+```bash
+npm install autocannon
+npx ts-node load-tests/run-load.ts
+```
+
+Python locust:
+```bash
+pip install locust --break-system-packages
+locust -f load-tests/locustfile.py --headless \
+  --host $BASE_URL -u 10 -r 2 --run-time 30s \
+  --html reports/load-report.html
+```

--- a/registry/skills/api-test-gen/references/playwright-ts.md
+++ b/registry/skills/api-test-gen/references/playwright-ts.md
@@ -1,0 +1,229 @@
+# TypeScript + Playwright Reference
+
+## Project layout
+```
+api-tests/
+├── playwright.config.ts
+├── package.json
+├── .env.example
+├── tests/
+│   ├── fixtures.ts          # shared APIRequestContext + auth
+│   ├── <tag>.spec.ts        # one file per OpenAPI tag
+│   └── workflows/
+│       └── <tag>-workflow.spec.ts
+├── helpers/
+│   ├── factories.ts         # data synthesizers per schema
+│   └── schema-validator.ts  # response schema assertions
+└── reports/                 # HTML output goes here
+```
+
+## playwright.config.ts
+```typescript
+import { defineConfig } from '@playwright/test';
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+export default defineConfig({
+  testDir: './tests',
+  reporter: [
+    ['html', { outputFolder: 'reports', open: 'never' }],
+    ['json', { outputFile: 'reports/results.json' }],
+    ['list']
+  ],
+  use: {
+    baseURL: process.env.BASE_URL,
+    extraHTTPHeaders: buildAuthHeaders(),
+  },
+});
+
+function buildAuthHeaders(): Record<string, string> {
+  if (process.env.auth_bearer) return { Authorization: `Bearer ${process.env.auth_bearer}` };
+  if (process.env.auth_apikey) return { [process.env.auth_apikey_header || 'X-API-Key']: process.env.auth_apikey };
+  if (process.env.auth_basic)  return { Authorization: `Basic ${process.env.auth_basic}` };
+  return {};
+}
+```
+
+## fixtures.ts
+```typescript
+import { test as base, APIRequestContext } from '@playwright/test';
+
+type Fixtures = { api: APIRequestContext; anonApi: APIRequestContext };
+
+export const test = base.extend<Fixtures>({
+  api: async ({ playwright }, use) => {
+    const ctx = await playwright.request.newContext({
+      baseURL: process.env.BASE_URL,
+      extraHTTPHeaders: buildAuthHeaders(),
+    });
+    await use(ctx);
+    await ctx.dispose();
+  },
+  anonApi: async ({ playwright }, use) => {
+    const ctx = await playwright.request.newContext({ baseURL: process.env.BASE_URL });
+    await use(ctx);
+    await ctx.dispose();
+  },
+});
+
+export { expect } from '@playwright/test';
+
+function buildAuthHeaders(): Record<string, string> {
+  if (process.env.auth_bearer) return { Authorization: `Bearer ${process.env.auth_bearer}` };
+  if (process.env.auth_apikey) return { [process.env.auth_apikey_header || 'X-API-Key']: process.env.auth_apikey };
+  if (process.env.auth_basic)  return { Authorization: `Basic ${process.env.auth_basic}` };
+  return {};
+}
+```
+
+## Test file template
+```typescript
+import { test, expect } from './fixtures';
+
+test.describe('POST /users', () => {
+
+  test('test_post_users_happy_valid_body', async ({ api }) => {
+    const res = await api.post('/users', {
+      data: { name: 'test-string-name', email: 'test@example.com' }
+    });
+    expect(res.status()).toBe(201);
+    const body = await res.json();
+    expect(body).toHaveProperty('id');
+    expect(body.email).toBe('test@example.com');
+  });
+
+  test('test_post_users_neg_missing_email', async ({ api }) => {
+    const res = await api.post('/users', { data: { name: 'test-string-name' } });
+    expect([400, 422]).toContain(res.status());
+  });
+
+  test('test_post_users_neg_no_auth', async ({ anonApi }) => {
+    const res = await anonApi.post('/users', {
+      data: { name: 'test-string-name', email: 'test@example.com' }
+    });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('test_post_users_edge_name_max_length', async ({ api }) => {
+    const res = await api.post('/users', {
+      data: { name: 'a'.repeat(255), email: 'test@example.com' }  // maxLength value
+    });
+    expect(res.status()).toBe(201);
+  });
+
+  test('test_post_users_edge_name_over_max_length', async ({ api }) => {
+    const res = await api.post('/users', {
+      data: { name: 'a'.repeat(256), email: 'test@example.com' }  // maxLength + 1
+    });
+    expect([400, 422]).toContain(res.status());
+  });
+
+});
+
+test.describe('GET /users/{id}', () => {
+
+  test('test_get_users_id_happy_existing', async ({ api }) => {
+    // Setup: create resource first
+    const created = await api.post('/users', {
+      data: { name: 'test-string-name', email: 'test@example.com' }
+    });
+    const { id } = await created.json();
+
+    const res = await api.get(`/users/${id}`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe(id);
+
+    // Cleanup
+    await api.delete(`/users/${id}`);
+  });
+
+  test('test_get_users_id_neg_not_found', async ({ api }) => {
+    const res = await api.get('/users/00000000-0000-0000-0000-000000000000');
+    expect(res.status()).toBe(404);
+  });
+
+});
+```
+
+## Workflow test template
+```typescript
+import { test, expect } from '../fixtures';
+
+test.describe('Users CRUD workflow', () => {
+  let resourceId: string;
+
+  test('step1_create_user', async ({ api }) => {
+    const res = await api.post('/users', {
+      data: { name: 'workflow-user', email: 'workflow@example.com' }
+    });
+    expect(res.status()).toBe(201);
+    resourceId = (await res.json()).id;
+    expect(resourceId).toBeTruthy();
+  });
+
+  test('step2_read_user', async ({ api }) => {
+    const res = await api.get(`/users/${resourceId}`);
+    expect(res.status()).toBe(200);
+    expect((await res.json()).name).toBe('workflow-user');
+  });
+
+  test('step3_update_user', async ({ api }) => {
+    const res = await api.put(`/users/${resourceId}`, {
+      data: { name: 'workflow-user-updated' }
+    });
+    expect(res.status()).toBe(200);
+    expect((await res.json()).name).toBe('workflow-user-updated');
+  });
+
+  test('step4_delete_user', async ({ api }) => {
+    const res = await api.delete(`/users/${resourceId}`);
+    expect([200, 204]).toContain(res.status());
+  });
+
+  test('step5_confirm_deleted', async ({ api }) => {
+    const res = await api.get(`/users/${resourceId}`);
+    expect(res.status()).toBe(404);
+  });
+});
+```
+
+## package.json
+```json
+{
+  "name": "api-tests",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "report": "playwright show-report reports"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.43.0",
+    "dotenv": "^16.0.0",
+    "typescript": "^5.0.0"
+  }
+}
+```
+
+## tsconfig.json
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist"
+  },
+  "include": ["tests/**/*.ts", "helpers/**/*.ts"]
+}
+```
+
+## Run command
+```bash
+npm install
+npx playwright install --with-deps chromium
+cp .env.example .env  # then fill in values
+BASE_URL=https://api.example.com auth_bearer=token npm test
+```

--- a/registry/skills/api-test-gen/references/pytest.md
+++ b/registry/skills/api-test-gen/references/pytest.md
@@ -1,0 +1,131 @@
+# Python + pytest Reference
+
+## Project layout
+```
+api-tests/
+├── pytest.ini
+├── requirements.txt
+├── .env.example
+├── tests/
+│   ├── conftest.py          # session-scoped client + auth
+│   ├── test_<tag>.py
+│   └── workflows/
+│       └── test_<tag>_workflow.py
+├── helpers/
+│   └── factories.py
+└── reports/
+```
+
+## conftest.py
+```python
+import os
+import pytest
+import httpx
+from dotenv import load_dotenv
+load_dotenv()
+
+def build_auth_headers() -> dict:
+    if os.getenv("auth_bearer"):
+        return {"Authorization": f"Bearer {os.getenv('auth_bearer')}"}
+    if os.getenv("auth_apikey"):
+        header = os.getenv("auth_apikey_header", "X-API-Key")
+        return {header: os.getenv("auth_apikey")}
+    if os.getenv("auth_basic"):
+        return {"Authorization": f"Basic {os.getenv('auth_basic')}"}
+    return {}
+
+@pytest.fixture(scope="session")
+def api():
+    with httpx.Client(base_url=os.getenv("BASE_URL"), headers=build_auth_headers()) as client:
+        yield client
+
+@pytest.fixture(scope="session")
+def anon():
+    with httpx.Client(base_url=os.getenv("BASE_URL")) as client:
+        yield client
+```
+
+## Test file template
+```python
+import pytest
+
+class TestPOSTUsers:
+
+    def test_post_users_happy_valid_body(self, api):
+        res = api.post("/users", json={"name": "test-string-name", "email": "test@example.com"})
+        assert res.status_code == 201
+        body = res.json()
+        assert "id" in body
+        assert body["email"] == "test@example.com"
+
+    def test_post_users_neg_missing_email(self, api):
+        res = api.post("/users", json={"name": "test-string-name"})
+        assert res.status_code in (400, 422)
+
+    def test_post_users_neg_no_auth(self, anon):
+        res = anon.post("/users", json={"name": "test-string-name", "email": "test@example.com"})
+        assert res.status_code in (401, 403)
+
+    def test_post_users_edge_name_max_length(self, api):
+        res = api.post("/users", json={"name": "a" * 255, "email": "test@example.com"})
+        assert res.status_code == 201
+
+    def test_post_users_edge_name_over_max_length(self, api):
+        res = api.post("/users", json={"name": "a" * 256, "email": "test@example.com"})
+        assert res.status_code in (400, 422)
+```
+
+## Workflow test template
+```python
+import pytest
+
+@pytest.fixture(scope="module")
+def created_resource(api):
+    res = api.post("/users", json={"name": "workflow-user", "email": "wf@example.com"})
+    assert res.status_code == 201
+    resource_id = res.json()["id"]
+    yield resource_id
+    api.delete(f"/users/{resource_id}")  # cleanup
+
+class TestUsersCRUDWorkflow:
+
+    def test_step1_read(self, api, created_resource):
+        res = api.get(f"/users/{created_resource}")
+        assert res.status_code == 200
+
+    def test_step2_update(self, api, created_resource):
+        res = api.put(f"/users/{created_resource}", json={"name": "workflow-user-updated"})
+        assert res.status_code == 200
+        assert res.json()["name"] == "workflow-user-updated"
+
+    def test_step3_delete(self, api, created_resource):
+        res = api.delete(f"/users/{created_resource}")
+        assert res.status_code in (200, 204)
+
+    def test_step4_confirm_gone(self, api, created_resource):
+        res = api.get(f"/users/{created_resource}")
+        assert res.status_code == 404
+```
+
+## requirements.txt
+```
+pytest>=8.0
+httpx>=0.27
+pytest-html>=4.0
+pytest-json-report>=1.5
+python-dotenv>=1.0
+```
+
+## pytest.ini
+```ini
+[pytest]
+testpaths = tests
+addopts = -v --json-report --json-report-file=reports/results.json --html=reports/index.html
+```
+
+## Run command
+```bash
+pip install -r requirements.txt --break-system-packages
+cp .env.example .env
+BASE_URL=https://api.example.com auth_bearer=token pytest
+```

--- a/registry/skills/api-test-gen/references/report-template.md
+++ b/registry/skills/api-test-gen/references/report-template.md
@@ -1,0 +1,133 @@
+# HTML Report Template
+
+Generate `reports/index.html` using this structure. Fill in values from test results.
+If tests weren't run yet, show status as "NOT EXECUTED" for all rows.
+
+## Template
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>API Test Report — {{spec_title}}</title>
+<style>
+  body { font-family: system-ui, sans-serif; margin: 0; background: #f5f5f5; color: #222; }
+  header { background: #1a1a2e; color: white; padding: 24px 32px; }
+  header h1 { margin: 0 0 6px; font-size: 1.4rem; }
+  header p  { margin: 0; opacity: 0.7; font-size: 0.85rem; }
+  .summary  { display: flex; gap: 16px; padding: 20px 32px; background: white;
+               border-bottom: 1px solid #e0e0e0; flex-wrap: wrap; }
+  .stat { padding: 12px 20px; border-radius: 8px; text-align: center; min-width: 90px; }
+  .stat .num { font-size: 2rem; font-weight: 700; }
+  .stat .lbl { font-size: 0.75rem; text-transform: uppercase; opacity: 0.7; }
+  .total  { background: #e8eaf6; }
+  .passed { background: #e8f5e9; color: #2e7d32; }
+  .failed { background: #ffebee; color: #c62828; }
+  .skipped{ background: #fff8e1; color: #f57f17; }
+  .rate   { background: #e3f2fd; color: #1565c0; }
+  .container { padding: 24px 32px; }
+  .tag-section { background: white; border-radius: 8px; margin-bottom: 16px;
+                  box-shadow: 0 1px 3px rgba(0,0,0,0.1); overflow: hidden; }
+  .tag-header { padding: 14px 20px; background: #f8f9fa; border-bottom: 1px solid #e0e0e0;
+                 font-weight: 600; cursor: pointer; display: flex; justify-content: space-between; }
+  table { width: 100%; border-collapse: collapse; }
+  th, td { padding: 10px 16px; text-align: left; border-bottom: 1px solid #f0f0f0;
+            font-size: 0.9rem; }
+  th { background: #fafafa; font-weight: 600; font-size: 0.8rem; text-transform: uppercase;
+       color: #666; }
+  .badge { padding: 3px 10px; border-radius: 12px; font-size: 0.75rem; font-weight: 600; }
+  .badge.pass { background: #e8f5e9; color: #2e7d32; }
+  .badge.fail { background: #ffebee; color: #c62828; }
+  .badge.skip { background: #fff8e1; color: #f57f17; }
+  .badge.none { background: #eeeeee; color: #616161; }
+  .error-detail { font-family: monospace; font-size: 0.8rem; background: #ffebee;
+                   padding: 8px 12px; border-left: 3px solid #c62828; margin-top: 4px; }
+  .coverage { width: 100%; border-collapse: collapse; margin-top: 24px; }
+  .coverage th, .coverage td { padding: 8px 12px; border: 1px solid #e0e0e0; font-size: 0.85rem; }
+  .coverage th { background: #f5f5f5; }
+  .cov-yes { color: #2e7d32; font-weight: 600; }
+  .cov-no  { color: #bdbdbd; }
+</style>
+</head>
+<body>
+<header>
+  <h1>API Test Report — {{spec_title}} v{{spec_version}}</h1>
+  <p>Generated: {{timestamp}} &nbsp;|&nbsp; Framework: {{framework}} &nbsp;|&nbsp; Base URL: {{base_url}}</p>
+</header>
+
+<div class="summary">
+  <div class="stat total" ><div class="num">{{total}}</div><div class="lbl">Total</div></div>
+  <div class="stat passed"><div class="num">{{passed}}</div><div class="lbl">Passed</div></div>
+  <div class="stat failed"><div class="num">{{failed}}</div><div class="lbl">Failed</div></div>
+  <div class="stat skipped"><div class="num">{{skipped}}</div><div class="lbl">Skipped</div></div>
+  <div class="stat rate"  ><div class="num">{{pass_rate}}%</div><div class="lbl">Pass Rate</div></div>
+</div>
+
+<div class="container">
+
+  <!-- Repeat this block per tag -->
+  {{#each tags}}
+  <div class="tag-section">
+    <div class="tag-header">
+      <span>{{tag_name}}</span>
+      <span>{{tag_passed}}/{{tag_total}} passed</span>
+    </div>
+    <table>
+      <thead><tr>
+        <th>Test Name</th><th>Type</th><th>Method</th><th>Path</th>
+        <th>Status</th><th>Duration</th>
+      </tr></thead>
+      <tbody>
+        {{#each tests}}
+        <tr>
+          <td>{{name}}</td>
+          <td>{{scenario_type}}</td>
+          <td><code>{{method}}</code></td>
+          <td><code>{{path}}</code></td>
+          <td><span class="badge {{status_class}}">{{status}}</span></td>
+          <td>{{duration_ms}}ms</td>
+        </tr>
+        {{#if error}}
+        <tr><td colspan="6"><div class="error-detail">{{error}}</div></td></tr>
+        {{/if}}
+        {{/each}}
+      </tbody>
+    </table>
+  </div>
+  {{/each}}
+
+  <!-- Coverage matrix -->
+  <h3>Coverage Matrix</h3>
+  <table class="coverage">
+    <thead><tr>
+      <th>Endpoint</th><th>Happy</th><th>Negative</th><th>Edge</th><th>Workflow</th>
+    </tr></thead>
+    <tbody>
+      {{#each endpoints}}
+      <tr>
+        <td><code>{{method}} {{path}}</code></td>
+        <td class="{{#if happy}}cov-yes{{else}}cov-no{{/if}}">{{#if happy}}✓{{else}}—{{/if}}</td>
+        <td class="{{#if negative}}cov-yes{{else}}cov-no{{/if}}">{{#if negative}}✓{{else}}—{{/if}}</td>
+        <td class="{{#if edge}}cov-yes{{else}}cov-no{{/if}}">{{#if edge}}✓{{else}}—{{/if}}</td>
+        <td class="{{#if workflow}}cov-yes{{else}}cov-no{{/if}}">{{#if workflow}}✓{{else}}—{{/if}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+
+</div>
+</body>
+</html>
+```
+
+## How to fill in values
+
+When tests haven't been run, use:
+- `total` = number of generated test cases
+- `passed` = 0, `failed` = 0, `skipped` = total
+- `pass_rate` = "N/A"
+- all test status = "NOT EXECUTED" with class `none`
+
+When tests have been run, parse the JSON results file:
+- Playwright: `reports/results.json` → `stats` + `suites[].specs[].tests[]`
+- pytest: `reports/results.json` → `summary` + `tests[]`

--- a/registry/skills/api-test-gen/references/scaffold.md
+++ b/registry/skills/api-test-gen/references/scaffold.md
@@ -1,0 +1,68 @@
+# Project Scaffold Reference
+
+## .env.example (always generate this)
+```
+# Required
+BASE_URL=https://api.example.com
+
+# Auth — uncomment one block only
+
+# Bearer token
+# auth_bearer=your-jwt-token-here
+
+# API Key
+# auth_apikey=your-api-key-here
+# auth_apikey_header=X-API-Key
+
+# Basic auth (base64 of user:pass)
+# auth_basic=dXNlcjpwYXNz
+```
+
+## README.md template
+```markdown
+# API Test Suite — <Spec Title>
+
+Generated from: `<spec file name>`  
+Generated at: `<timestamp>`  
+Framework: `<framework>`
+
+## Prerequisites
+<framework-specific prerequisites>
+
+## Setup
+```sh
+cp .env.example .env
+# Edit .env and fill in BASE_URL and auth credentials
+```
+
+## Run tests
+```sh
+<run command from framework reference>
+```
+
+## View report
+Open `reports/index.html` in your browser after running tests.
+
+## Coverage
+| Tag | Endpoints | Happy | Negative | Edge | Workflow |
+|-----|-----------|-------|----------|------|----------|
+<generated coverage table>
+
+## Gaps
+<list any endpoints skipped due to insufficient spec info>
+```
+
+## Directory scaffold (create these empty dirs/files)
+```
+api-tests/
+├── .env.example         ← generated
+├── README.md            ← generated
+├── <config file>        ← from framework reference
+├── <package file>       ← from framework reference
+├── tests/
+│   └── .gitkeep
+├── helpers/
+│   └── .gitkeep
+└── reports/
+    └── .gitkeep
+```


### PR DESCRIPTION
api-test-gen — API Test Generator Skill

Generates a complete, runnable API test project from an API specification or plain endpoint description. Takes any of OpenAPI/Swagger (JSON or YAML), Postman Collection, GraphQL schema, or a verbal description of endpoints as input and produces typed models, test files, project scaffolding, and an HTML coverage report.

**Frameworks supported**

- TypeScript + Playwright
- Python + pytest

**Test coverage per endpoint**

- Happy path — valid inputs, expected 2xx response
- Negative — missing required fields, wrong types, missing auth
- Edge — boundary values from schema constraints (minLength, maximum, enum, etc.)
- Workflow — auto-detected CRUD chains (POST → GET → PUT → DELETE → 404)