### PR TITLE
registry(skills): Add aws-lambda-best-practices 

### DIFF
--- a/registry/skills/aws-lambda-best-practices/SKILL.md
+++ b/registry/skills/aws-lambda-best-practices/SKILL.md
@@ -17,7 +17,7 @@ Opinionated, language-agnostic conventions for designing and operating Lambda fu
 
 ## Is Lambda the Right Choice?
 
-Lambda is not a general-purpose compute service -- it excels at event-driven, short-lived, stateless workloads. Evaluate fit before committing.
+Lambda excels at event-driven, short-lived, stateless workloads. Evaluate fit before committing.
 
 | Requirement | Lambda fit | Better alternative |
 |---|---|---|
@@ -30,72 +30,19 @@ Lambda is not a general-purpose compute service -- it excels at event-driven, sh
 | Large deployment artifact (> 10 GB) | Container image limit | ECS/Fargate |
 | Sub-millisecond latency | Cold starts add latency | EC2 or containers |
 
-See `references/anti-patterns.md` for detailed analysis of each anti-pattern with migration strategies.
+## Function Design
 
-## Architecture Anti-Patterns -- When Lambda Feels Right But Isn't
+**One function per responsibility.** Scope by event source or business operation. Keep the handler thin: validate input, delegate to business logic (pure functions), return a structured response. Initialize SDK clients and connections at module level -- Lambda reuses the execution environment across invocations.
 
-Even when Lambda appears to fit, certain architectural patterns lead to fragile, costly, or unmaintainable systems. Recognize these before committing.
+**Don't:** build a Lambda monolith (all routes in one function), inline business logic in the handler, or create connections inside the handler.
 
-| Anti-pattern | Signal | What to use instead |
-|---|---|---|
-| **Lambda monolith** | One function handles all routes/event types | Decompose: one function per task |
-| **Lambda as orchestrator** | Function has more workflow logic than business logic | AWS Step Functions for workflows; EventBridge across services |
-| **Lambda calling Lambda** | Function synchronously invokes another function and waits | SQS between functions; Step Functions for orchestration |
-| **Recursive invocation loop** | Function writes to the same resource that triggered it | Separate source and destination resources |
-| **Synchronous waiting** | Function runs 3+ independent operations sequentially | Concurrent execution or event-driven split |
+**Idempotency is mandatory.** Lambda guarantees at-least-once invocation -- your function will receive duplicates. Use an idempotency key (request ID, message ID) with DynamoDB or Powertools to prevent reprocessing.
 
-### Quick self-check
+**Don't:** write orchestration logic in Lambda. If your function has more if/else/retry than business logic, move the workflow to Step Functions. Never have Lambda synchronously invoke another Lambda -- use SQS or Step Functions to decouple.
 
-If any of these are true, reconsider your design:
-- Your function's IAM role needs broad wildcards because it does too many things
-- Your function's timeout must be 15 minutes because it chains through multiple steps
-- Your function has more `if/else/try/catch` orchestration than business logic
-- Your function invokes other Lambda functions with `invoke()` and waits for the response
-- Your function writes output to the same S3 bucket / SQS queue / DynamoDB table that triggered it
+**Don't:** write to the same resource that triggered the function -- this causes recursive invocation loops with exponential cost. If detected, set reserved concurrency to **0** immediately.
 
-See `references/anti-patterns.md` for detailed analysis of each anti-pattern with migration strategies.
-
-## Function Code
-
-### Handler design -- separate logic from plumbing
-
-The handler is the entry point. Keep it thin:
-
-1. **Parse and validate** the incoming event
-2. **Delegate** to business logic (pure functions, testable independently)
-3. **Return** a well-structured response
-
-### Execution environment reuse
-
-Initialize SDK clients, database connections, and heavy resources **outside** the handler. Lambda reuses the execution environment across invocations -- resources initialized at module level persist.
-
-```
-# GOOD: initialized once, reused across invocations
-db_client = create_db_client()
-
-def handler(event, context):
-    return db_client.query(event["id"])
-
-# BAD: new connection every invocation
-def handler(event, context):
-    db_client = create_db_client()
-    return db_client.query(event["id"])
-```
-
-### Idempotency -- design for at-least-once delivery
-
-Lambda guarantees at-least-once invocation. Your function **will** receive duplicate events. Design accordingly:
-
-- Use a unique event identifier (request ID, message ID) as an idempotency key
-- Store the key in DynamoDB or a similar store before processing
-- On duplicate, return the cached result instead of re-processing
-- Consider using Powertools for AWS Lambda idempotency utilities
-
-### Persistent connections
-
-Use keep-alive directives to maintain connections between invocations. Lambda purges idle connections -- attempting to reuse a stale connection causes errors.
-
-See `references/function-code.md` for recursive invocation prevention, environment variable usage, and security implications of execution environment reuse.
+See `references/function-code.md` for execution environment reuse details, cold start factors, idempotency implementation, connection management, and environment variables. See `references/anti-patterns.md` for why each anti-pattern feels right but isn't, impact analysis, and migration strategies.
 
 ## Function Configuration
 
@@ -110,17 +57,13 @@ Lambda allocates CPU proportional to memory. At **1,769 MB**, a function gets on
 | 1,769-3,008 MB | 1-2 vCPU | Data processing, image manipulation |
 | 3,008-10,240 MB | 2-6 vCPU | ML inference, heavy computation |
 
-**Always performance-test** to find the optimal memory setting. Use the open-source [AWS Lambda Power Tuning](https://github.com/alexcasalboni/aws-lambda-power-tuning) tool to find the best price/performance balance.
+Use [AWS Lambda Power Tuning](https://github.com/alexcasalboni/aws-lambda-power-tuning) to find the optimal price/performance balance.
 
 ### Timeout -- set deliberately, not defensively
 
-| Guideline | Why |
-|---|---|
-| Set timeout to expected duration + buffer, not max (900s) | Prevents runaway invocations from accumulating cost and concurrency |
-| Load-test to measure actual duration under load | Network calls to downstream services can slow under concurrency |
-| For SQS triggers, keep timeout < Visibility Timeout | Prevents duplicate processing |
+Set to p99 duration + 20-50% buffer. For SQS triggers, set SQS Visibility Timeout >= 6x function timeout. API Gateway enforces a 29-second integration timeout.
 
-### Key quotas to remember
+### Key quotas
 
 | Resource | Limit | Notes |
 |---|---|---|
@@ -134,7 +77,7 @@ Lambda allocates CPU proportional to memory. At **1,769 MB**, a function gets on
 | Concurrent executions | 1,000 default | Soft limit, increase via Service Quotas |
 | Layers | 5 per function | -- |
 
-See `references/function-configuration.md` for IAM policy guidance, SQS integration, quota management, and cleanup best practices.
+See `references/function-configuration.md` for memory/CPU tuning strategies, IAM policy guidance, SQS integration, and quota management.
 
 ## Function Scalability
 
@@ -146,45 +89,25 @@ Concurrency = (requests per second) x (average duration in seconds)
 
 100 RPS with 200ms average duration = 20 concurrent executions.
 
-### Concurrency controls
+### Choosing a concurrency control
 
-| Control | What it does | Cost | Use case |
-|---|---|---|---|
-| **Unreserved** (default) | Shares account pool (1,000 default) | Free | Most functions |
-| **Reserved concurrency** | Guarantees AND caps concurrency for a function | Free | Protect critical functions; throttle to protect downstream |
-| **Provisioned concurrency** | Pre-initializes execution environments | Additional charge | Eliminate cold starts for latency-sensitive workloads |
-
-### Scaling rate
-
-Lambda scales at **1,000 new execution environments every 10 seconds** per function. For sudden traffic spikes:
-
-- Use provisioned concurrency to absorb initial burst
-- Implement retries with exponential backoff and jitter in callers
-- Set reserved concurrency to protect downstream services from overload
-
-### Upstream/downstream awareness
-
-Lambda scales automatically -- your dependencies may not. Common bottlenecks:
-
-| Dependency | Risk | Mitigation |
+| Scenario | Control | How to size |
 |---|---|---|
-| RDS / relational DB | Connection pool exhaustion | Use RDS Proxy |
-| API Gateway | 10,000 RPS default throttle | Request quota increase; match Lambda concurrency |
-| DynamoDB (provisioned) | Throttled reads/writes | Switch to on-demand or match WCU/RCU to expected concurrency |
-| SQS | N/A (scales with Lambda) | -- |
-| Third-party APIs | Rate limits | Use reserved concurrency to cap Lambda scaling |
+| Most functions, no special needs | **Unreserved** (default) | Shares account pool (1,000 default) |
+| Critical function that must always have capacity | **Reserved concurrency** | Peak concurrent executions x 1.3 |
+| Protect downstream from overload (DB, API) | **Reserved concurrency** | Match downstream's safe throughput |
+| User-facing API with latency SLA | **Provisioned concurrency** | Eliminates cold starts; use auto-scaling |
+| Emergency stop for runaway function | **Reserved concurrency = 0** | Halts all invocations immediately |
 
-See `references/function-scalability.md` for provisioned concurrency scheduling, throttle tolerance patterns, and concurrency estimation.
+Lambda scales automatically -- **your dependencies may not.** Use RDS Proxy for relational databases, reserved concurrency to cap scaling to third-party rate limits, and on-demand mode for DynamoDB under Lambda workloads.
+
+**Don't:** let Lambda overwhelm your database. A traffic spike -> 1,000 concurrent functions -> 1,000 simultaneous DB connections -> connection exhaustion -> all functions timeout -> cascade failure. This is the most common Lambda production incident.
+
+See `references/function-scalability.md` for scaling rate, provisioned concurrency scheduling, throttle tolerance patterns, upstream/downstream protection, and cascade failure prevention.
 
 ## Metrics and Alarms
 
-### Use CloudWatch metrics, not in-function metrics
-
-Never call the CloudWatch `PutMetricData` API from your handler. Instead:
-
-- Use **Embedded Metric Format (EMF)** -- emit metrics through structured logs, zero API call overhead
-- Use **Powertools for AWS Lambda Metrics** utility to handle EMF formatting automatically
-- Set CloudWatch Alarms on built-in Lambda metrics
+Prefer **Embedded Metric Format (EMF)** over `PutMetricData` API calls for custom metrics -- zero latency overhead. Use Powertools for AWS Lambda to handle EMF formatting. Use `PutMetricData` only when you need high-resolution (1-second) metrics or immediate availability.
 
 ### Key metrics to alarm on
 
@@ -192,107 +115,62 @@ Never call the CloudWatch `PutMetricData` API from your handler. Instead:
 |---|---|---|
 | `Errors` | > 0 for N minutes | Function failures |
 | `Throttles` | > 0 | Hitting concurrency limits |
-| `Duration` | p99 > threshold | Latency degradation, downstream slowness |
-| `ConcurrentExecutions` | > 80% of reserved | Approaching concurrency ceiling |
+| `Duration` | p99 > threshold | Latency degradation |
+| `ConcurrentExecutions` | > 80% of reserved | Approaching ceiling |
 | `IteratorAge` (streams) | > 30,000 ms | Falling behind on stream processing |
 | `DeadLetterErrors` | > 0 | DLQ delivery failures |
 
-### Observability best practices
+Use structured JSON logging, correlation IDs across services, X-Ray tracing, and Cost Anomaly Detection.
 
-| Practice | Why |
-|---|---|
-| Structured JSON logging | Enables search, filter, and analysis in CloudWatch Logs Insights |
-| Correlation IDs across services | Trace requests end-to-end in distributed systems |
-| AWS Cost Anomaly Detection | Catches runaway Lambda costs within 24 hours |
-| X-Ray tracing | Visualize latency across Lambda and downstream services |
-
-See `references/metrics-and-alarms.md` for EMF details, structured logging guidance, and cost anomaly detection setup.
+See `references/metrics-and-alarms.md` for EMF details, structured logging guidance, alarm configuration, and cost anomaly detection setup.
 
 ## Working with Streams
 
-### Batch tuning -- the critical lever
-
-| Setting | Default | Guidance |
-|---|---|---|
-| `BatchSize` | 100 (Kinesis), 10 (SQS) | Larger batches amortize invocation overhead; test for your workload |
-| `MaximumBatchingWindowInSeconds` | 0 | Set up to 5 min to buffer small batches; reduces invocations at cost of latency |
-| Payload limit | 6 MB | Batches are capped at 6 MB regardless of `BatchSize` |
-
-### Partial batch response -- avoid reprocessing successes
-
-Enable `ReportBatchItemFailures` to retry **only failed records** instead of the entire batch. Without this, one failed record causes the entire batch to be retried.
-
-### Stream scaling
+**Batch tuning** is the critical lever -- larger batches amortize overhead, batching windows buffer small batches. **Always enable `ReportBatchItemFailures`** in production to retry only failed records instead of the entire batch. **Every stream-processing function must be idempotent** -- at-least-once delivery is guaranteed.
 
 | Stream type | Scaling lever | Concurrency model |
 |---|---|---|
-| Kinesis | Add shards | 1 Lambda invocation per shard (default); up to 10 with parallelization factor |
-| DynamoDB Streams | Add partitions (indirect) | 1 Lambda invocation per shard |
+| Kinesis | Add shards | 1 invocation per shard (default); up to 10 with parallelization factor |
+| DynamoDB Streams | Add partitions (indirect) | 1 invocation per shard |
 | SQS | Automatic | Lambda scales pollers up to concurrency limit |
 
-### Idempotency is critical for streams
-
-Event source mappings guarantee **at-least-once** delivery. Duplicate processing will occur. Every stream-processing function must be idempotent.
-
-See `references/stream-events.md` for Kinesis shard management, IteratorAge monitoring, parallelization factor, and partition key design.
+See `references/stream-events.md` for batch tuning parameters, partial batch response implementation, Kinesis shard management, IteratorAge monitoring, and SQS FIFO considerations.
 
 ## Security
 
-### IAM -- least privilege, always
-
-| Principle | Implementation |
-|---|---|
-| Narrow execution role | Grant only the specific actions and resources the function needs |
-| No wildcards in production | `s3:GetObject` on specific bucket, not `s3:*` on `*` |
-| Separate roles per function | Avoid sharing execution roles across functions with different responsibilities |
-| Use resource-based policies | Control who can invoke your function |
-
-### Runtime security
+**IAM -- least privilege, always.** One narrowly scoped execution role per function. No wildcards in production. Use resource-based policies to control who can invoke your function.
 
 | Practice | Why |
 |---|---|
-| Code signing | Verify deployment artifact integrity; prevent unauthorized code changes |
-| VPC placement | Required for accessing private resources; adds cold start latency |
+| Code signing | Verify deployment artifact integrity |
+| VPC placement | Required for private resources; minor cold start impact (Hyperplane ENIs) |
 | Security Hub controls | Automated CSPM checks against Lambda configurations |
-| GuardDuty Lambda Protection | Monitors network activity for threats (crypto mining, C2 communication) |
-| Secrets Manager / Parameter Store | Never hardcode secrets; use environment variable references to secrets |
+| GuardDuty Lambda Protection | Monitors for threats (crypto mining, C2 communication) |
+| Secrets Manager / Parameter Store | Never hardcode secrets |
 
-### Data protection
-
-| Layer | Mechanism |
-|---|---|
-| In transit | All Lambda APIs use TLS |
-| At rest (env vars) | Encrypted with AWS KMS by default; use customer-managed CMK for sensitive data |
-| At rest (code) | Stored encrypted in S3 |
-| `/tmp` storage | Ephemeral, isolated per execution environment |
-
-See `references/security.md` for VPC configuration trade-offs, code signing setup, and governance strategies.
+See `references/security.md` for VPC configuration trade-offs, code signing setup, secrets management patterns, data protection, and governance strategies.
 
 ## Common Mistakes
 
 | Mistake | Fix |
 |---|---|
 | Initializing SDK clients inside the handler | Move to module/global scope for execution environment reuse |
-| Setting timeout to 15 minutes "just in case" | Set to expected duration + reasonable buffer; load test |
+| Setting timeout to 15 minutes "just in case" | Set to p99 duration + reasonable buffer; load test |
 | Ignoring cold starts for user-facing APIs | Use provisioned concurrency or optimize package size |
 | Not designing for idempotency | Use idempotency keys with DynamoDB or Powertools |
-| Recursive invocations (function triggers itself) | Set reserved concurrency to 0 immediately; fix the loop |
-| Hardcoding resource names | Use environment variables |
+| Recursive invocations (function triggers itself) | Set reserved concurrency to 0 immediately; fix the trigger/output separation |
+| Hardcoding resource names | Use environment variables for bucket names, table names, endpoints |
 | Wildcard IAM permissions | Grant specific actions on specific resources |
 | Not monitoring IteratorAge on streams | Alarm at 30s; add shards or increase parallelization |
 | Retrying the full batch on partial failure | Enable `ReportBatchItemFailures` |
 | Over-provisioning memory without testing | Use Lambda Power Tuning to find optimal setting |
-| Single function handling all API routes (monolith) | Decompose to one function per route/task |
-| Writing workflow orchestration logic in a Lambda handler | Use Step Functions for branching, retries, wait states |
-| Lambda function synchronously invoking another Lambda | Decouple with SQS or orchestrate with Step Functions |
-| Sequential independent operations in one function | Run concurrently or split into event-driven chain |
 
 ## Reference Files
 
-- **`references/anti-patterns.md`** -- Lambda monolith, Lambda as orchestrator, synchronous chains, recursive loops, synchronous waiting, decision matrix
-- **`references/function-code.md`** -- Handler design, execution environment reuse, idempotency patterns, connection management, recursive invocation prevention
-- **`references/function-configuration.md`** -- Memory/CPU tuning, timeout strategy, quotas, IAM policies, SQS integration, cleanup
-- **`references/function-scalability.md`** -- Concurrency model, reserved vs provisioned concurrency, scaling rate, upstream/downstream protection, throttle tolerance
-- **`references/metrics-and-alarms.md`** -- CloudWatch metrics, EMF, structured logging, alarms, Cost Anomaly Detection, X-Ray tracing
-- **`references/stream-events.md`** -- Batch tuning, partial batch response, Kinesis/DynamoDB Streams/SQS scaling, IteratorAge monitoring
-- **`references/security.md`** -- IAM least privilege, code signing, VPC trade-offs, data protection, Security Hub, GuardDuty
+- **`references/anti-patterns.md`** -- Lambda monolith, Lambda as orchestrator, synchronous chains, recursive loops, synchronous waiting -- why each feels right, impact analysis, migration strategies
+- **`references/function-code.md`** -- Execution environment reuse, cold start factors, idempotency implementation, connection management, RDS Proxy, environment variables
+- **`references/function-configuration.md`** -- Memory/CPU tuning strategies, timeout alignment, quotas, IAM policies, SQS integration, cleanup
+- **`references/function-scalability.md`** -- Concurrency estimation, reserved vs provisioned concurrency, scaling rate, upstream/downstream protection, cascade failure prevention
+- **`references/metrics-and-alarms.md`** -- CloudWatch metrics, EMF implementation, structured logging, alarm configuration, Cost Anomaly Detection, X-Ray tracing
+- **`references/stream-events.md`** -- Batch tuning, partial batch response, Kinesis/DynamoDB Streams/SQS scaling, IteratorAge monitoring, SQS FIFO high-throughput mode
+- **`references/security.md`** -- IAM least privilege, code signing, VPC trade-offs, secrets management, data protection, Security Hub, GuardDuty, governance

--- a/registry/skills/aws-lambda-best-practices/SKILL.md
+++ b/registry/skills/aws-lambda-best-practices/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: aws-lambda-best-practices
+description: >-
+  AWS Lambda best practices for function design, configuration, and operations. Use when
+  designing Lambda functions, choosing memory/timeout settings, planning concurrency and
+  scaling, setting up monitoring, processing streams, or securing Lambda workloads. Triggers
+  on tasks involving Lambda function creation, handler design, cold start optimization,
+  idempotency, event source mapping, reserved/provisioned concurrency, or deciding whether
+  Lambda is the right compute choice. Does not cover language-specific SDK patterns,
+  CloudFormation/Terraform resource definitions, or Lambda@Edge.
+version: 0.1.0
+---
+
+# AWS Lambda Best Practices
+
+Opinionated, language-agnostic conventions for designing and operating Lambda functions at scale. For SDK/API usage, infrastructure-as-code definitions, or language-specific handler patterns, consult the relevant AWS SDK or Terraform documentation instead.
+
+## Is Lambda the Right Choice?
+
+Lambda is not a general-purpose compute service -- it excels at event-driven, short-lived, stateless workloads. Evaluate fit before committing.
+
+| Requirement | Lambda fit | Better alternative |
+|---|---|---|
+| Event-driven, bursty traffic | Excellent | -- |
+| Execution < 15 minutes | Good | ECS/Fargate for longer tasks |
+| Stateless request/response | Excellent | -- |
+| Persistent connections (WebSockets) | Poor | API Gateway WebSocket + ECS |
+| Predictable, steady-state high throughput | Evaluate cost | ECS/Fargate or EC2 |
+| GPU or specialized hardware | Not supported | EC2 or SageMaker |
+| Large deployment artifact (> 10 GB) | Container image limit | ECS/Fargate |
+| Sub-millisecond latency | Cold starts add latency | EC2 or containers |
+
+See `references/anti-patterns.md` for detailed analysis of each anti-pattern with migration strategies.
+
+## Architecture Anti-Patterns -- When Lambda Feels Right But Isn't
+
+Even when Lambda appears to fit, certain architectural patterns lead to fragile, costly, or unmaintainable systems. Recognize these before committing.
+
+| Anti-pattern | Signal | What to use instead |
+|---|---|---|
+| **Lambda monolith** | One function handles all routes/event types | Decompose: one function per task |
+| **Lambda as orchestrator** | Function has more workflow logic than business logic | AWS Step Functions for workflows; EventBridge across services |
+| **Lambda calling Lambda** | Function synchronously invokes another function and waits | SQS between functions; Step Functions for orchestration |
+| **Recursive invocation loop** | Function writes to the same resource that triggered it | Separate source and destination resources |
+| **Synchronous waiting** | Function runs 3+ independent operations sequentially | Concurrent execution or event-driven split |
+
+### Quick self-check
+
+If any of these are true, reconsider your design:
+- Your function's IAM role needs broad wildcards because it does too many things
+- Your function's timeout must be 15 minutes because it chains through multiple steps
+- Your function has more `if/else/try/catch` orchestration than business logic
+- Your function invokes other Lambda functions with `invoke()` and waits for the response
+- Your function writes output to the same S3 bucket / SQS queue / DynamoDB table that triggered it
+
+See `references/anti-patterns.md` for detailed analysis of each anti-pattern with migration strategies.
+
+## Function Code
+
+### Handler design -- separate logic from plumbing
+
+The handler is the entry point. Keep it thin:
+
+1. **Parse and validate** the incoming event
+2. **Delegate** to business logic (pure functions, testable independently)
+3. **Return** a well-structured response
+
+### Execution environment reuse
+
+Initialize SDK clients, database connections, and heavy resources **outside** the handler. Lambda reuses the execution environment across invocations -- resources initialized at module level persist.
+
+```
+# GOOD: initialized once, reused across invocations
+db_client = create_db_client()
+
+def handler(event, context):
+    return db_client.query(event["id"])
+
+# BAD: new connection every invocation
+def handler(event, context):
+    db_client = create_db_client()
+    return db_client.query(event["id"])
+```
+
+### Idempotency -- design for at-least-once delivery
+
+Lambda guarantees at-least-once invocation. Your function **will** receive duplicate events. Design accordingly:
+
+- Use a unique event identifier (request ID, message ID) as an idempotency key
+- Store the key in DynamoDB or a similar store before processing
+- On duplicate, return the cached result instead of re-processing
+- Consider using Powertools for AWS Lambda idempotency utilities
+
+### Persistent connections
+
+Use keep-alive directives to maintain connections between invocations. Lambda purges idle connections -- attempting to reuse a stale connection causes errors.
+
+See `references/function-code.md` for recursive invocation prevention, environment variable usage, and security implications of execution environment reuse.
+
+## Function Configuration
+
+### Memory and CPU -- they are linked
+
+Lambda allocates CPU proportional to memory. At **1,769 MB**, a function gets one full vCPU.
+
+| Memory | CPU | Best for |
+|---|---|---|
+| 128-512 MB | Fractional vCPU | Simple transforms, routing |
+| 512-1,769 MB | Up to 1 vCPU | API handlers, moderate processing |
+| 1,769-3,008 MB | 1-2 vCPU | Data processing, image manipulation |
+| 3,008-10,240 MB | 2-6 vCPU | ML inference, heavy computation |
+
+**Always performance-test** to find the optimal memory setting. Use the open-source [AWS Lambda Power Tuning](https://github.com/alexcasalboni/aws-lambda-power-tuning) tool to find the best price/performance balance.
+
+### Timeout -- set deliberately, not defensively
+
+| Guideline | Why |
+|---|---|
+| Set timeout to expected duration + buffer, not max (900s) | Prevents runaway invocations from accumulating cost and concurrency |
+| Load-test to measure actual duration under load | Network calls to downstream services can slow under concurrency |
+| For SQS triggers, keep timeout < Visibility Timeout | Prevents duplicate processing |
+
+### Key quotas to remember
+
+| Resource | Limit | Notes |
+|---|---|---|
+| Max execution time | 15 minutes | Hard limit |
+| Payload (sync) | 6 MB request / 6 MB response | 200 MB for streamed responses |
+| Payload (async) | 1 MB | -- |
+| Deployment package (.zip) | 50 MB zipped / 250 MB unzipped | Use S3 for larger uploads |
+| Container image | 10 GB | -- |
+| `/tmp` storage | 512 MB - 10,240 MB | Configurable |
+| Environment variables | 4 KB total | Aggregate across all variables |
+| Concurrent executions | 1,000 default | Soft limit, increase via Service Quotas |
+| Layers | 5 per function | -- |
+
+See `references/function-configuration.md` for IAM policy guidance, SQS integration, quota management, and cleanup best practices.
+
+## Function Scalability
+
+### Concurrency model
+
+```
+Concurrency = (requests per second) x (average duration in seconds)
+```
+
+100 RPS with 200ms average duration = 20 concurrent executions.
+
+### Concurrency controls
+
+| Control | What it does | Cost | Use case |
+|---|---|---|---|
+| **Unreserved** (default) | Shares account pool (1,000 default) | Free | Most functions |
+| **Reserved concurrency** | Guarantees AND caps concurrency for a function | Free | Protect critical functions; throttle to protect downstream |
+| **Provisioned concurrency** | Pre-initializes execution environments | Additional charge | Eliminate cold starts for latency-sensitive workloads |
+
+### Scaling rate
+
+Lambda scales at **1,000 new execution environments every 10 seconds** per function. For sudden traffic spikes:
+
+- Use provisioned concurrency to absorb initial burst
+- Implement retries with exponential backoff and jitter in callers
+- Set reserved concurrency to protect downstream services from overload
+
+### Upstream/downstream awareness
+
+Lambda scales automatically -- your dependencies may not. Common bottlenecks:
+
+| Dependency | Risk | Mitigation |
+|---|---|---|
+| RDS / relational DB | Connection pool exhaustion | Use RDS Proxy |
+| API Gateway | 10,000 RPS default throttle | Request quota increase; match Lambda concurrency |
+| DynamoDB (provisioned) | Throttled reads/writes | Switch to on-demand or match WCU/RCU to expected concurrency |
+| SQS | N/A (scales with Lambda) | -- |
+| Third-party APIs | Rate limits | Use reserved concurrency to cap Lambda scaling |
+
+See `references/function-scalability.md` for provisioned concurrency scheduling, throttle tolerance patterns, and concurrency estimation.
+
+## Metrics and Alarms
+
+### Use CloudWatch metrics, not in-function metrics
+
+Never call the CloudWatch `PutMetricData` API from your handler. Instead:
+
+- Use **Embedded Metric Format (EMF)** -- emit metrics through structured logs, zero API call overhead
+- Use **Powertools for AWS Lambda Metrics** utility to handle EMF formatting automatically
+- Set CloudWatch Alarms on built-in Lambda metrics
+
+### Key metrics to alarm on
+
+| Metric | Alarm condition | What it catches |
+|---|---|---|
+| `Errors` | > 0 for N minutes | Function failures |
+| `Throttles` | > 0 | Hitting concurrency limits |
+| `Duration` | p99 > threshold | Latency degradation, downstream slowness |
+| `ConcurrentExecutions` | > 80% of reserved | Approaching concurrency ceiling |
+| `IteratorAge` (streams) | > 30,000 ms | Falling behind on stream processing |
+| `DeadLetterErrors` | > 0 | DLQ delivery failures |
+
+### Observability best practices
+
+| Practice | Why |
+|---|---|
+| Structured JSON logging | Enables search, filter, and analysis in CloudWatch Logs Insights |
+| Correlation IDs across services | Trace requests end-to-end in distributed systems |
+| AWS Cost Anomaly Detection | Catches runaway Lambda costs within 24 hours |
+| X-Ray tracing | Visualize latency across Lambda and downstream services |
+
+See `references/metrics-and-alarms.md` for EMF details, structured logging guidance, and cost anomaly detection setup.
+
+## Working with Streams
+
+### Batch tuning -- the critical lever
+
+| Setting | Default | Guidance |
+|---|---|---|
+| `BatchSize` | 100 (Kinesis), 10 (SQS) | Larger batches amortize invocation overhead; test for your workload |
+| `MaximumBatchingWindowInSeconds` | 0 | Set up to 5 min to buffer small batches; reduces invocations at cost of latency |
+| Payload limit | 6 MB | Batches are capped at 6 MB regardless of `BatchSize` |
+
+### Partial batch response -- avoid reprocessing successes
+
+Enable `ReportBatchItemFailures` to retry **only failed records** instead of the entire batch. Without this, one failed record causes the entire batch to be retried.
+
+### Stream scaling
+
+| Stream type | Scaling lever | Concurrency model |
+|---|---|---|
+| Kinesis | Add shards | 1 Lambda invocation per shard (default); up to 10 with parallelization factor |
+| DynamoDB Streams | Add partitions (indirect) | 1 Lambda invocation per shard |
+| SQS | Automatic | Lambda scales pollers up to concurrency limit |
+
+### Idempotency is critical for streams
+
+Event source mappings guarantee **at-least-once** delivery. Duplicate processing will occur. Every stream-processing function must be idempotent.
+
+See `references/stream-events.md` for Kinesis shard management, IteratorAge monitoring, parallelization factor, and partition key design.
+
+## Security
+
+### IAM -- least privilege, always
+
+| Principle | Implementation |
+|---|---|
+| Narrow execution role | Grant only the specific actions and resources the function needs |
+| No wildcards in production | `s3:GetObject` on specific bucket, not `s3:*` on `*` |
+| Separate roles per function | Avoid sharing execution roles across functions with different responsibilities |
+| Use resource-based policies | Control who can invoke your function |
+
+### Runtime security
+
+| Practice | Why |
+|---|---|
+| Code signing | Verify deployment artifact integrity; prevent unauthorized code changes |
+| VPC placement | Required for accessing private resources; adds cold start latency |
+| Security Hub controls | Automated CSPM checks against Lambda configurations |
+| GuardDuty Lambda Protection | Monitors network activity for threats (crypto mining, C2 communication) |
+| Secrets Manager / Parameter Store | Never hardcode secrets; use environment variable references to secrets |
+
+### Data protection
+
+| Layer | Mechanism |
+|---|---|
+| In transit | All Lambda APIs use TLS |
+| At rest (env vars) | Encrypted with AWS KMS by default; use customer-managed CMK for sensitive data |
+| At rest (code) | Stored encrypted in S3 |
+| `/tmp` storage | Ephemeral, isolated per execution environment |
+
+See `references/security.md` for VPC configuration trade-offs, code signing setup, and governance strategies.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Initializing SDK clients inside the handler | Move to module/global scope for execution environment reuse |
+| Setting timeout to 15 minutes "just in case" | Set to expected duration + reasonable buffer; load test |
+| Ignoring cold starts for user-facing APIs | Use provisioned concurrency or optimize package size |
+| Not designing for idempotency | Use idempotency keys with DynamoDB or Powertools |
+| Recursive invocations (function triggers itself) | Set reserved concurrency to 0 immediately; fix the loop |
+| Hardcoding resource names | Use environment variables |
+| Wildcard IAM permissions | Grant specific actions on specific resources |
+| Not monitoring IteratorAge on streams | Alarm at 30s; add shards or increase parallelization |
+| Retrying the full batch on partial failure | Enable `ReportBatchItemFailures` |
+| Over-provisioning memory without testing | Use Lambda Power Tuning to find optimal setting |
+| Single function handling all API routes (monolith) | Decompose to one function per route/task |
+| Writing workflow orchestration logic in a Lambda handler | Use Step Functions for branching, retries, wait states |
+| Lambda function synchronously invoking another Lambda | Decouple with SQS or orchestrate with Step Functions |
+| Sequential independent operations in one function | Run concurrently or split into event-driven chain |
+
+## Reference Files
+
+- **`references/anti-patterns.md`** -- Lambda monolith, Lambda as orchestrator, synchronous chains, recursive loops, synchronous waiting, decision matrix
+- **`references/function-code.md`** -- Handler design, execution environment reuse, idempotency patterns, connection management, recursive invocation prevention
+- **`references/function-configuration.md`** -- Memory/CPU tuning, timeout strategy, quotas, IAM policies, SQS integration, cleanup
+- **`references/function-scalability.md`** -- Concurrency model, reserved vs provisioned concurrency, scaling rate, upstream/downstream protection, throttle tolerance
+- **`references/metrics-and-alarms.md`** -- CloudWatch metrics, EMF, structured logging, alarms, Cost Anomaly Detection, X-Ray tracing
+- **`references/stream-events.md`** -- Batch tuning, partial batch response, Kinesis/DynamoDB Streams/SQS scaling, IteratorAge monitoring
+- **`references/security.md`** -- IAM least privilege, code signing, VPC trade-offs, data protection, Security Hub, GuardDuty

--- a/registry/skills/aws-lambda-best-practices/SKILL.md
+++ b/registry/skills/aws-lambda-best-practices/SKILL.md
@@ -20,7 +20,7 @@ Opinionated, language-agnostic conventions for designing and operating Lambda fu
 Lambda excels at event-driven, short-lived, stateless workloads. Evaluate fit before committing.
 
 | Requirement | Lambda fit | Better alternative |
-|---|---|---|
+| --- | --- | --- |
 | Event-driven, bursty traffic | Excellent | -- |
 | Execution < 15 minutes | Good | ECS/Fargate for longer tasks |
 | Stateless request/response | Excellent | -- |
@@ -28,7 +28,7 @@ Lambda excels at event-driven, short-lived, stateless workloads. Evaluate fit be
 | Predictable, steady-state high throughput | Evaluate cost | ECS/Fargate or EC2 |
 | GPU or specialized hardware | Not supported | EC2 or SageMaker |
 | Large deployment artifact (> 10 GB) | Container image limit | ECS/Fargate |
-| Sub-millisecond latency | Cold starts add latency | EC2 or containers |
+| Sub-millisecond latency | Not achievable -- invocation overhead is milliseconds even on warm starts | EC2 or containers |
 
 ## Function Design
 
@@ -42,7 +42,7 @@ Lambda excels at event-driven, short-lived, stateless workloads. Evaluate fit be
 
 **Don't:** write to the same resource that triggered the function -- this causes recursive invocation loops with exponential cost. If detected, set reserved concurrency to **0** immediately.
 
-See `references/function-code.md` for execution environment reuse details, cold start factors, idempotency implementation, connection management, and environment variables. See `references/anti-patterns.md` for why each anti-pattern feels right but isn't, impact analysis, and migration strategies.
+See `references/function-design.md` for execution environment reuse details, cold start factors, idempotency implementation, connection management, and environment variables. See `references/anti-patterns.md` for why each anti-pattern feels right but isn't, impact analysis, and migration strategies.
 
 ## Function Configuration
 
@@ -51,7 +51,7 @@ See `references/function-code.md` for execution environment reuse details, cold 
 Lambda allocates CPU proportional to memory. At **1,769 MB**, a function gets one full vCPU.
 
 | Memory | CPU | Best for |
-|---|---|---|
+| --- | --- | --- |
 | 128-512 MB | Fractional vCPU | Simple transforms, routing |
 | 512-1,769 MB | Up to 1 vCPU | API handlers, moderate processing |
 | 1,769-3,008 MB | 1-2 vCPU | Data processing, image manipulation |
@@ -59,14 +59,18 @@ Lambda allocates CPU proportional to memory. At **1,769 MB**, a function gets on
 
 Use [AWS Lambda Power Tuning](https://github.com/alexcasalboni/aws-lambda-power-tuning) to find the optimal price/performance balance.
 
+### Architecture -- default to arm64
+
+arm64 (Graviton) costs 20% less per GB-second than x86_64 with equal or better performance. Use it unless a native dependency, layer, or container base image requires x86_64.
+
 ### Timeout -- set deliberately, not defensively
 
-Set to p99 duration + 20-50% buffer. For SQS triggers, set SQS Visibility Timeout >= 6x function timeout. API Gateway enforces a 29-second integration timeout.
+Set to p99 duration + 20-50% buffer. For SQS triggers, set SQS Visibility Timeout >= 6x function timeout. API Gateway's integration timeout is 29 seconds by default (raisable above that only for Regional/private REST APIs via quota increase).
 
 ### Key quotas
 
 | Resource | Limit | Notes |
-|---|---|---|
+| --- | --- | --- |
 | Max execution time | 15 minutes | Hard limit |
 | Payload (sync) | 6 MB request / 6 MB response | 200 MB for streamed responses |
 | Payload (async) | 1 MB | -- |
@@ -77,13 +81,13 @@ Set to p99 duration + 20-50% buffer. For SQS triggers, set SQS Visibility Timeou
 | Concurrent executions | 1,000 default | Soft limit, increase via Service Quotas |
 | Layers | 5 per function | -- |
 
-See `references/function-configuration.md` for memory/CPU tuning strategies, IAM policy guidance, SQS integration, and quota management.
+See `references/function-configuration.md` for memory/CPU tuning strategies, architecture selection, IAM policy guidance, SQS integration, and quota management.
 
 ## Function Scalability
 
 ### Concurrency model
 
-```
+```text
 Concurrency = (requests per second) x (average duration in seconds)
 ```
 
@@ -92,7 +96,7 @@ Concurrency = (requests per second) x (average duration in seconds)
 ### Choosing a concurrency control
 
 | Scenario | Control | How to size |
-|---|---|---|
+| --- | --- | --- |
 | Most functions, no special needs | **Unreserved** (default) | Shares account pool (1,000 default) |
 | Critical function that must always have capacity | **Reserved concurrency** | Peak concurrent executions x 1.3 |
 | Protect downstream from overload (DB, API) | **Reserved concurrency** | Match downstream's safe throughput |
@@ -112,7 +116,7 @@ Prefer **Embedded Metric Format (EMF)** over `PutMetricData` API calls for custo
 ### Key metrics to alarm on
 
 | Metric | Alarm condition | What it catches |
-|---|---|---|
+| --- | --- | --- |
 | `Errors` | > 0 for N minutes | Function failures |
 | `Throttles` | > 0 | Hitting concurrency limits |
 | `Duration` | p99 > threshold | Latency degradation |
@@ -129,7 +133,7 @@ See `references/metrics-and-alarms.md` for EMF details, structured logging guida
 **Batch tuning** is the critical lever -- larger batches amortize overhead, batching windows buffer small batches. **Always enable `ReportBatchItemFailures`** in production to retry only failed records instead of the entire batch. **Every stream-processing function must be idempotent** -- at-least-once delivery is guaranteed.
 
 | Stream type | Scaling lever | Concurrency model |
-|---|---|---|
+| --- | --- | --- |
 | Kinesis | Add shards | 1 invocation per shard (default); up to 10 with parallelization factor |
 | DynamoDB Streams | Add partitions (indirect) | 1 invocation per shard |
 | SQS | Automatic | Lambda scales pollers up to concurrency limit |
@@ -141,7 +145,7 @@ See `references/stream-events.md` for batch tuning parameters, partial batch res
 **IAM -- least privilege, always.** One narrowly scoped execution role per function. No wildcards in production. Use resource-based policies to control who can invoke your function.
 
 | Practice | Why |
-|---|---|
+| --- | --- |
 | Code signing | Verify deployment artifact integrity |
 | VPC placement | Required for private resources; minor cold start impact (Hyperplane ENIs) |
 | Security Hub controls | Automated CSPM checks against Lambda configurations |
@@ -153,10 +157,10 @@ See `references/security.md` for VPC configuration trade-offs, code signing setu
 ## Common Mistakes
 
 | Mistake | Fix |
-|---|---|
+| --- | --- |
 | Initializing SDK clients inside the handler | Move to module/global scope for execution environment reuse |
 | Setting timeout to 15 minutes "just in case" | Set to p99 duration + reasonable buffer; load test |
-| Ignoring cold starts for user-facing APIs | Use provisioned concurrency or optimize package size |
+| Ignoring cold starts for user-facing APIs | Use provisioned concurrency, SnapStart (Java/Python/.NET), or optimize package size |
 | Not designing for idempotency | Use idempotency keys with DynamoDB or Powertools |
 | Recursive invocations (function triggers itself) | Set reserved concurrency to 0 immediately; fix the trigger/output separation |
 | Hardcoding resource names | Use environment variables for bucket names, table names, endpoints |
@@ -168,8 +172,8 @@ See `references/security.md` for VPC configuration trade-offs, code signing setu
 ## Reference Files
 
 - **`references/anti-patterns.md`** -- Lambda monolith, Lambda as orchestrator, synchronous chains, recursive loops, synchronous waiting -- why each feels right, impact analysis, migration strategies
-- **`references/function-code.md`** -- Execution environment reuse, cold start factors, idempotency implementation, connection management, RDS Proxy, environment variables
-- **`references/function-configuration.md`** -- Memory/CPU tuning strategies, timeout alignment, quotas, IAM policies, SQS integration, cleanup
+- **`references/function-design.md`** -- Execution environment reuse, cold start factors, idempotency implementation, connection management, RDS Proxy, environment variables
+- **`references/function-configuration.md`** -- Memory/CPU tuning strategies, arm64/Graviton selection, timeout alignment, quotas, IAM policies, SQS integration, cleanup
 - **`references/function-scalability.md`** -- Concurrency estimation, reserved vs provisioned concurrency, scaling rate, upstream/downstream protection, cascade failure prevention
 - **`references/metrics-and-alarms.md`** -- CloudWatch metrics, EMF implementation, structured logging, alarm configuration, Cost Anomaly Detection, X-Ray tracing
 - **`references/stream-events.md`** -- Batch tuning, partial batch response, Kinesis/DynamoDB Streams/SQS scaling, IteratorAge monitoring, SQS FIFO high-throughput mode

--- a/registry/skills/aws-lambda-best-practices/references/anti-patterns.md
+++ b/registry/skills/aws-lambda-best-practices/references/anti-patterns.md
@@ -83,7 +83,7 @@ A payment function must handle:
 
 | Need | Use |
 |---|---|
-| Multi-step workflows within a bounded context | **AWS Step Functions** -- JSON/YAML-defined state machines with built-in error handling, retries, wait states, parallel execution, and visual monitoring. Workflows can run up to 1 year. |
+| Multi-step workflows within a bounded context | **AWS Step Functions** -- state machines with built-in error handling, retries, wait states, parallel execution, and visual monitoring. Workflows can run up to 1 year. |
 | Coordination across multiple microservices | **Amazon EventBridge** -- serverless event bus that routes events based on rules, decoupling producers from consumers |
 | Simple async handoff between two steps | **SQS queue** between Lambda functions |
 
@@ -96,7 +96,8 @@ A payment function must handle:
 Lambda functions invoke other Lambda functions synchronously, forming a chain where each caller waits for the downstream function to return.
 
 ```
-Create Order --> (waits) --> Process Payment --> (waits) --> Create Invoice
+Create Order --> (waits 2s) --> Process Payment --> (waits 3s) --> Create Invoice
+Result: 5s billed x 3 functions = 15s of compute for 5s of work
 ```
 
 ### Why it feels right
@@ -147,7 +148,7 @@ Step Functions state machine:
 A Lambda function writes to the same resource that triggered it, creating an infinite invocation loop.
 
 ```
-S3 put event --> Lambda function --> writes object to SAME S3 bucket --> S3 put event --> Lambda ...
+S3 put event --> Lambda function --> writes to SAME S3 bucket --> S3 put event --> Lambda ...
 ```
 
 ### Why it feels right
@@ -205,11 +206,8 @@ If a recursive loop is running:
 A Lambda function performs multiple independent operations sequentially, waiting for each to complete before starting the next.
 
 ```
-Lambda handler:
-  1. Write to S3        (wait 200ms)
-  2. Write to DynamoDB  (wait 100ms)
-  3. Call external API  (wait 500ms)
-  Total: 800ms billed duration
+Sequential: S3 (200ms) + DynamoDB (100ms) + external API (500ms) = 800ms billed
+Concurrent: max(200ms, 100ms, 500ms) = 500ms billed
 ```
 
 ### Why it feels right
@@ -228,18 +226,7 @@ Lambda handler:
 
 ### What to do instead
 
-**If operations are independent:** run them concurrently within the same function.
-
-```
-Lambda handler:
-  parallel:
-    - Write to S3        (200ms)
-    - Write to DynamoDB  (100ms)
-    - Call external API   (500ms)
-  Total: 500ms billed duration (longest task)
-```
-
-Use your language's concurrency primitives (Promise.all, asyncio.gather, CompletableFuture, goroutines, etc.).
+**If operations are independent:** run them concurrently within the same function using your language's concurrency primitives.
 
 **If operations are dependent** (B needs A's result): split into separate functions connected by events.
 

--- a/registry/skills/aws-lambda-best-practices/references/anti-patterns.md
+++ b/registry/skills/aws-lambda-best-practices/references/anti-patterns.md
@@ -1,0 +1,266 @@
+# Anti-Patterns in Event-Driven Lambda Architectures
+
+These anti-patterns describe situations where Lambda **feels like the right choice** but leads to suboptimal, costly, or fragile architectures. Recognizing them early avoids expensive rework.
+
+## The Lambda Monolith
+
+### The pattern
+
+A single Lambda function contains all application logic and handles all routes or event types. Common when "lift and shift" migrating from EC2, Elastic Beanstalk, or traditional servers.
+
+```
+API Gateway (all routes) --> Single Lambda function --> All downstream resources
+```
+
+### Why it feels right
+
+- Familiar -- mirrors the single-server model developers already know
+- Simple deployment -- one function, one artifact, one pipeline
+- Fewer moving parts initially
+
+### Why it's an anti-pattern
+
+| Problem | Impact |
+|---|---|
+| **Bloated package size** | Contains all code for all paths; slower cold starts |
+| **Overly broad IAM permissions** | Execution role must grant access to every resource for every path; violates least privilege |
+| **Risky upgrades** | Any change to one path risks breaking all paths; entire application deploys as one unit |
+| **Hard to maintain** | Monolithic code repository increases cognitive burden; multiple developers stepping on each other |
+| **Hard to reuse** | Extracting libraries from monoliths is difficult; slows future projects |
+| **Hard to test** | Lines of code grow, combinatorial test complexity grows faster |
+
+### What to do instead
+
+Decompose into individual microservices: **one Lambda function per well-defined task**.
+
+```
+API Gateway /orders   --> createOrder function   --> Orders table
+API Gateway /payments --> processPayment function --> Payments table
+API Gateway /users    --> getUser function        --> Users table
+```
+
+Each function has:
+- Its own minimal deployment package
+- Its own narrowly scoped IAM role
+- Independent deployment and rollback (canary releases)
+- Focused unit tests with smaller input surface
+
+**Migration strategy:** Use the strangler pattern -- extract one route/handler at a time from the monolith into its own function, routing traffic incrementally.
+
+## Lambda as Orchestrator
+
+### The pattern
+
+A Lambda function contains complex branching workflow logic -- conditionals, error handling, retries, wait states, and compensation logic for multi-step business processes.
+
+### Example: payment processing
+
+A payment function must handle:
+- Multiple payment types (cash, check, credit card) with different processing flows
+- Credit card states (approved, declined, pending, fraud review)
+- Partial and full refunds
+- Third-party payment processor outages
+- Multi-day processing windows
+
+### Why it feels right
+
+- Developers are comfortable writing procedural workflow code
+- A single function keeps the "workflow" in one place
+- No additional services to learn
+
+### Why it's an anti-pattern
+
+| Problem | Impact |
+|---|---|
+| **Spaghetti code** | Complex branching, nested error handling, state tracking become unreadable |
+| **Fragile in production** | One edge case in workflow logic can break the entire process |
+| **15-minute timeout** | Long-running workflows hit Lambda's execution limit |
+| **Custom retry logic** | Re-inventing retry, backoff, and compensation patterns that already exist in managed services |
+| **Harder to version** | Changing workflow logic requires changing and redeploying code |
+| **Harder to visualize** | No built-in way to see workflow state or execution history |
+
+### What to do instead
+
+| Need | Use |
+|---|---|
+| Multi-step workflows within a bounded context | **AWS Step Functions** -- JSON/YAML-defined state machines with built-in error handling, retries, wait states, parallel execution, and visual monitoring. Workflows can run up to 1 year. |
+| Coordination across multiple microservices | **Amazon EventBridge** -- serverless event bus that routes events based on rules, decoupling producers from consumers |
+| Simple async handoff between two steps | **SQS queue** between Lambda functions |
+
+**Key insight:** If your Lambda function has more orchestration logic (if/else, try/catch, retry loops, state tracking) than business logic, it belongs in Step Functions.
+
+## Lambda Calling Lambda (Synchronous Chains)
+
+### The pattern
+
+Lambda functions invoke other Lambda functions synchronously, forming a chain where each caller waits for the downstream function to return.
+
+```
+Create Order --> (waits) --> Process Payment --> (waits) --> Create Invoice
+```
+
+### Why it feels right
+
+- Mirrors synchronous function calls in application code
+- Straightforward request/response model
+- Each function is small and focused (appears to follow the microservice principle)
+
+### Why it's an anti-pattern
+
+| Problem | Impact |
+|---|---|
+| **Compounded cost** | All upstream functions run (and bill) while waiting for downstream to complete. 3 chained functions = 3x the duration cost of the slowest |
+| **Complex error handling** | Errors in downstream functions must bubble up through every layer. Should a payment error trigger an order rollback? Each function needs custom compensation logic |
+| **Tight coupling** | The entire chain is only as available as the slowest, least reliable function. One slow function blocks the entire flow |
+| **Wasted concurrency** | Waiting functions consume concurrency slots doing nothing. 3 chained functions = 3x the concurrency consumption |
+| **Cascading timeouts** | Parent function timeout must exceed the sum of all downstream timeouts |
+
+### What to do instead
+
+**Option 1: SQS between functions** (when downstream is slower or independent)
+
+```
+Create Order --> SQS --> Process Payment --> SQS --> Create Invoice
+```
+
+- Each function runs independently, bills only for its own work
+- SQS durably persists messages if downstream is slow or fails
+- Functions scale independently
+
+**Option 2: Step Functions** (when you need orchestration, error handling, retries)
+
+```
+Step Functions state machine:
+  1. Create Order
+  2. Process Payment (with retry on failure)
+  3. Create Invoice (parallel with Send Confirmation)
+```
+
+- Built-in error handling and retry per step
+- Visual execution history for debugging
+- Each Lambda bills only for its own execution time
+
+## Recursive Patterns That Cause Invocation Loops
+
+### The pattern
+
+A Lambda function writes to the same resource that triggered it, creating an infinite invocation loop.
+
+```
+S3 put event --> Lambda function --> writes object to SAME S3 bucket --> S3 put event --> Lambda ...
+```
+
+### Why it feels right
+
+- The function's job is to transform/process data in a bucket or table
+- Writing results back to the source is the simplest implementation
+- "I'll just filter the trigger to avoid the loop" -- but the filter is wrong or incomplete
+
+### Why it's an anti-pattern
+
+| Problem | Impact |
+|---|---|
+| **Infinite scaling** | Both Lambda and S3/SQS/SNS auto-scale, so the loop grows exponentially |
+| **Runaway cost** | Unbounded invocations accumulate charges until the loop is detected and stopped |
+| **Consumes all concurrency** | Loop can consume the entire account's concurrency pool, throttling all other functions |
+| **Hard to detect** | May not be obvious until CloudWatch alarms fire or the bill arrives |
+
+### Services at risk
+
+This is not limited to S3. Recursive loops can occur with:
+- Amazon S3 (put/delete events)
+- Amazon SQS (function sends message back to its source queue)
+- Amazon SNS (function publishes to its source topic)
+- Amazon DynamoDB (function writes to its source table via DynamoDB Streams)
+
+### What to do instead
+
+**Primary rule:** The resource that triggers a function should be different from the resource the function writes to.
+
+```
+Source S3 bucket --> Lambda --> Destination S3 bucket (different bucket)
+Source DynamoDB table --> Lambda --> Destination table or S3
+```
+
+If you must write back to the same resource:
+
+| Safeguard | How |
+|---|---|
+| **Positive trigger filter** | Trigger only on a specific prefix/tag/naming convention that the function's output does NOT match |
+| **Reserved concurrency** | Set a low cap to limit blast radius during development/testing |
+| **CloudWatch alarm** | Alarm on ConcurrentExecutions spike to detect loops early |
+| **Lambda recursive loop detection** | Lambda automatically detects and stops some loops between Lambda, SQS, and SNS (limited scope -- do not rely on this as sole protection) |
+
+### Emergency response
+
+If a recursive loop is running:
+1. Set the function's reserved concurrency to **0** immediately (Lambda console "Throttle" button)
+2. This stops all invocations while you fix the code
+3. Fix the trigger/output separation, then restore concurrency
+
+## Synchronous Waiting Within a Single Function
+
+### The pattern
+
+A Lambda function performs multiple independent operations sequentially, waiting for each to complete before starting the next.
+
+```
+Lambda handler:
+  1. Write to S3        (wait 200ms)
+  2. Write to DynamoDB  (wait 100ms)
+  3. Call external API  (wait 500ms)
+  Total: 800ms billed duration
+```
+
+### Why it feels right
+
+- Sequential code is easy to write and reason about
+- The operations are logically related ("process this order")
+- "It's just three API calls, how bad can it be?"
+
+### Why it's an anti-pattern
+
+| Problem | Impact |
+|---|---|
+| **Compounded latency** | Total duration = sum of all wait times, not the longest |
+| **Higher cost** | Billed for the entire duration, including all wait times |
+| **Unnecessary coupling** | If operations are independent, sequencing them adds no value |
+
+### What to do instead
+
+**If operations are independent:** run them concurrently within the same function.
+
+```
+Lambda handler:
+  parallel:
+    - Write to S3        (200ms)
+    - Write to DynamoDB  (100ms)
+    - Call external API   (500ms)
+  Total: 500ms billed duration (longest task)
+```
+
+Use your language's concurrency primitives (Promise.all, asyncio.gather, CompletableFuture, goroutines, etc.).
+
+**If operations are dependent** (B needs A's result): split into separate functions connected by events.
+
+```
+Lambda A: Write to S3 --> S3 event triggers --> Lambda B: Write to DynamoDB
+```
+
+- Lambda A completes and bills only for its work
+- Lambda B runs independently when triggered by the S3 event
+- Total cost is often lower, and each function is simpler
+
+## Anti-Pattern Decision Matrix
+
+Use this to quickly identify which anti-pattern you might be falling into:
+
+| Signal | Likely anti-pattern | Alternative |
+|---|---|---|
+| Single function handles all API routes | Lambda monolith | Decompose to one function per route |
+| Function has more if/else/retry than business logic | Lambda as orchestrator | Step Functions |
+| Function invokes another function with `invoke()` and waits | Lambda calling Lambda | SQS or Step Functions |
+| Function writes to the same resource that triggered it | Recursive loop | Separate source and destination resources |
+| Function does 3+ independent API calls sequentially | Synchronous waiting | Concurrent execution or event-driven split |
+| Function timeout is set to 15 min "just in case" | Multiple anti-patterns | Measure actual duration; consider decomposition |
+| Function's IAM role has broad wildcards | Lambda monolith symptom | Decompose and scope roles per function |

--- a/registry/skills/aws-lambda-best-practices/references/anti-patterns.md
+++ b/registry/skills/aws-lambda-best-practices/references/anti-patterns.md
@@ -4,24 +4,24 @@ These anti-patterns describe situations where Lambda **feels like the right choi
 
 ## The Lambda Monolith
 
-### The pattern
+### The monolith pattern
 
 A single Lambda function contains all application logic and handles all routes or event types. Common when "lift and shift" migrating from EC2, Elastic Beanstalk, or traditional servers.
 
-```
+```text
 API Gateway (all routes) --> Single Lambda function --> All downstream resources
 ```
 
-### Why it feels right
+### Why the monolith feels right
 
 - Familiar -- mirrors the single-server model developers already know
 - Simple deployment -- one function, one artifact, one pipeline
 - Fewer moving parts initially
 
-### Why it's an anti-pattern
+### Why the monolith is an anti-pattern
 
 | Problem | Impact |
-|---|---|
+| --- | --- |
 | **Bloated package size** | Contains all code for all paths; slower cold starts |
 | **Overly broad IAM permissions** | Execution role must grant access to every resource for every path; violates least privilege |
 | **Risky upgrades** | Any change to one path risks breaking all paths; entire application deploys as one unit |
@@ -29,17 +29,18 @@ API Gateway (all routes) --> Single Lambda function --> All downstream resources
 | **Hard to reuse** | Extracting libraries from monoliths is difficult; slows future projects |
 | **Hard to test** | Lines of code grow, combinatorial test complexity grows faster |
 
-### What to do instead
+### What to do instead of the monolith
 
 Decompose into individual microservices: **one Lambda function per well-defined task**.
 
-```
+```text
 API Gateway /orders   --> createOrder function   --> Orders table
 API Gateway /payments --> processPayment function --> Payments table
 API Gateway /users    --> getUser function        --> Users table
 ```
 
 Each function has:
+
 - Its own minimal deployment package
 - Its own narrowly scoped IAM role
 - Independent deployment and rollback (canary releases)
@@ -49,29 +50,30 @@ Each function has:
 
 ## Lambda as Orchestrator
 
-### The pattern
+### The orchestrator pattern
 
 A Lambda function contains complex branching workflow logic -- conditionals, error handling, retries, wait states, and compensation logic for multi-step business processes.
 
 ### Example: payment processing
 
 A payment function must handle:
+
 - Multiple payment types (cash, check, credit card) with different processing flows
 - Credit card states (approved, declined, pending, fraud review)
 - Partial and full refunds
 - Third-party payment processor outages
 - Multi-day processing windows
 
-### Why it feels right
+### Why orchestrating in Lambda feels right
 
 - Developers are comfortable writing procedural workflow code
 - A single function keeps the "workflow" in one place
 - No additional services to learn
 
-### Why it's an anti-pattern
+### Why the orchestrator is an anti-pattern
 
 | Problem | Impact |
-|---|---|
+| --- | --- |
 | **Spaghetti code** | Complex branching, nested error handling, state tracking become unreadable |
 | **Fragile in production** | One edge case in workflow logic can break the entire process |
 | **15-minute timeout** | Long-running workflows hit Lambda's execution limit |
@@ -79,10 +81,10 @@ A payment function must handle:
 | **Harder to version** | Changing workflow logic requires changing and redeploying code |
 | **Harder to visualize** | No built-in way to see workflow state or execution history |
 
-### What to do instead
+### What to do instead of orchestrating in Lambda
 
 | Need | Use |
-|---|---|
+| --- | --- |
 | Multi-step workflows within a bounded context | **AWS Step Functions** -- state machines with built-in error handling, retries, wait states, parallel execution, and visual monitoring. Workflows can run up to 1 year. |
 | Coordination across multiple microservices | **Amazon EventBridge** -- serverless event bus that routes events based on rules, decoupling producers from consumers |
 | Simple async handoff between two steps | **SQS queue** between Lambda functions |
@@ -91,36 +93,36 @@ A payment function must handle:
 
 ## Lambda Calling Lambda (Synchronous Chains)
 
-### The pattern
+### The synchronous chain pattern
 
 Lambda functions invoke other Lambda functions synchronously, forming a chain where each caller waits for the downstream function to return.
 
-```
+```text
 Create Order --> (waits 2s) --> Process Payment --> (waits 3s) --> Create Invoice
 Result: 5s billed x 3 functions = 15s of compute for 5s of work
 ```
 
-### Why it feels right
+### Why synchronous chains feel right
 
 - Mirrors synchronous function calls in application code
 - Straightforward request/response model
 - Each function is small and focused (appears to follow the microservice principle)
 
-### Why it's an anti-pattern
+### Why synchronous chains are an anti-pattern
 
 | Problem | Impact |
-|---|---|
+| --- | --- |
 | **Compounded cost** | All upstream functions run (and bill) while waiting for downstream to complete. 3 chained functions = 3x the duration cost of the slowest |
 | **Complex error handling** | Errors in downstream functions must bubble up through every layer. Should a payment error trigger an order rollback? Each function needs custom compensation logic |
 | **Tight coupling** | The entire chain is only as available as the slowest, least reliable function. One slow function blocks the entire flow |
 | **Wasted concurrency** | Waiting functions consume concurrency slots doing nothing. 3 chained functions = 3x the concurrency consumption |
 | **Cascading timeouts** | Parent function timeout must exceed the sum of all downstream timeouts |
 
-### What to do instead
+### What to do instead of synchronous chains
 
 **Option 1: SQS between functions** (when downstream is slower or independent)
 
-```
+```text
 Create Order --> SQS --> Process Payment --> SQS --> Create Invoice
 ```
 
@@ -130,7 +132,7 @@ Create Order --> SQS --> Process Payment --> SQS --> Create Invoice
 
 **Option 2: Step Functions** (when you need orchestration, error handling, retries)
 
-```
+```text
 Step Functions state machine:
   1. Create Order
   2. Process Payment (with retry on failure)
@@ -143,24 +145,24 @@ Step Functions state machine:
 
 ## Recursive Patterns That Cause Invocation Loops
 
-### The pattern
+### The recursive loop pattern
 
 A Lambda function writes to the same resource that triggered it, creating an infinite invocation loop.
 
-```
+```text
 S3 put event --> Lambda function --> writes to SAME S3 bucket --> S3 put event --> Lambda ...
 ```
 
-### Why it feels right
+### Why writing back to the source feels right
 
 - The function's job is to transform/process data in a bucket or table
 - Writing results back to the source is the simplest implementation
 - "I'll just filter the trigger to avoid the loop" -- but the filter is wrong or incomplete
 
-### Why it's an anti-pattern
+### Why recursive loops are an anti-pattern
 
 | Problem | Impact |
-|---|---|
+| --- | --- |
 | **Infinite scaling** | Both Lambda and S3/SQS/SNS auto-scale, so the loop grows exponentially |
 | **Runaway cost** | Unbounded invocations accumulate charges until the loop is detected and stopped |
 | **Consumes all concurrency** | Loop can consume the entire account's concurrency pool, throttling all other functions |
@@ -169,16 +171,17 @@ S3 put event --> Lambda function --> writes to SAME S3 bucket --> S3 put event -
 ### Services at risk
 
 This is not limited to S3. Recursive loops can occur with:
+
 - Amazon S3 (put/delete events)
 - Amazon SQS (function sends message back to its source queue)
 - Amazon SNS (function publishes to its source topic)
 - Amazon DynamoDB (function writes to its source table via DynamoDB Streams)
 
-### What to do instead
+### What to do instead of writing back to the source
 
 **Primary rule:** The resource that triggers a function should be different from the resource the function writes to.
 
-```
+```text
 Source S3 bucket --> Lambda --> Destination S3 bucket (different bucket)
 Source DynamoDB table --> Lambda --> Destination table or S3
 ```
@@ -186,51 +189,52 @@ Source DynamoDB table --> Lambda --> Destination table or S3
 If you must write back to the same resource:
 
 | Safeguard | How |
-|---|---|
+| --- | --- |
 | **Positive trigger filter** | Trigger only on a specific prefix/tag/naming convention that the function's output does NOT match |
 | **Reserved concurrency** | Set a low cap to limit blast radius during development/testing |
-| **CloudWatch alarm** | Alarm on ConcurrentExecutions spike to detect loops early |
-| **Lambda recursive loop detection** | Lambda automatically detects and stops some loops between Lambda, SQS, and SNS (limited scope -- do not rely on this as sole protection) |
+| **CloudWatch alarm** | Alarm on ConcurrentExecutions spike and `RecursiveInvocationsDropped` > 0 to detect loops early |
+| **Lambda recursive loop detection** | Lambda automatically stops loops involving Lambda, SQS, S3, and SNS after ~16 invocations in the same request chain (requires a supported AWS SDK version; loops through other services such as DynamoDB are NOT detected -- do not rely on this as the only protection) |
 
 ### Emergency response
 
 If a recursive loop is running:
+
 1. Set the function's reserved concurrency to **0** immediately (Lambda console "Throttle" button)
 2. This stops all invocations while you fix the code
 3. Fix the trigger/output separation, then restore concurrency
 
 ## Synchronous Waiting Within a Single Function
 
-### The pattern
+### The synchronous waiting pattern
 
 A Lambda function performs multiple independent operations sequentially, waiting for each to complete before starting the next.
 
-```
+```text
 Sequential: S3 (200ms) + DynamoDB (100ms) + external API (500ms) = 800ms billed
 Concurrent: max(200ms, 100ms, 500ms) = 500ms billed
 ```
 
-### Why it feels right
+### Why sequential waiting feels right
 
 - Sequential code is easy to write and reason about
 - The operations are logically related ("process this order")
 - "It's just three API calls, how bad can it be?"
 
-### Why it's an anti-pattern
+### Why synchronous waiting is an anti-pattern
 
 | Problem | Impact |
-|---|---|
+| --- | --- |
 | **Compounded latency** | Total duration = sum of all wait times, not the longest |
 | **Higher cost** | Billed for the entire duration, including all wait times |
 | **Unnecessary coupling** | If operations are independent, sequencing them adds no value |
 
-### What to do instead
+### What to do instead of waiting sequentially
 
 **If operations are independent:** run them concurrently within the same function using your language's concurrency primitives.
 
 **If operations are dependent** (B needs A's result): split into separate functions connected by events.
 
-```
+```text
 Lambda A: Write to S3 --> S3 event triggers --> Lambda B: Write to DynamoDB
 ```
 
@@ -243,7 +247,7 @@ Lambda A: Write to S3 --> S3 event triggers --> Lambda B: Write to DynamoDB
 Use this to quickly identify which anti-pattern you might be falling into:
 
 | Signal | Likely anti-pattern | Alternative |
-|---|---|---|
+| --- | --- | --- |
 | Single function handles all API routes | Lambda monolith | Decompose to one function per route |
 | Function has more if/else/retry than business logic | Lambda as orchestrator | Step Functions |
 | Function invokes another function with `invoke()` and waits | Lambda calling Lambda | SQS or Step Functions |

--- a/registry/skills/aws-lambda-best-practices/references/function-code.md
+++ b/registry/skills/aws-lambda-best-practices/references/function-code.md
@@ -4,12 +4,13 @@
 
 The handler is Lambda's entry point. A well-designed handler is thin, testable, and separates concerns:
 
-### Structure
-
 ```
-1. Parse/validate the incoming event
-2. Call business logic (pure functions, no Lambda-specific dependencies)
-3. Format and return the response
+Module level:  initialize DB client, validator (reused across invocations)
+
+Handler:
+  1. Validate incoming event
+  2. Call business logic (pure function, no Lambda dependencies)
+  3. Return structured response
 ```
 
 ### Why this matters
@@ -18,9 +19,21 @@ The handler is Lambda's entry point. A well-designed handler is thin, testable, 
 - **Portability** -- if you later move to ECS or another compute, the business logic doesn't change
 - **Readability** -- the handler reads as a pipeline: input -> process -> output
 
-### Anti-pattern: monolithic handler
+### Anti-pattern: fat handler
 
-Avoid putting validation, business logic, data access, error handling, and response formatting all in the handler. This makes functions hard to test, debug, and maintain.
+```
+Handler:
+  Create new DB connection           <-- re-created every invocation
+  If event type is "order":          <-- routing logic in handler
+    50 lines of validation...
+    80 lines of business logic...
+    30 lines of error handling...
+    Write to DB                      <-- data access mixed in
+    Send email                       <-- side effects buried deep
+    Catch all exceptions --> 500     <-- generic catch-all hides real errors
+```
+
+This is untestable, unreusable, and impossible to reason about when it grows. Split validation, business logic, and data access into separate modules.
 
 ## Execution Environment Reuse
 
@@ -48,7 +61,7 @@ Lambda may reuse the execution environment (the container running your function)
 |---|---|
 | Package size | Larger package = longer initialization |
 | Number of imports/dependencies | More imports = longer module-level execution |
-| VPC attachment | Adds network interface setup time |
+| VPC attachment | Adds ENI setup time on first invocation; significantly reduced since Hyperplane ENI improvements (seconds, not minutes) |
 | Runtime | Interpreted languages (Python, Node.js) generally start faster than compiled (Java, .NET) |
 | Provisioned concurrency | Eliminates cold starts entirely (at additional cost) |
 
@@ -107,23 +120,27 @@ Lambda reuses execution environments, but idle connections get purged. Without k
 
 ### Database connections
 
-| Pattern | When to use |
-|---|---|
-| Connection per invocation | Never (high overhead, connection exhaustion under concurrency) |
-| Module-level connection | Simple functions with low concurrency |
-| Connection pooling (via RDS Proxy) | Functions connecting to RDS at any concurrency |
-| DynamoDB / S3 (HTTP-based) | No connection pooling needed -- SDK handles this |
+| Pattern | Verdict | When to use |
+|---|---|---|
+| Module-level connection + RDS Proxy | Best | Any function connecting to RDS with non-trivial concurrency |
+| Module-level connection (no proxy) | Good | Low-concurrency functions with simple connection needs |
+| Connection per invocation | Avoid for concurrent workloads | Acceptable only for very-low-concurrency functions that run infrequently |
+| HTTP-based services (DynamoDB, S3, SQS) | No pooling needed | SDK handles connection management |
 
 ### RDS Proxy
 
-For relational databases, **always use RDS Proxy** with Lambda:
+For relational databases with non-trivial concurrency, **use RDS Proxy** with Lambda:
 
 - Pools and shares database connections across function instances
 - Handles connection cleanup when Lambda scales down
 - Supports IAM authentication (no passwords in config)
 - Without it: 1,000 concurrent Lambda invocations = 1,000 database connections
 
+For low-concurrency functions (e.g., cron jobs, admin tools), a module-level connection without RDS Proxy is acceptable and avoids the additional cost.
+
 ## Recursive Invocations
+
+See `anti-patterns.md` for full analysis of why recursive patterns feel right, impact tables, and safeguards. This section provides a quick prevention checklist.
 
 A recursive invocation occurs when a Lambda function directly or indirectly triggers itself:
 
@@ -137,7 +154,7 @@ A recursive invocation occurs when a Lambda function directly or indirectly trig
 - **Use prefixes or suffixes** -- trigger on `input/` prefix, write to `output/` prefix
 - **Add a recursion guard** -- check for a recursion marker in the event and bail out
 - **Emergency stop** -- if detected, set reserved concurrency to 0 immediately to halt all invocations while you fix the code
-- **Lambda recursive loop detection** -- Lambda automatically detects and stops recursive loops between Lambda, SQS, and SNS (limited scope)
+- **Lambda recursive loop detection** -- Lambda automatically detects and stops recursive loops between Lambda, SQS, and SNS (limited scope -- do not rely on this as sole protection)
 
 ## Environment Variables
 

--- a/registry/skills/aws-lambda-best-practices/references/function-code.md
+++ b/registry/skills/aws-lambda-best-practices/references/function-code.md
@@ -1,0 +1,150 @@
+# Function Code Best Practices
+
+## Handler Design Principles
+
+The handler is Lambda's entry point. A well-designed handler is thin, testable, and separates concerns:
+
+### Structure
+
+```
+1. Parse/validate the incoming event
+2. Call business logic (pure functions, no Lambda-specific dependencies)
+3. Format and return the response
+```
+
+### Why this matters
+
+- **Testability** -- business logic in pure functions can be unit-tested without mocking Lambda
+- **Portability** -- if you later move to ECS or another compute, the business logic doesn't change
+- **Readability** -- the handler reads as a pipeline: input -> process -> output
+
+### Anti-pattern: monolithic handler
+
+Avoid putting validation, business logic, data access, error handling, and response formatting all in the handler. This makes functions hard to test, debug, and maintain.
+
+## Execution Environment Reuse
+
+Lambda may reuse the execution environment (the container running your function) across invocations. This is called a "warm start."
+
+### What persists between invocations
+
+| Resource | Persists? | Notes |
+|---|---|---|
+| Global/module-level variables | Yes | Use for SDK clients, DB connections, config |
+| `/tmp` directory contents | Yes | Up to configured size (512 MB - 10 GB) |
+| Background processes | Yes, but risky | Lambda may freeze/thaw the environment |
+| Handler-local variables | No | Fresh each invocation |
+
+### Best practices
+
+- **Initialize expensive resources at module level** -- SDK clients, database connection pools, configuration loading, static asset caching
+- **Cache in `/tmp`** -- downloaded files, compiled templates, ML model weights
+- **Never store user-specific state in globals** -- this leaks data between invocations from different users
+- **Don't rely on reuse** -- your code must work correctly on cold starts too
+
+### Cold start impact
+
+| Factor | Impact on cold start |
+|---|---|
+| Package size | Larger package = longer initialization |
+| Number of imports/dependencies | More imports = longer module-level execution |
+| VPC attachment | Adds network interface setup time |
+| Runtime | Interpreted languages (Python, Node.js) generally start faster than compiled (Java, .NET) |
+| Provisioned concurrency | Eliminates cold starts entirely (at additional cost) |
+
+## Idempotency
+
+Lambda provides **at-least-once** invocation semantics. Your function will receive duplicate events in the following scenarios:
+
+- Async invocation retries (up to 2 retries by default)
+- Stream event source mapping reprocessing on failure
+- SQS visibility timeout expiry causing redelivery
+- Network issues between Lambda and your function
+
+### Implementing idempotency
+
+1. **Extract an idempotency key** from the event (request ID, message ID, transaction ID)
+2. **Check if already processed** -- look up the key in a persistent store (DynamoDB is common)
+3. **If new, process and store the result** with the key
+4. **If duplicate, return the stored result** without reprocessing
+
+### Idempotency key selection
+
+| Event source | Good idempotency key |
+|---|---|
+| API Gateway | `requestContext.requestId` or a client-supplied header |
+| SQS | `messageId` |
+| SNS | `Sns.MessageId` |
+| Kinesis | `eventID` or a composite of `partitionKey` + `sequenceNumber` |
+| DynamoDB Streams | `eventID` |
+| S3 | Bucket + key + versionId |
+| EventBridge | `id` |
+
+### Operations that are naturally idempotent
+
+Some operations don't need explicit idempotency handling:
+
+- **Upserts** -- writing the same value to the same key
+- **S3 PutObject** with deterministic content -- same content to same key
+- **DynamoDB PutItem** with same attributes -- overwrites with identical data
+
+Operations that are **not** naturally idempotent:
+
+- Counter increments (`UpdateItem` with `ADD`)
+- Sending emails or notifications
+- Financial transactions
+- Appending to a list
+
+## Connection Management
+
+### Keep-alive directives
+
+Lambda reuses execution environments, but idle connections get purged. Without keep-alive, you get connection errors on warm starts.
+
+- Enable TCP keep-alive in your HTTP client configuration
+- Set appropriate idle timeout (shorter than Lambda's purge interval)
+- Most AWS SDKs enable keep-alive by default in recent versions -- verify your SDK version
+
+### Database connections
+
+| Pattern | When to use |
+|---|---|
+| Connection per invocation | Never (high overhead, connection exhaustion under concurrency) |
+| Module-level connection | Simple functions with low concurrency |
+| Connection pooling (via RDS Proxy) | Functions connecting to RDS at any concurrency |
+| DynamoDB / S3 (HTTP-based) | No connection pooling needed -- SDK handles this |
+
+### RDS Proxy
+
+For relational databases, **always use RDS Proxy** with Lambda:
+
+- Pools and shares database connections across function instances
+- Handles connection cleanup when Lambda scales down
+- Supports IAM authentication (no passwords in config)
+- Without it: 1,000 concurrent Lambda invocations = 1,000 database connections
+
+## Recursive Invocations
+
+A recursive invocation occurs when a Lambda function directly or indirectly triggers itself:
+
+- Function writes to an S3 bucket -> S3 event triggers the same function
+- Function publishes to an SNS topic -> SNS triggers the same function
+- Function writes to a DynamoDB table -> DynamoDB Stream triggers the same function
+
+### Prevention
+
+- **Design the trigger and output to use different resources** -- write to a different bucket/table than the one triggering the function
+- **Use prefixes or suffixes** -- trigger on `input/` prefix, write to `output/` prefix
+- **Add a recursion guard** -- check for a recursion marker in the event and bail out
+- **Emergency stop** -- if detected, set reserved concurrency to 0 immediately to halt all invocations while you fix the code
+- **Lambda recursive loop detection** -- Lambda automatically detects and stops recursive loops between Lambda, SQS, and SNS (limited scope)
+
+## Environment Variables
+
+| Guideline | Why |
+|---|---|
+| Use env vars for operational parameters | Bucket names, table names, API endpoints, feature flags |
+| Never hardcode resource identifiers | Enables multi-environment deployment (dev/staging/prod) |
+| Don't store secrets in plain-text env vars | Use Secrets Manager or Parameter Store with env var references |
+| Total env var size limit is 4 KB | For larger config, use Parameter Store or S3 |
+| Env vars are encrypted at rest with KMS | Use a customer-managed CMK for sensitive values |

--- a/registry/skills/aws-lambda-best-practices/references/function-configuration.md
+++ b/registry/skills/aws-lambda-best-practices/references/function-configuration.md
@@ -1,0 +1,143 @@
+# Function Configuration
+
+## Memory and CPU Tuning
+
+### The memory-CPU relationship
+
+Lambda allocates CPU power proportional to configured memory:
+
+| Memory | Approximate CPU | vCPU equivalent |
+|---|---|---|
+| 128 MB | ~7% of a vCPU | 0.07 |
+| 256 MB | ~14% of a vCPU | 0.14 |
+| 512 MB | ~28% of a vCPU | 0.28 |
+| 1,024 MB | ~56% of a vCPU | 0.56 |
+| 1,769 MB | 1 full vCPU | 1.0 |
+| 3,538 MB | 2 vCPU | 2.0 |
+| 5,307 MB | 3 vCPU | 3.0 |
+| 10,240 MB | ~6 vCPU | 5.8 |
+
+### Finding optimal memory
+
+More memory doesn't always mean more cost. A function at 256 MB running for 1,000ms costs the same as the same function at 512 MB running for 500ms -- but finishes twice as fast.
+
+**Use AWS Lambda Power Tuning:**
+
+1. Deploy the [Power Tuning state machine](https://github.com/alexcasalboni/aws-lambda-power-tuning) in your account
+2. Run it against your function with a representative payload
+3. It tests multiple memory configurations and produces a cost-vs-speed graph
+4. Pick the knee of the curve -- best price/performance balance
+
+### When to go higher
+
+| Signal | Action |
+|---|---|
+| `Max Memory Used` close to configured memory | Increase memory (risk of OOM) |
+| Duration decreases linearly with more memory | Function is CPU-bound; more memory = more CPU |
+| Duration doesn't change with more memory | Function is I/O-bound (waiting on network); more memory won't help |
+| Billed Duration >> actual Duration | You're paying for unused capacity; consider reducing |
+
+### Monitoring memory usage
+
+Every invocation logs a `REPORT` line:
+
+```
+REPORT RequestId: abc123  Duration: 45.00 ms  Billed Duration: 46 ms  Memory Size: 256 MB  Max Memory Used: 82 MB
+```
+
+Track `Max Memory Used` over time. If it consistently stays far below configured memory, you're over-provisioned.
+
+## Timeout Strategy
+
+### Setting the right timeout
+
+| Principle | Details |
+|---|---|
+| Measure actual duration under load | Not just happy-path; include downstream latency |
+| Add a buffer (20-50%) above measured p99 | Accounts for variance without excessive waste |
+| Never use the max (900s) as a default | A stuck function at 15 min timeout accumulates cost and concurrency |
+| Align with upstream expectations | API Gateway has a 29-second integration timeout |
+| Align with downstream expectations | SQS Visibility Timeout must exceed function timeout |
+
+### SQS Visibility Timeout alignment
+
+When Lambda processes SQS messages:
+
+```
+Function timeout < SQS Visibility Timeout
+```
+
+If the function times out before the visibility timeout expires, the message remains invisible. If the function timeout exceeds visibility timeout, the message becomes visible again and triggers a duplicate invocation.
+
+**Recommended:** Set SQS Visibility Timeout to **6x your function timeout** (AWS recommendation).
+
+### API Gateway integration timeout
+
+API Gateway enforces a **29-second** maximum integration timeout. If your Lambda function needs more than 29 seconds:
+
+- Refactor to async pattern: API Gateway -> Lambda (start job) -> Step Functions or SQS -> Lambda (process)
+- Use Lambda response streaming for long-running responses
+
+## Quotas Reference
+
+### Hard limits (cannot be increased)
+
+| Resource | Limit |
+|---|---|
+| Maximum execution time | 900 seconds (15 minutes) |
+| Synchronous payload (request) | 6 MB |
+| Synchronous payload (response) | 6 MB (200 MB streamed) |
+| Asynchronous payload | 1 MB |
+| Deployment package (zipped) | 50 MB via API (use S3 for larger) |
+| Deployment package (unzipped) | 250 MB (including layers) |
+| Container image | 10 GB |
+| Environment variables | 4 KB total |
+| Layers | 5 per function |
+| File descriptors | 1,024 |
+| Processes/threads | 1,024 |
+
+### Soft limits (can be increased via Service Quotas)
+
+| Resource | Default | Typical increase |
+|---|---|---|
+| Concurrent executions | 1,000 | Tens of thousands |
+| Function code storage | 75 GB | Terabytes |
+| ENIs per VPC | 500 | Thousands |
+
+### New accounts
+
+New AWS accounts start with **reduced** concurrency and memory quotas. AWS raises these automatically based on usage. If you need immediate capacity, request increases through Service Quotas.
+
+## IAM Execution Role
+
+### Least privilege checklist
+
+- Grant only the specific API actions needed (e.g., `dynamodb:GetItem`, not `dynamodb:*`)
+- Restrict resources to specific ARNs (e.g., the specific table, not `*`)
+- Use IAM conditions where appropriate (e.g., `aws:RequestedRegion`)
+- One role per function (or per group of functions with identical needs)
+- Audit roles with IAM Access Analyzer to identify unused permissions
+
+### Common execution role permissions
+
+| Function type | Typical permissions |
+|---|---|
+| API handler | DynamoDB CRUD on specific table, CloudWatch Logs |
+| S3 processor | S3 GetObject on source bucket, PutObject on destination bucket |
+| SQS consumer | SQS ReceiveMessage, DeleteMessage, GetQueueAttributes |
+| Kinesis consumer | Kinesis GetRecords, GetShardIterator, DescribeStream, ListShards |
+
+### Managed policies to avoid in production
+
+- `AWSLambdaFullAccess` -- overly broad
+- `AdministratorAccess` -- never attach to a Lambda execution role
+- `AmazonS3FullAccess` -- grants access to all buckets
+
+## Function Lifecycle Management
+
+### Cleanup
+
+- **Delete unused functions** -- they count against your code storage quota (75 GB default)
+- **Remove old versions** -- each published version consumes storage
+- **Prune unused layers** -- layer versions also count against storage
+- **Archive** -- if you need to retain code, store it in S3 or a code repository, not as deployed Lambda functions

--- a/registry/skills/aws-lambda-best-practices/references/function-configuration.md
+++ b/registry/skills/aws-lambda-best-practices/references/function-configuration.md
@@ -15,7 +15,7 @@ Lambda allocates CPU power proportional to configured memory:
 | 1,769 MB | 1 full vCPU | 1.0 |
 | 3,538 MB | 2 vCPU | 2.0 |
 | 5,307 MB | 3 vCPU | 3.0 |
-| 10,240 MB | ~6 vCPU | 5.8 |
+| 10,240 MB | ~6 vCPU | ~5.8 |
 
 ### Finding optimal memory
 

--- a/registry/skills/aws-lambda-best-practices/references/function-configuration.md
+++ b/registry/skills/aws-lambda-best-practices/references/function-configuration.md
@@ -7,7 +7,7 @@
 Lambda allocates CPU power proportional to configured memory:
 
 | Memory | Approximate CPU | vCPU equivalent |
-|---|---|---|
+| --- | --- | --- |
 | 128 MB | ~7% of a vCPU | 0.07 |
 | 256 MB | ~14% of a vCPU | 0.14 |
 | 512 MB | ~28% of a vCPU | 0.28 |
@@ -31,7 +31,7 @@ More memory doesn't always mean more cost. A function at 256 MB running for 1,00
 ### When to go higher
 
 | Signal | Action |
-|---|---|
+| --- | --- |
 | `Max Memory Used` close to configured memory | Increase memory (risk of OOM) |
 | Duration decreases linearly with more memory | Function is CPU-bound; more memory = more CPU |
 | Duration doesn't change with more memory | Function is I/O-bound (waiting on network); more memory won't help |
@@ -41,29 +41,37 @@ More memory doesn't always mean more cost. A function at 256 MB running for 1,00
 
 Every invocation logs a `REPORT` line:
 
-```
+```text
 REPORT RequestId: abc123  Duration: 45.00 ms  Billed Duration: 46 ms  Memory Size: 256 MB  Max Memory Used: 82 MB
 ```
 
 Track `Max Memory Used` over time. If it consistently stays far below configured memory, you're over-provisioned.
+
+## Architecture Selection (x86_64 vs arm64)
+
+- **Default to arm64 (AWS Graviton) for new functions** -- duration charges are 20% lower than x86_64, with up to 19% better performance (AWS cites up to 34% better price/performance)
+- The 20% duration discount also applies to provisioned concurrency
+- Switching is a one-line config change (`Architectures: [arm64]`) for functions without architecture-specific binaries -- typical for Python, Node.js, and Java bytecode
+- Before switching, verify arm64 support in: native dependencies (compiled wheels, shared libraries), layers, extensions, and container base images
+- Benchmark both architectures with Lambda Power Tuning -- gains are workload-dependent
 
 ## Timeout Strategy
 
 ### Setting the right timeout
 
 | Principle | Details |
-|---|---|
+| --- | --- |
 | Measure actual duration under load | Not just happy-path; include downstream latency |
 | Add a buffer (20-50%) above measured p99 | Accounts for variance without excessive waste |
 | Never use the max (900s) as a default | A stuck function at 15 min timeout accumulates cost and concurrency |
-| Align with upstream expectations | API Gateway has a 29-second integration timeout |
+| Align with upstream expectations | API Gateway's integration timeout is 29 seconds by default (see below) |
 | Align with downstream expectations | SQS Visibility Timeout must exceed function timeout |
 
 ### SQS Visibility Timeout alignment
 
 When Lambda processes SQS messages:
 
-```
+```text
 Function timeout < SQS Visibility Timeout
 ```
 
@@ -73,17 +81,19 @@ If the function times out before the visibility timeout expires, the message rem
 
 ### API Gateway integration timeout
 
-API Gateway enforces a **29-second** maximum integration timeout. If your Lambda function needs more than 29 seconds:
+API Gateway's integration timeout is **29 seconds by default**. For **Regional and private REST APIs**, it can be raised above 29 seconds via a Service Quotas increase (may require reducing the account-level throttle quota). Edge-optimized REST APIs, HTTP APIs (30-second cap), and WebSocket APIs cannot be increased.
+
+If your Lambda function needs to run longer, prefer restructuring over a timeout increase:
 
 - Refactor to async pattern: API Gateway -> Lambda (start job) -> Step Functions or SQS -> Lambda (process)
-- Use Lambda response streaming for long-running responses
+- Use Lambda response streaming (via Function URLs) for long-running responses
 
 ## Quotas Reference
 
 ### Hard limits (cannot be increased)
 
 | Resource | Limit |
-|---|---|
+| --- | --- |
 | Maximum execution time | 900 seconds (15 minutes) |
 | Synchronous payload (request) | 6 MB |
 | Synchronous payload (response) | 6 MB (200 MB streamed) |
@@ -99,10 +109,10 @@ API Gateway enforces a **29-second** maximum integration timeout. If your Lambda
 ### Soft limits (can be increased via Service Quotas)
 
 | Resource | Default | Typical increase |
-|---|---|---|
+| --- | --- | --- |
 | Concurrent executions | 1,000 | Tens of thousands |
 | Function code storage | 75 GB | Terabytes |
-| ENIs per VPC | 500 | Thousands |
+| ENIs per VPC | 250 | Thousands |
 
 ### New accounts
 
@@ -121,7 +131,7 @@ New AWS accounts start with **reduced** concurrency and memory quotas. AWS raise
 ### Common execution role permissions
 
 | Function type | Typical permissions |
-|---|---|
+| --- | --- |
 | API handler | DynamoDB CRUD on specific table, CloudWatch Logs |
 | S3 processor | S3 GetObject on source bucket, PutObject on destination bucket |
 | SQS consumer | SQS ReceiveMessage, DeleteMessage, GetQueueAttributes |

--- a/registry/skills/aws-lambda-best-practices/references/function-design.md
+++ b/registry/skills/aws-lambda-best-practices/references/function-design.md
@@ -1,10 +1,10 @@
-# Function Code Best Practices
+# Function Design Best Practices
 
 ## Handler Design Principles
 
 The handler is Lambda's entry point. A well-designed handler is thin, testable, and separates concerns:
 
-```
+```text
 Module level:  initialize DB client, validator (reused across invocations)
 
 Handler:
@@ -21,7 +21,7 @@ Handler:
 
 ### Anti-pattern: fat handler
 
-```
+```text
 Handler:
   Create new DB connection           <-- re-created every invocation
   If event type is "order":          <-- routing logic in handler
@@ -42,7 +42,7 @@ Lambda may reuse the execution environment (the container running your function)
 ### What persists between invocations
 
 | Resource | Persists? | Notes |
-|---|---|---|
+| --- | --- | --- |
 | Global/module-level variables | Yes | Use for SDK clients, DB connections, config |
 | `/tmp` directory contents | Yes | Up to configured size (512 MB - 10 GB) |
 | Background processes | Yes, but risky | Lambda may freeze/thaw the environment |
@@ -58,18 +58,20 @@ Lambda may reuse the execution environment (the container running your function)
 ### Cold start impact
 
 | Factor | Impact on cold start |
-|---|---|
+| --- | --- |
 | Package size | Larger package = longer initialization |
 | Number of imports/dependencies | More imports = longer module-level execution |
-| VPC attachment | Adds ENI setup time on first invocation; significantly reduced since Hyperplane ENI improvements (seconds, not minutes) |
+| VPC attachment | Minimal impact since Hyperplane ENIs -- interfaces are created when the function is created or its VPC config changes, not at invocation; cold starts only set up a network tunnel to the pre-created ENI |
 | Runtime | Interpreted languages (Python, Node.js) generally start faster than compiled (Java, .NET) |
+| SnapStart | Resumes from a pre-initialized snapshot instead of running init -- often sub-second cold starts. Java 11+, Python 3.12+, .NET 8+ only; published versions/aliases only; no extra cost for Java, cache + restore charges for Python/.NET; incompatible with provisioned concurrency |
 | Provisioned concurrency | Eliminates cold starts entirely (at additional cost) |
 
 ## Idempotency
 
 Lambda provides **at-least-once** invocation semantics. Your function will receive duplicate events in the following scenarios:
 
-- Async invocation retries (up to 2 retries by default)
+- Async invocation retries -- function errors are retried up to 2 more times by default; throttles (429) and system errors (5xx) are requeued for up to 6 hours
+- Async event queue is eventually consistent -- the same event can be delivered more than once even without errors
 - Stream event source mapping reprocessing on failure
 - SQS visibility timeout expiry causing redelivery
 - Network issues between Lambda and your function
@@ -84,7 +86,7 @@ Lambda provides **at-least-once** invocation semantics. Your function will recei
 ### Idempotency key selection
 
 | Event source | Good idempotency key |
-|---|---|
+| --- | --- |
 | API Gateway | `requestContext.requestId` or a client-supplied header |
 | SQS | `messageId` |
 | SNS | `Sns.MessageId` |
@@ -121,7 +123,7 @@ Lambda reuses execution environments, but idle connections get purged. Without k
 ### Database connections
 
 | Pattern | Verdict | When to use |
-|---|---|---|
+| --- | --- | --- |
 | Module-level connection + RDS Proxy | Best | Any function connecting to RDS with non-trivial concurrency |
 | Module-level connection (no proxy) | Good | Low-concurrency functions with simple connection needs |
 | Connection per invocation | Avoid for concurrent workloads | Acceptable only for very-low-concurrency functions that run infrequently |
@@ -154,12 +156,12 @@ A recursive invocation occurs when a Lambda function directly or indirectly trig
 - **Use prefixes or suffixes** -- trigger on `input/` prefix, write to `output/` prefix
 - **Add a recursion guard** -- check for a recursion marker in the event and bail out
 - **Emergency stop** -- if detected, set reserved concurrency to 0 immediately to halt all invocations while you fix the code
-- **Lambda recursive loop detection** -- Lambda automatically detects and stops recursive loops between Lambda, SQS, and SNS (limited scope -- do not rely on this as sole protection)
+- **Lambda recursive loop detection** -- Lambda automatically stops loops involving Lambda, SQS, S3, and SNS after ~16 invocations in the same request chain (on by default, requires a supported AWS SDK version). Loops through other services -- including DynamoDB Streams -- are NOT detected, so do not rely on this as the only protection. If recursion is intentional, set the function's recursion config to `Allow` (`PutFunctionRecursionConfig`)
 
 ## Environment Variables
 
 | Guideline | Why |
-|---|---|
+| --- | --- |
 | Use env vars for operational parameters | Bucket names, table names, API endpoints, feature flags |
 | Never hardcode resource identifiers | Enables multi-environment deployment (dev/staging/prod) |
 | Don't store secrets in plain-text env vars | Use Secrets Manager or Parameter Store with env var references |

--- a/registry/skills/aws-lambda-best-practices/references/function-scalability.md
+++ b/registry/skills/aws-lambda-best-practices/references/function-scalability.md
@@ -1,0 +1,160 @@
+# Function Scalability
+
+## Concurrency Model
+
+### How Lambda scales
+
+Lambda creates one execution environment per concurrent request. Concurrency is determined by:
+
+```
+Concurrency = (requests per second) x (average duration in seconds)
+```
+
+| Scenario | RPS | Avg duration | Concurrency needed |
+|---|---|---|---|
+| Fast API handler | 1,000 | 50ms | 50 |
+| Moderate processing | 500 | 200ms | 100 |
+| Heavy computation | 100 | 2s | 200 |
+| Slow external API call | 50 | 5s | 250 |
+
+### Scaling rate
+
+Lambda scales at **1,000 new execution environments every 10 seconds** per function. This means:
+
+- At t=0: up to 1,000 environments
+- At t=10s: up to 2,000 environments
+- At t=20s: up to 3,000 environments
+
+This scaling rate applies per function, regardless of account-level concurrency limits.
+
+### Account concurrency pool
+
+All functions in a region share the account's concurrency pool (1,000 default). If `function-a` consumes 900, only 100 remain for all other functions. This is why reserved concurrency matters.
+
+## Reserved Concurrency
+
+Reserved concurrency sets both a **minimum guarantee** and a **maximum cap** for a function.
+
+### When to use
+
+| Scenario | Reserved concurrency value |
+|---|---|
+| Critical function that must always have capacity | Set to peak expected concurrency |
+| Function that overwhelms downstream (DB, API) | Set to downstream's safe throughput |
+| Emergency stop for a runaway function | Set to 0 |
+| Non-critical background processing | Leave unreserved (shares the pool) |
+
+### Trade-offs
+
+| Benefit | Cost |
+|---|---|
+| Guarantees capacity for your function | Reduces available capacity for other functions |
+| Caps scaling to protect downstream | Can cause throttling if traffic exceeds reserved amount |
+| Free (no additional charges) | Must leave 100 units unreserved for other functions |
+
+### Calculating reserved concurrency
+
+Use CloudWatch `ConcurrentExecutions` metric:
+
+1. Look at peak concurrency over a representative period (1-2 weeks)
+2. Add 20-50% buffer above the peak
+3. Verify that remaining unreserved pool is sufficient for other functions
+
+### Formula verification
+
+```
+Reserved = peak_concurrent_executions x 1.3  (30% buffer)
+```
+
+Ensure: `sum(all reserved) <= account_limit - 100`
+
+## Provisioned Concurrency
+
+Provisioned concurrency **pre-initializes** execution environments so they're ready to serve requests immediately (no cold start).
+
+### When to use
+
+| Use case | Provisioned concurrency? |
+|---|---|
+| User-facing API with latency SLA | Yes |
+| Interactive web/mobile backend | Yes |
+| Async data pipeline | No (latency-insensitive) |
+| Scheduled batch job | Rarely (only if cold start exceeds timeout tolerance) |
+| Event-driven with unpredictable spikes | Maybe (combine with auto-scaling) |
+
+### Provisioned concurrency auto-scaling
+
+Use Application Auto Scaling to adjust provisioned concurrency based on a schedule or utilization:
+
+- **Scheduled scaling** -- increase before known traffic peaks (e.g., business hours, marketing campaigns)
+- **Target tracking** -- maintain a target utilization (e.g., keep 70% of provisioned concurrency utilized)
+
+### Cost model
+
+- Provisioned concurrency has a per-hour charge for pre-initialized environments
+- Requests served by provisioned environments cost less per request than on-demand
+- Over-provisioning wastes money; under-provisioning falls back to cold starts
+- Use Power Tuning and CloudWatch metrics to right-size
+
+## Throttle Tolerance
+
+When Lambda cannot scale fast enough or hits concurrency limits, it throttles requests.
+
+### Synchronous invocations (API Gateway, SDK calls)
+
+Throttled requests return HTTP 429 (TooManyRequestsException). The caller is responsible for retrying.
+
+**Caller-side strategies:**
+
+- Exponential backoff with jitter
+- Circuit breaker pattern for downstream protection
+- Queue-based load leveling (put requests in SQS, process at sustainable rate)
+
+### Asynchronous invocations (S3, SNS, EventBridge)
+
+Lambda automatically retries throttled async invocations:
+
+- Retries up to 2 times (configurable)
+- Backs off automatically between retries
+- After retries are exhausted, sends to Dead Letter Queue (DLQ) or failure destination
+
+### Event source mappings (SQS, Kinesis, DynamoDB Streams)
+
+Lambda manages retries internally:
+
+- SQS: messages return to the queue after visibility timeout, retried until maxReceiveCount, then go to DLQ
+- Kinesis/DynamoDB Streams: retries the batch until success or record expiry (bisects batch on failure if configured)
+
+## Upstream/Downstream Protection
+
+### Downstream bottleneck patterns
+
+| Downstream | Problem | Solution |
+|---|---|---|
+| RDS database | Connection exhaustion | Use RDS Proxy; set reserved concurrency to match connection pool |
+| DynamoDB (provisioned) | Write throttling | Switch to on-demand; or match WCU to expected concurrency |
+| Third-party API | Rate limit exceeded | Set reserved concurrency to stay within rate limit |
+| SQS (as destination) | N/A | SQS scales automatically |
+| S3 | Prefix throttling (3,500 PUT/s) | Distribute keys across prefixes |
+
+### Upstream mismatch patterns
+
+| Upstream | Problem | Solution |
+|---|---|---|
+| API Gateway | 10,000 RPS default > Lambda 1,000 concurrency | Increase Lambda concurrency or add API Gateway throttling |
+| ALB | No default request limit | Set Lambda reserved concurrency to protect downstream |
+| CloudFront + Lambda@Edge | Global traffic concentration | Use regional edge caches; set appropriate concurrency |
+
+### The cascade failure pattern
+
+```
+Traffic spike
+  -> Lambda scales to 1,000 concurrent
+    -> 1,000 simultaneous DB connections
+      -> Database CPU/connection exhaustion
+        -> All Lambda functions timeout waiting for DB
+          -> Concurrency stays maxed (long-running stuck functions)
+            -> New requests throttled
+```
+
+**Prevention:** Reserved concurrency + RDS Proxy + appropriate timeout + circuit breakers.

--- a/registry/skills/aws-lambda-best-practices/references/function-scalability.md
+++ b/registry/skills/aws-lambda-best-practices/references/function-scalability.md
@@ -6,12 +6,12 @@
 
 Lambda creates one execution environment per concurrent request. Concurrency is determined by:
 
-```
+```text
 Concurrency = (requests per second) x (average duration in seconds)
 ```
 
 | Scenario | RPS | Avg duration | Concurrency needed |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Fast API handler | 1,000 | 50ms | 50 |
 | Moderate processing | 500 | 200ms | 100 |
 | Heavy computation | 100 | 2s | 200 |
@@ -19,13 +19,11 @@ Concurrency = (requests per second) x (average duration in seconds)
 
 ### Scaling rate
 
-Lambda scales at **1,000 new execution environments every 10 seconds** per function. This means:
-
-- At t=0: up to 1,000 environments
-- At t=10s: up to 2,000 environments
-- At t=20s: up to 3,000 environments
-
-This scaling rate applies per function, regardless of account-level concurrency limits.
+- Maximum scaling rate: **1,000 new execution environments per 10 seconds**, per function, per Region
+- This is an upper bound, not a step schedule -- capacity refills continuously (best effort)
+- Unused capacity does not accrue
+- The rate is per function; total scale-out is still capped by account concurrency (or reserved concurrency)
+- Requests beyond the scaling rate or available concurrency are throttled (429)
 
 ### Account concurrency pool
 
@@ -35,10 +33,10 @@ All functions in a region share the account's concurrency pool (1,000 default). 
 
 Reserved concurrency sets both a **minimum guarantee** and a **maximum cap** for a function.
 
-### When to use
+### When to use reserved concurrency
 
 | Scenario | Reserved concurrency value |
-|---|---|
+| --- | --- |
 | Critical function that must always have capacity | Set to peak expected concurrency |
 | Function that overwhelms downstream (DB, API) | Set to downstream's safe throughput |
 | Emergency stop for a runaway function | Set to 0 |
@@ -47,7 +45,7 @@ Reserved concurrency sets both a **minimum guarantee** and a **maximum cap** for
 ### Trade-offs
 
 | Benefit | Cost |
-|---|---|
+| --- | --- |
 | Guarantees capacity for your function | Reduces available capacity for other functions |
 | Caps scaling to protect downstream | Can cause throttling if traffic exceeds reserved amount |
 | Free (no additional charges) | Must leave 100 units unreserved for other functions |
@@ -62,7 +60,7 @@ Use CloudWatch `ConcurrentExecutions` metric:
 
 ### Formula verification
 
-```
+```text
 Reserved = peak_concurrent_executions x 1.3  (30% buffer)
 ```
 
@@ -72,10 +70,10 @@ Ensure: `sum(all reserved) <= account_limit - 100`
 
 Provisioned concurrency **pre-initializes** execution environments so they're ready to serve requests immediately (no cold start).
 
-### When to use
+### When to use provisioned concurrency
 
 | Use case | Provisioned concurrency? |
-|---|---|
+| --- | --- |
 | User-facing API with latency SLA | Yes |
 | Interactive web/mobile backend | Yes |
 | Async data pipeline | No (latency-insensitive) |
@@ -130,7 +128,7 @@ Lambda manages retries internally:
 ### Downstream bottleneck patterns
 
 | Downstream | Problem | Solution |
-|---|---|---|
+| --- | --- | --- |
 | RDS database | Connection exhaustion | Use RDS Proxy; set reserved concurrency to match connection pool |
 | DynamoDB (provisioned) | Write throttling | Switch to on-demand; or match WCU to expected concurrency |
 | Third-party API | Rate limit exceeded | Set reserved concurrency to stay within rate limit |
@@ -140,14 +138,14 @@ Lambda manages retries internally:
 ### Upstream mismatch patterns
 
 | Upstream | Problem | Solution |
-|---|---|---|
+| --- | --- | --- |
 | API Gateway | 10,000 RPS default > Lambda 1,000 concurrency | Increase Lambda concurrency or add API Gateway throttling |
 | ALB | No default request limit | Set Lambda reserved concurrency to protect downstream |
 | CloudFront + Lambda@Edge | Global traffic concentration | Use regional edge caches; set appropriate concurrency |
 
 ### The cascade failure pattern
 
-```
+```text
 Traffic spike
   -> Lambda scales to 1,000 concurrent
     -> 1,000 simultaneous DB connections

--- a/registry/skills/aws-lambda-best-practices/references/function-scalability.md
+++ b/registry/skills/aws-lambda-best-practices/references/function-scalability.md
@@ -110,11 +110,11 @@ Throttled requests return HTTP 429 (TooManyRequestsException). The caller is res
 
 ### Asynchronous invocations (S3, SNS, EventBridge)
 
-Lambda automatically retries throttled async invocations:
+Lambda automatically retries async invocations, with different behavior per error type:
 
-- Retries up to 2 times (configurable)
-- Backs off automatically between retries
-- After retries are exhausted, sends to Dead Letter Queue (DLQ) or failure destination
+- Function errors: retried up to 2 more times (configurable), with backoff between retries
+- Throttles and system errors: the event returns to the internal queue and Lambda retries for up to 6 hours (configurable via maximum event age)
+- After retries are exhausted, the event is sent to a Dead Letter Queue (DLQ) or failure destination
 
 ### Event source mappings (SQS, Kinesis, DynamoDB Streams)
 

--- a/registry/skills/aws-lambda-best-practices/references/metrics-and-alarms.md
+++ b/registry/skills/aws-lambda-best-practices/references/metrics-and-alarms.md
@@ -48,12 +48,14 @@ Lambda publishes these metrics to CloudWatch automatically (no instrumentation r
 
 ## Embedded Metric Format (EMF)
 
-### Why EMF over PutMetricData
+### Why prefer EMF over PutMetricData
 
 | Approach | Latency impact | Cost | Complexity |
 |---|---|---|---|
 | `PutMetricData` API call in handler | Adds network round-trip to each invocation | API call charges + higher function duration | Error handling for API failures |
 | EMF (metrics in structured logs) | Zero -- metrics emitted as log lines | Standard CloudWatch Logs ingestion | Minimal -- structured log lines |
+
+EMF is the default choice for most use cases. Use `PutMetricData` only when you need high-resolution metrics (1-second resolution) or immediate metric availability without log ingestion delay.
 
 ### How EMF works
 

--- a/registry/skills/aws-lambda-best-practices/references/metrics-and-alarms.md
+++ b/registry/skills/aws-lambda-best-practices/references/metrics-and-alarms.md
@@ -1,0 +1,158 @@
+# Metrics and Alarms
+
+## Built-in Lambda Metrics
+
+Lambda publishes these metrics to CloudWatch automatically (no instrumentation required):
+
+| Metric | Unit | What it tells you |
+|---|---|---|
+| `Invocations` | Count | Number of times your function was invoked |
+| `Duration` | Milliseconds | Execution time (use p50, p90, p99 percentiles) |
+| `Errors` | Count | Invocations that resulted in a function error |
+| `Throttles` | Count | Invocations rejected due to concurrency limits |
+| `ConcurrentExecutions` | Count | Number of concurrent function instances |
+| `UnreservedConcurrentExecutions` | Count | Concurrency used from the unreserved pool |
+| `ProvisionedConcurrencyInvocations` | Count | Invocations served by provisioned environments |
+| `ProvisionedConcurrencySpilloverInvocations` | Count | Invocations that exceeded provisioned concurrency |
+| `ProvisionedConcurrencyUtilization` | Percentage | How much of provisioned concurrency is being used |
+| `IteratorAge` | Milliseconds | Age of the last record processed (stream sources only) |
+| `DeadLetterErrors` | Count | Failed attempts to send to DLQ |
+| `AsyncEventsDropped` | Count | Async events dropped after all retries exhausted (no DLQ configured) |
+
+## Recommended Alarms
+
+### Critical alarms (set up for every production function)
+
+| Metric | Statistic | Period | Threshold | Action |
+|---|---|---|---|---|
+| `Errors` | Sum | 1 min | > 0 for 3 consecutive periods | Page oncall; investigate function failures |
+| `Throttles` | Sum | 1 min | > 0 for 3 consecutive periods | Request concurrency increase or review traffic |
+| `Duration` | p99 | 5 min | > 80% of timeout | Investigate latency; risk of timeouts |
+
+### Important alarms (set up for business-critical functions)
+
+| Metric | Statistic | Period | Threshold | Action |
+|---|---|---|---|---|
+| `ConcurrentExecutions` | Maximum | 1 min | > 80% of reserved concurrency | Scale concurrency or investigate traffic |
+| `IteratorAge` | Maximum | 1 min | > 30,000 ms | Falling behind on stream processing; add shards or optimize |
+| `DeadLetterErrors` | Sum | 5 min | > 0 | DLQ delivery failures; check DLQ permissions and capacity |
+| `AsyncEventsDropped` | Sum | 5 min | > 0 | Events being lost; configure a DLQ |
+
+### Provisioned concurrency alarms
+
+| Metric | Statistic | Period | Threshold | Action |
+|---|---|---|---|---|
+| `ProvisionedConcurrencyUtilization` | Average | 5 min | > 85% | Scale up provisioned concurrency |
+| `ProvisionedConcurrencySpilloverInvocations` | Sum | 5 min | > 0 sustained | Cold starts occurring; increase provisioned concurrency |
+| `ProvisionedConcurrencyUtilization` | Average | 5 min | < 20% sustained | Over-provisioned; reduce to save cost |
+
+## Embedded Metric Format (EMF)
+
+### Why EMF over PutMetricData
+
+| Approach | Latency impact | Cost | Complexity |
+|---|---|---|---|
+| `PutMetricData` API call in handler | Adds network round-trip to each invocation | API call charges + higher function duration | Error handling for API failures |
+| EMF (metrics in structured logs) | Zero -- metrics emitted as log lines | Standard CloudWatch Logs ingestion | Minimal -- structured log lines |
+
+### How EMF works
+
+1. Your function writes a specially formatted JSON log line
+2. CloudWatch Logs automatically extracts metrics from the log
+3. Metrics appear in CloudWatch Metrics with dimensions and namespaces
+
+### EMF structure
+
+```json
+{
+  "_aws": {
+    "Timestamp": 1234567890,
+    "CloudWatchMetrics": [{
+      "Namespace": "MyService",
+      "Dimensions": [["FunctionName", "Environment"]],
+      "Metrics": [
+        { "Name": "ProcessingTime", "Unit": "Milliseconds" },
+        { "Name": "ItemsProcessed", "Unit": "Count" }
+      ]
+    }]
+  },
+  "FunctionName": "order-processor",
+  "Environment": "production",
+  "ProcessingTime": 145,
+  "ItemsProcessed": 12
+}
+```
+
+### Powertools for AWS Lambda
+
+Instead of manually formatting EMF, use the Metrics utility from Powertools for AWS Lambda. Available for Python, TypeScript, Java, and .NET. It handles:
+
+- EMF JSON formatting
+- Namespace and dimension management
+- Automatic flushing at the end of invocation
+- Default dimensions (function name, service)
+
+## Structured Logging
+
+### Why structured JSON logging
+
+| Plain text | Structured JSON |
+|---|---|
+| `Error processing order 123` | `{"level": "ERROR", "message": "Error processing order", "orderId": "123", "error": "timeout"}` |
+| Hard to search and filter | CloudWatch Logs Insights queries: `fields @timestamp, orderId | filter level = "ERROR"` |
+| No consistent format across functions | Consistent schema enables dashboards and automated analysis |
+
+### What to include in every log entry
+
+| Field | Purpose |
+|---|---|
+| `level` | Severity (DEBUG, INFO, WARN, ERROR) |
+| `message` | Human-readable description |
+| `timestamp` | ISO 8601 format |
+| `requestId` | Lambda request ID (from context) |
+| `correlationId` | End-to-end trace identifier |
+| `service` | Service/function name |
+
+### Correlation IDs
+
+In distributed systems, trace a request across services:
+
+1. Extract or generate a correlation ID at the entry point (API Gateway, first Lambda)
+2. Pass it through all downstream calls (HTTP headers, SQS message attributes, event metadata)
+3. Include it in every log entry
+4. Use CloudWatch Logs Insights or X-Ray to search across functions by correlation ID
+
+## AWS X-Ray
+
+Enable active tracing to visualize request flow across Lambda and downstream services:
+
+- **Traces** -- end-to-end view of a request across services
+- **Segments** -- per-service timing (Lambda initialization, invocation, overhead)
+- **Subsegments** -- individual operations (DynamoDB call, HTTP request)
+- **Service map** -- visual topology of your application
+
+### When to use X-Ray vs CloudWatch
+
+| Need | Use |
+|---|---|
+| Per-function health and alerting | CloudWatch Metrics + Alarms |
+| Cross-service latency analysis | X-Ray |
+| Debugging a specific slow request | X-Ray traces |
+| Aggregate performance trends | CloudWatch Metrics dashboards |
+| Custom business metrics | EMF via CloudWatch Logs |
+
+## Cost Anomaly Detection
+
+AWS Cost Anomaly Detection uses ML to identify unusual spending patterns:
+
+- Detects anomalies within 24 hours of usage
+- Requires Cost Explorer to be enabled
+- Configure alerts for Lambda-specific cost anomalies
+- Catches runaway functions, recursive invocations, and unexpected traffic spikes that drive cost
+
+### Setup
+
+1. Enable Cost Explorer in your AWS account
+2. Access Cost Anomaly Detection from the Cost Management console
+3. Create a cost monitor for Lambda service specifically
+4. Configure SNS notifications for detected anomalies

--- a/registry/skills/aws-lambda-best-practices/references/metrics-and-alarms.md
+++ b/registry/skills/aws-lambda-best-practices/references/metrics-and-alarms.md
@@ -124,7 +124,7 @@ In distributed systems, trace a request across services:
 1. Extract or generate a correlation ID at the entry point (API Gateway, first Lambda)
 2. Pass it through all downstream calls (HTTP headers, SQS message attributes, event metadata)
 3. Include it in every log entry
-4. Use CloudWatch Logs Insights or X-Ray to search across functions by correlation ID
+4. Use CloudWatch Logs Insights to query across functions by the logged `correlationId`; X-Ray can also filter by it, but only if you add the value as a trace annotation
 
 ## AWS X-Ray
 

--- a/registry/skills/aws-lambda-best-practices/references/metrics-and-alarms.md
+++ b/registry/skills/aws-lambda-best-practices/references/metrics-and-alarms.md
@@ -5,7 +5,7 @@
 Lambda publishes these metrics to CloudWatch automatically (no instrumentation required):
 
 | Metric | Unit | What it tells you |
-|---|---|---|
+| --- | --- | --- |
 | `Invocations` | Count | Number of times your function was invoked |
 | `Duration` | Milliseconds | Execution time (use p50, p90, p99 percentiles) |
 | `Errors` | Count | Invocations that resulted in a function error |
@@ -18,13 +18,14 @@ Lambda publishes these metrics to CloudWatch automatically (no instrumentation r
 | `IteratorAge` | Milliseconds | Age of the last record processed (stream sources only) |
 | `DeadLetterErrors` | Count | Failed attempts to send to DLQ |
 | `AsyncEventsDropped` | Count | Async events dropped after all retries exhausted (no DLQ configured) |
+| `RecursiveInvocationsDropped` | Count | Invocations stopped by recursive loop detection (emitted immediately -- fastest signal of a loop) |
 
 ## Recommended Alarms
 
 ### Critical alarms (set up for every production function)
 
 | Metric | Statistic | Period | Threshold | Action |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | `Errors` | Sum | 1 min | > 0 for 3 consecutive periods | Page oncall; investigate function failures |
 | `Throttles` | Sum | 1 min | > 0 for 3 consecutive periods | Request concurrency increase or review traffic |
 | `Duration` | p99 | 5 min | > 80% of timeout | Investigate latency; risk of timeouts |
@@ -32,16 +33,17 @@ Lambda publishes these metrics to CloudWatch automatically (no instrumentation r
 ### Important alarms (set up for business-critical functions)
 
 | Metric | Statistic | Period | Threshold | Action |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | `ConcurrentExecutions` | Maximum | 1 min | > 80% of reserved concurrency | Scale concurrency or investigate traffic |
 | `IteratorAge` | Maximum | 1 min | > 30,000 ms | Falling behind on stream processing; add shards or optimize |
 | `DeadLetterErrors` | Sum | 5 min | > 0 | DLQ delivery failures; check DLQ permissions and capacity |
 | `AsyncEventsDropped` | Sum | 5 min | > 0 | Events being lost; configure a DLQ |
+| `RecursiveInvocationsDropped` | Sum | 1 min | > 0 | Recursive loop detected and stopped; fix trigger/output separation |
 
 ### Provisioned concurrency alarms
 
 | Metric | Statistic | Period | Threshold | Action |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | `ProvisionedConcurrencyUtilization` | Average | 5 min | > 85% | Scale up provisioned concurrency |
 | `ProvisionedConcurrencySpilloverInvocations` | Sum | 5 min | > 0 sustained | Cold starts occurring; increase provisioned concurrency |
 | `ProvisionedConcurrencyUtilization` | Average | 5 min | < 20% sustained | Over-provisioned; reduce to save cost |
@@ -51,7 +53,7 @@ Lambda publishes these metrics to CloudWatch automatically (no instrumentation r
 ### Why prefer EMF over PutMetricData
 
 | Approach | Latency impact | Cost | Complexity |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `PutMetricData` API call in handler | Adds network round-trip to each invocation | API call charges + higher function duration | Error handling for API failures |
 | EMF (metrics in structured logs) | Zero -- metrics emitted as log lines | Standard CloudWatch Logs ingestion | Minimal -- structured log lines |
 
@@ -99,15 +101,15 @@ Instead of manually formatting EMF, use the Metrics utility from Powertools for 
 ### Why structured JSON logging
 
 | Plain text | Structured JSON |
-|---|---|
+| --- | --- |
 | `Error processing order 123` | `{"level": "ERROR", "message": "Error processing order", "orderId": "123", "error": "timeout"}` |
-| Hard to search and filter | CloudWatch Logs Insights queries: `fields @timestamp, orderId | filter level = "ERROR"` |
+| Hard to search and filter | CloudWatch Logs Insights queries: `fields @timestamp, orderId \| filter level = "ERROR"` |
 | No consistent format across functions | Consistent schema enables dashboards and automated analysis |
 
 ### What to include in every log entry
 
 | Field | Purpose |
-|---|---|
+| --- | --- |
 | `level` | Severity (DEBUG, INFO, WARN, ERROR) |
 | `message` | Human-readable description |
 | `timestamp` | ISO 8601 format |
@@ -136,7 +138,7 @@ Enable active tracing to visualize request flow across Lambda and downstream ser
 ### When to use X-Ray vs CloudWatch
 
 | Need | Use |
-|---|---|
+| --- | --- |
 | Per-function health and alerting | CloudWatch Metrics + Alarms |
 | Cross-service latency analysis | X-Ray |
 | Debugging a specific slow request | X-Ray traces |

--- a/registry/skills/aws-lambda-best-practices/references/security.md
+++ b/registry/skills/aws-lambda-best-practices/references/security.md
@@ -78,7 +78,7 @@ Code signing ensures that only trusted code runs in your Lambda function.
 
 | Benefit | Cost |
 |---|---|
-| Network isolation for private resources | Additional cold start latency (ENI attachment) |
+| Network isolation for private resources | Minor additional cold start latency (Hyperplane ENI attachment -- significantly improved since 2019) |
 | Security group and NACL controls | Requires VPC endpoint or NAT for public services |
 | Private connectivity to on-premises | ENI quota consumption |
 | Compliance with network segmentation policies | More complex networking configuration |

--- a/registry/skills/aws-lambda-best-practices/references/security.md
+++ b/registry/skills/aws-lambda-best-practices/references/security.md
@@ -1,0 +1,193 @@
+# Security Best Practices
+
+## IAM Least Privilege
+
+### Execution role design
+
+Every Lambda function has an **execution role** -- the IAM role it assumes when running. This role determines what AWS services and resources the function can access.
+
+### Principles
+
+| Principle | Implementation |
+|---|---|
+| Specific actions | `dynamodb:GetItem`, `dynamodb:PutItem` -- not `dynamodb:*` |
+| Specific resources | `arn:aws:dynamodb:us-east-1:123456789:table/MyTable` -- not `*` |
+| One role per function | Functions with different responsibilities get different roles |
+| Condition keys | Use `aws:RequestedRegion`, `aws:SourceArn` to narrow further |
+| Regular audits | Use IAM Access Analyzer to find unused permissions |
+
+### Resource-based policies
+
+Control who can **invoke** your function (separate from what the function can do):
+
+- Allow specific AWS services (API Gateway, S3, SNS) to invoke the function
+- Restrict invocation to specific accounts or source ARNs
+- Deny cross-account invocation unless explicitly required
+
+### Common anti-patterns
+
+| Anti-pattern | Risk | Fix |
+|---|---|---|
+| `"Action": "*"` on execution role | Full AWS access if function is compromised | List specific actions |
+| `"Resource": "*"` | Access to all resources of that type | Specify resource ARNs |
+| Shared execution role across many functions | Blast radius of compromised function expands | Separate roles per function |
+| Managed policies like `AmazonS3FullAccess` | Grants access to all buckets in the account | Custom policy with specific bucket ARN |
+| Never rotating credentials | Long-lived credentials are a risk | Lambda execution role credentials are short-lived by default -- don't override this |
+
+## Code Signing
+
+Code signing ensures that only trusted code runs in your Lambda function.
+
+### How it works
+
+1. You configure a **signing profile** in AWS Signer
+2. You sign your deployment package with the profile
+3. You attach a **code signing configuration** to your Lambda function
+4. Lambda verifies the signature on every deploy and rejects unsigned or tampered code
+
+### When to use
+
+| Scenario | Code signing? |
+|---|---|
+| Production functions handling sensitive data | Yes |
+| Functions in regulated industries (finance, healthcare) | Yes |
+| Internal dev/test functions | Optional |
+| Functions deployed via trusted CI/CD only | Recommended as defense in depth |
+
+### Configuration options
+
+| Setting | Options |
+|---|---|
+| `UntrustedArtifactOnDeployment` | `Warn` (log but deploy) or `Enforce` (reject) |
+| Signing profile platform | `AWSLambda-SHA384-ECDSA` |
+| Signature validity | Configurable expiry period |
+
+## VPC Configuration
+
+### When to place Lambda in a VPC
+
+| Need | VPC required? |
+|---|---|
+| Access private RDS/ElastiCache/Redshift | Yes |
+| Access resources in a private subnet | Yes |
+| Call public AWS APIs (DynamoDB, S3, SQS) | No -- use VPC endpoints or stay outside VPC |
+| Internet access from Lambda | NAT Gateway required if in VPC |
+| Compliance requirement for network isolation | Yes |
+
+### VPC trade-offs
+
+| Benefit | Cost |
+|---|---|
+| Network isolation for private resources | Additional cold start latency (ENI attachment) |
+| Security group and NACL controls | Requires VPC endpoint or NAT for public services |
+| Private connectivity to on-premises | ENI quota consumption |
+| Compliance with network segmentation policies | More complex networking configuration |
+
+### VPC best practices
+
+- Place Lambda in **private subnets** -- never public subnets (Lambda doesn't use public IPs even in public subnets)
+- Use **VPC endpoints** for AWS services (S3, DynamoDB, SQS, etc.) to avoid NAT Gateway costs and latency
+- Use **at least 2 subnets** across different AZs for availability
+- Size subnets for ENI consumption: each concurrent execution may use an ENI (Lambda optimizes sharing)
+- Monitor ENI quota -- shared with other services in the same VPC
+
+## Secrets Management
+
+### Where to store secrets
+
+| Method | Security | Rotation | Cost |
+|---|---|---|---|
+| Hardcoded in code | Terrible -- exposed in source control | Manual | Free |
+| Environment variables (plaintext) | Low -- visible in Lambda console | Manual redeploy | Free |
+| Environment variables (encrypted with CMK) | Medium -- encrypted at rest | Manual redeploy | KMS charges |
+| Secrets Manager | High -- encrypted, audited, versioned | Automatic rotation supported | Per-secret charge |
+| Parameter Store (SecureString) | High -- encrypted with KMS | Manual or custom rotation | Free (standard) / small charge (advanced) |
+
+### Recommended pattern
+
+1. Store secrets in **Secrets Manager** or **Parameter Store SecureString**
+2. Reference the secret ARN in a Lambda environment variable
+3. Retrieve and cache the secret at module level (execution environment reuse)
+4. Grant the execution role `secretsmanager:GetSecretValue` on the specific secret ARN
+5. Enable automatic rotation for database credentials
+
+### Lambda environment variable encryption
+
+- All environment variables are encrypted at rest by default using an AWS-managed KMS key
+- For sensitive values, use a **customer-managed CMK** for additional control and audit trail
+- Enable **encryption helpers** in the console to encrypt values in transit with a different key
+
+## Security Monitoring
+
+### AWS Security Hub
+
+Security Hub evaluates Lambda configurations against security controls:
+
+| Control | What it checks |
+|---|---|
+| Lambda functions should use supported runtimes | Flags end-of-life runtimes |
+| Lambda functions should have a dead-letter queue configured | Ensures failed events aren't silently lost |
+| Lambda functions should restrict public access | Flags functions with overly permissive resource policies |
+| Lambda function policies should prohibit public access | Checks for `"Principal": "*"` in resource policies |
+
+### Amazon GuardDuty Lambda Protection
+
+GuardDuty monitors network activity when Lambda functions are invoked:
+
+- Detects communication with known malicious IPs
+- Identifies cryptocurrency mining activity
+- Flags DNS queries to malicious domains
+- Monitors for credential exfiltration attempts
+
+### CloudTrail
+
+All Lambda API calls are logged in CloudTrail:
+
+- `CreateFunction`, `UpdateFunctionCode`, `UpdateFunctionConfiguration`
+- `Invoke` (data events -- must be explicitly enabled)
+- `AddPermission`, `RemovePermission` (resource policy changes)
+
+Enable CloudTrail data events for Lambda to audit who invoked which functions.
+
+## Data Protection
+
+### Encryption
+
+| Data state | Protection |
+|---|---|
+| In transit | All Lambda APIs require TLS 1.2+ |
+| At rest (code) | Encrypted in S3 with service-managed keys |
+| At rest (environment variables) | Encrypted with KMS (AWS-managed or customer-managed key) |
+| In transit (environment variables) | Decrypted only in the execution environment |
+| `/tmp` storage | Ephemeral, isolated per execution environment, destroyed on environment shutdown |
+
+### Network security
+
+| Control | Purpose |
+|---|---|
+| Security groups | Control inbound/outbound traffic for VPC-attached functions |
+| NACLs | Subnet-level network filtering |
+| VPC endpoints | Private connectivity to AWS services without internet |
+| PrivateLink | Private connectivity to third-party services |
+
+## Governance
+
+### Governance strategies for Lambda
+
+| Strategy | Implementation |
+|---|---|
+| Approved runtimes | Use AWS Config rules to flag functions with unsupported runtimes |
+| Maximum timeout limits | Organization SCPs or Config rules to enforce timeout caps |
+| Required tags | SCPs requiring cost-center, team, environment tags |
+| Code signing enforcement | Organization-wide code signing configurations |
+| VPC requirement | SCPs requiring VPC configuration for functions accessing sensitive data |
+| Layer governance | Approve and publish shared layers centrally; restrict layer sources |
+
+### Service Control Policies (SCPs)
+
+Use SCPs to enforce organization-wide Lambda policies:
+
+- Prevent creation of functions without VPC configuration
+- Restrict allowed runtimes
+- Require encryption with customer-managed keys
+- Prevent public resource policies

--- a/registry/skills/aws-lambda-best-practices/references/security.md
+++ b/registry/skills/aws-lambda-best-practices/references/security.md
@@ -9,7 +9,7 @@ Every Lambda function has an **execution role** -- the IAM role it assumes when 
 ### Principles
 
 | Principle | Implementation |
-|---|---|
+| --- | --- |
 | Specific actions | `dynamodb:GetItem`, `dynamodb:PutItem` -- not `dynamodb:*` |
 | Specific resources | `arn:aws:dynamodb:us-east-1:123456789:table/MyTable` -- not `*` |
 | One role per function | Functions with different responsibilities get different roles |
@@ -27,7 +27,7 @@ Control who can **invoke** your function (separate from what the function can do
 ### Common anti-patterns
 
 | Anti-pattern | Risk | Fix |
-|---|---|---|
+| --- | --- | --- |
 | `"Action": "*"` on execution role | Full AWS access if function is compromised | List specific actions |
 | `"Resource": "*"` | Access to all resources of that type | Specify resource ARNs |
 | Shared execution role across many functions | Blast radius of compromised function expands | Separate roles per function |
@@ -48,7 +48,7 @@ Code signing ensures that only trusted code runs in your Lambda function.
 ### When to use
 
 | Scenario | Code signing? |
-|---|---|
+| --- | --- |
 | Production functions handling sensitive data | Yes |
 | Functions in regulated industries (finance, healthcare) | Yes |
 | Internal dev/test functions | Optional |
@@ -57,7 +57,7 @@ Code signing ensures that only trusted code runs in your Lambda function.
 ### Configuration options
 
 | Setting | Options |
-|---|---|
+| --- | --- |
 | `UntrustedArtifactOnDeployment` | `Warn` (log but deploy) or `Enforce` (reject) |
 | Signing profile platform | `AWSLambda-SHA384-ECDSA` |
 | Signature validity | Configurable expiry period |
@@ -67,7 +67,7 @@ Code signing ensures that only trusted code runs in your Lambda function.
 ### When to place Lambda in a VPC
 
 | Need | VPC required? |
-|---|---|
+| --- | --- |
 | Access private RDS/ElastiCache/Redshift | Yes |
 | Access resources in a private subnet | Yes |
 | Call public AWS APIs (DynamoDB, S3, SQS) | No -- use VPC endpoints or stay outside VPC |
@@ -77,7 +77,7 @@ Code signing ensures that only trusted code runs in your Lambda function.
 ### VPC trade-offs
 
 | Benefit | Cost |
-|---|---|
+| --- | --- |
 | Network isolation for private resources | Minor additional cold start latency (Hyperplane ENI attachment -- significantly improved since 2019) |
 | Security group and NACL controls | Requires VPC endpoint or NAT for public services |
 | Private connectivity to on-premises | ENI quota consumption |
@@ -85,18 +85,19 @@ Code signing ensures that only trusted code runs in your Lambda function.
 
 ### VPC best practices
 
-- Place Lambda in **private subnets** -- never public subnets (Lambda doesn't use public IPs even in public subnets)
+- Always use **private subnets** -- Lambda never gets a public IP, so a public subnet gives no internet access and only wastes its IP space; internet egress requires a NAT gateway
 - Use **VPC endpoints** for AWS services (S3, DynamoDB, SQS, etc.) to avoid NAT Gateway costs and latency
 - Use **at least 2 subnets** across different AZs for availability
-- Size subnets for ENI consumption: each concurrent execution may use an ENI (Lambda optimizes sharing)
-- Monitor ENI quota -- shared with other services in the same VPC
+- Reuse the same **subnet + security-group combination** across functions: Lambda creates one shared Hyperplane ENI per unique combination (not per concurrent execution) and functions sharing a combination share ENIs
+- Don't over-size subnets for Lambda's own ENI usage -- typically only a handful of ENIs per function; Lambda adds ENIs only when connection demand requires it (~65,000 connections per ENI)
+- Monitor the ENI quota -- default 250 network interfaces per VPC, shared with other services in the same VPC (raise via Service Quotas)
 
 ## Secrets Management
 
 ### Where to store secrets
 
 | Method | Security | Rotation | Cost |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Hardcoded in code | Terrible -- exposed in source control | Manual | Free |
 | Environment variables (plaintext) | Low -- visible in Lambda console | Manual redeploy | Free |
 | Environment variables (encrypted with CMK) | Medium -- encrypted at rest | Manual redeploy | KMS charges |
@@ -124,7 +125,7 @@ Code signing ensures that only trusted code runs in your Lambda function.
 Security Hub evaluates Lambda configurations against security controls:
 
 | Control | What it checks |
-|---|---|
+| --- | --- |
 | Lambda functions should use supported runtimes | Flags end-of-life runtimes |
 | Lambda functions should have a dead-letter queue configured | Ensures failed events aren't silently lost |
 | Lambda functions should restrict public access | Flags functions with overly permissive resource policies |
@@ -154,7 +155,7 @@ Enable CloudTrail data events for Lambda to audit who invoked which functions.
 ### Encryption
 
 | Data state | Protection |
-|---|---|
+| --- | --- |
 | In transit | All Lambda APIs require TLS 1.2+ |
 | At rest (code) | Encrypted in S3 with service-managed keys |
 | At rest (environment variables) | Encrypted with KMS (AWS-managed or customer-managed key) |
@@ -164,7 +165,7 @@ Enable CloudTrail data events for Lambda to audit who invoked which functions.
 ### Network security
 
 | Control | Purpose |
-|---|---|
+| --- | --- |
 | Security groups | Control inbound/outbound traffic for VPC-attached functions |
 | NACLs | Subnet-level network filtering |
 | VPC endpoints | Private connectivity to AWS services without internet |
@@ -175,7 +176,7 @@ Enable CloudTrail data events for Lambda to audit who invoked which functions.
 ### Governance strategies for Lambda
 
 | Strategy | Implementation |
-|---|---|
+| --- | --- |
 | Approved runtimes | Use AWS Config rules to flag functions with unsupported runtimes |
 | Maximum timeout limits | Organization SCPs or Config rules to enforce timeout caps |
 | Required tags | SCPs requiring cost-center, team, environment tags |

--- a/registry/skills/aws-lambda-best-practices/references/stream-events.md
+++ b/registry/skills/aws-lambda-best-practices/references/stream-events.md
@@ -1,0 +1,202 @@
+# Working with Streams
+
+## Event Source Mapping Basics
+
+Lambda uses **event source mappings** to poll streams and queues and invoke your function with batches of records. Lambda manages the polling infrastructure -- you configure batch size, batching window, and error handling.
+
+### Supported stream sources
+
+| Source | Polling model | Ordering guarantee | Retry behavior |
+|---|---|---|---|
+| Kinesis Data Streams | Shard-based | Per-shard ordering | Retries until record expires or succeeds |
+| DynamoDB Streams | Shard-based | Per-shard ordering | Retries until record expires or succeeds |
+| SQS Standard | Automatic scaling | No ordering | Returns to queue after visibility timeout |
+| SQS FIFO | Message group-based | Per-message-group ordering | Returns to queue after visibility timeout |
+| Amazon MSK / Self-managed Kafka | Partition-based | Per-partition ordering | Retries until record expires or succeeds |
+
+## Batch Tuning
+
+### BatchSize
+
+The maximum number of records Lambda sends to your function per invocation.
+
+| Source | Default | Max | Guidance |
+|---|---|---|---|
+| Kinesis | 100 | 10,000 | Larger batches amortize invocation overhead |
+| DynamoDB Streams | 100 | 10,000 | Match to processing capacity |
+| SQS | 10 | 10,000 | Balance throughput vs processing time |
+| Kafka / MSK | 100 | 10,000 | Match to consumer group throughput |
+
+**All sources:** batch payload is capped at **6 MB** regardless of BatchSize setting.
+
+### MaximumBatchingWindowInSeconds
+
+How long Lambda waits to accumulate records before invoking your function.
+
+| Setting | Effect |
+|---|---|
+| 0 (default) | Invoke as soon as records are available |
+| 1-300 seconds | Buffer records; invoke when batch is full OR window expires |
+
+**When to increase batching window:**
+
+- Low-volume streams where you want to process records in larger batches
+- Cost optimization -- fewer invocations = lower cost
+- Processing that benefits from batch operations (bulk DB writes)
+
+**When to keep at 0:**
+
+- Latency-sensitive processing
+- High-volume streams that naturally fill batches quickly
+
+## Partial Batch Response
+
+### The problem
+
+Without partial batch response, if one record in a batch of 100 fails, Lambda retries the **entire batch of 100**. The 99 successful records get reprocessed.
+
+### The solution
+
+Enable `ReportBatchItemFailures` in the event source mapping. Your function returns only the IDs of failed records. Lambda retries only those records.
+
+### Response format
+
+```json
+{
+  "batchItemFailures": [
+    { "itemIdentifier": "failed-record-sequence-number-or-message-id" }
+  ]
+}
+```
+
+### How identifiers map per source
+
+| Source | Identifier field |
+|---|---|
+| Kinesis | `kinesis.sequenceNumber` |
+| DynamoDB Streams | `dynamodb.SequenceNumber` |
+| SQS | `messageId` |
+
+### Best practices for partial batch response
+
+- **Always enable** for production stream processing
+- Process records individually, catch errors per-record, collect failed IDs
+- Return an empty `batchItemFailures` array on full success
+- If your function throws an unhandled exception, the entire batch is retried (partial response not used)
+
+## Kinesis Scaling
+
+### Shard-to-Lambda relationship
+
+By default: **1 concurrent Lambda invocation per shard.** Each shard supports up to 1 MB/s or 1,000 records/s input.
+
+### Parallelization factor
+
+Set `ParallelizationFactor` (1-10) to process each shard with multiple concurrent Lambda invocations:
+
+| Factor | Concurrent invocations per shard | Use case |
+|---|---|---|
+| 1 (default) | 1 | Simple, ordered processing |
+| 2-5 | 2-5 | Higher throughput needed, can handle out-of-order within shard |
+| 10 | 10 | Maximum throughput, processing is order-independent |
+
+**Important:** With parallelization factor > 1, records within a shard may be processed out of order. Only use when order doesn't matter or your application handles reordering.
+
+### Adding shards
+
+If parallelization factor at 10 isn't enough:
+
+1. Increase the number of shards in your Kinesis stream
+2. Choose a partition key with good distribution (similar to DynamoDB partition key design)
+3. Lambda automatically creates new pollers for new shards
+
+### Shard iterator and checkpoint
+
+Lambda tracks the position in each shard automatically. If your function fails:
+
+- Lambda retries the batch from the last successful checkpoint
+- Records ahead of the failure are blocked until the failed batch succeeds or is discarded
+- Use `BisectBatchOnFunctionError` to split the batch in half and isolate the failing record
+
+## IteratorAge Monitoring
+
+`IteratorAge` measures how far behind your function is from the stream's latest record.
+
+| IteratorAge | Status | Action |
+|---|---|---|
+| < 1,000 ms | Healthy | None |
+| 1,000 - 30,000 ms | Behind | Monitor; may catch up |
+| 30,000 - 60,000 ms | Significantly behind | Add shards, increase parallelization, optimize function |
+| > 60,000 ms | Critical | Immediate action -- records may expire before processing |
+
+### Alarm configuration
+
+```
+Metric: IteratorAge
+Statistic: Maximum
+Period: 1 minute
+Threshold: > 30,000 ms for 3 consecutive periods
+Action: Alert oncall
+```
+
+### Kinesis record retention
+
+Default retention: **24 hours** (extendable to 365 days at additional cost). If IteratorAge exceeds retention period, records are lost permanently.
+
+## DynamoDB Streams
+
+### Key differences from Kinesis
+
+| Aspect | Kinesis | DynamoDB Streams |
+|---|---|---|
+| Shard count | You control | Managed by DynamoDB (tied to table partitions) |
+| Retention | 24h - 365 days | 24 hours (not configurable) |
+| Record content | Your data | Change records (old/new image of DynamoDB items) |
+| Parallelization factor | Supported | Supported |
+
+### Common DynamoDB Streams patterns
+
+| Pattern | Description |
+|---|---|
+| Change data capture (CDC) | Replicate changes to another data store |
+| Materialized views | Build read-optimized projections |
+| Event sourcing | Publish domain events from table changes |
+| Cross-region sync | Replicate data (though Global Tables is simpler) |
+| Audit logging | Record all changes for compliance |
+
+## SQS Integration
+
+### SQS Standard vs FIFO with Lambda
+
+| Feature | SQS Standard | SQS FIFO |
+|---|---|---|
+| Ordering | Best-effort | Strict per message group |
+| Lambda scaling | Up to 1,000 concurrent (or reserved limit) | 1 concurrent per message group |
+| Throughput | Nearly unlimited | 300 messages/s (3,000 with batching) |
+| Duplicates | Possible | Exactly-once delivery |
+
+### Visibility Timeout alignment
+
+```
+SQS Visibility Timeout >= 6 x Lambda function timeout
+```
+
+This accounts for retries and processing time. If visibility timeout is too short, messages reappear in the queue and cause duplicate processing.
+
+### Dead Letter Queue (DLQ)
+
+Configure a DLQ on the SQS queue (not on the Lambda function) for SQS sources:
+
+- Set `maxReceiveCount` to limit retry attempts (e.g., 3-5)
+- After `maxReceiveCount` failures, the message moves to the DLQ
+- Monitor DLQ depth as an alarm -- messages there need manual investigation
+
+## Idempotency for Streams
+
+**Every stream-processing function must be idempotent.** Duplicate delivery is guaranteed to happen:
+
+- Kinesis/DynamoDB Streams: batch retries on failure deliver duplicates
+- SQS: visibility timeout expiry causes redelivery
+- Partial batch response: successfully processed records in a failed batch may be re-delivered depending on checkpoint behavior
+
+See `function-code.md` for idempotency implementation patterns and key selection by event source.

--- a/registry/skills/aws-lambda-best-practices/references/stream-events.md
+++ b/registry/skills/aws-lambda-best-practices/references/stream-events.md
@@ -172,7 +172,7 @@ Default retention: **24 hours** (extendable to 365 days at additional cost). If 
 |---|---|---|
 | Ordering | Best-effort | Strict per message group |
 | Lambda scaling | Up to 1,000 concurrent (or reserved limit) | 1 concurrent per message group |
-| Throughput | Nearly unlimited | 300 messages/s (3,000 with batching) |
+| Throughput | Nearly unlimited | 300 messages/s (3,000 with batching); up to 70,000 messages/s with high-throughput FIFO mode |
 | Duplicates | Possible | Exactly-once delivery |
 
 ### Visibility Timeout alignment

--- a/registry/skills/aws-lambda-best-practices/references/stream-events.md
+++ b/registry/skills/aws-lambda-best-practices/references/stream-events.md
@@ -7,7 +7,7 @@ Lambda uses **event source mappings** to poll streams and queues and invoke your
 ### Supported stream sources
 
 | Source | Polling model | Ordering guarantee | Retry behavior |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Kinesis Data Streams | Shard-based | Per-shard ordering | Retries until record expires or succeeds |
 | DynamoDB Streams | Shard-based | Per-shard ordering | Retries until record expires or succeeds |
 | SQS Standard | Automatic scaling | No ordering | Returns to queue after visibility timeout |
@@ -21,10 +21,11 @@ Lambda uses **event source mappings** to poll streams and queues and invoke your
 The maximum number of records Lambda sends to your function per invocation.
 
 | Source | Default | Max | Guidance |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Kinesis | 100 | 10,000 | Larger batches amortize invocation overhead |
 | DynamoDB Streams | 100 | 10,000 | Match to processing capacity |
-| SQS | 10 | 10,000 | Balance throughput vs processing time |
+| SQS (standard) | 10 | 10,000 | Balance throughput vs processing time; BatchSize > 10 requires a batching window of at least 1 second |
+| SQS (FIFO) | 10 | 10 | Batching window is not supported |
 | Kafka / MSK | 100 | 10,000 | Match to consumer group throughput |
 
 **All sources:** batch payload is capped at **6 MB** regardless of BatchSize setting.
@@ -34,9 +35,11 @@ The maximum number of records Lambda sends to your function per invocation.
 How long Lambda waits to accumulate records before invoking your function.
 
 | Setting | Effect |
-|---|---|
+| --- | --- |
 | 0 (default) | Invoke as soon as records are available |
 | 1-300 seconds | Buffer records; invoke when batch is full OR window expires |
+
+**Not supported for SQS FIFO queues** -- FIFO event source mappings invoke the function as soon as messages are available, up to a BatchSize of 10.
 
 **When to increase batching window:**
 
@@ -72,7 +75,7 @@ Enable `ReportBatchItemFailures` in the event source mapping. Your function retu
 ### How identifiers map per source
 
 | Source | Identifier field |
-|---|---|
+| --- | --- |
 | Kinesis | `kinesis.sequenceNumber` |
 | DynamoDB Streams | `dynamodb.SequenceNumber` |
 | SQS | `messageId` |
@@ -95,7 +98,7 @@ By default: **1 concurrent Lambda invocation per shard.** Each shard supports up
 Set `ParallelizationFactor` (1-10) to process each shard with multiple concurrent Lambda invocations:
 
 | Factor | Concurrent invocations per shard | Use case |
-|---|---|---|
+| --- | --- | --- |
 | 1 (default) | 1 | Simple, ordered processing |
 | 2-5 | 2-5 | Higher throughput needed, can handle out-of-order within shard |
 | 10 | 10 | Maximum throughput, processing is order-independent |
@@ -123,7 +126,7 @@ Lambda tracks the position in each shard automatically. If your function fails:
 `IteratorAge` measures how far behind your function is from the stream's latest record.
 
 | IteratorAge | Status | Action |
-|---|---|---|
+| --- | --- | --- |
 | < 1,000 ms | Healthy | None |
 | 1,000 - 30,000 ms | Behind | Monitor; may catch up |
 | 30,000 - 60,000 ms | Significantly behind | Add shards, increase parallelization, optimize function |
@@ -131,7 +134,7 @@ Lambda tracks the position in each shard automatically. If your function fails:
 
 ### Alarm configuration
 
-```
+```text
 Metric: IteratorAge
 Statistic: Maximum
 Period: 1 minute
@@ -148,7 +151,7 @@ Default retention: **24 hours** (extendable to 365 days at additional cost). If 
 ### Key differences from Kinesis
 
 | Aspect | Kinesis | DynamoDB Streams |
-|---|---|---|
+| --- | --- | --- |
 | Shard count | You control | Managed by DynamoDB (tied to table partitions) |
 | Retention | 24h - 365 days | 24 hours (not configurable) |
 | Record content | Your data | Change records (old/new image of DynamoDB items) |
@@ -157,7 +160,7 @@ Default retention: **24 hours** (extendable to 365 days at additional cost). If 
 ### Common DynamoDB Streams patterns
 
 | Pattern | Description |
-|---|---|
+| --- | --- |
 | Change data capture (CDC) | Replicate changes to another data store |
 | Materialized views | Build read-optimized projections |
 | Event sourcing | Publish domain events from table changes |
@@ -169,15 +172,15 @@ Default retention: **24 hours** (extendable to 365 days at additional cost). If 
 ### SQS Standard vs FIFO with Lambda
 
 | Feature | SQS Standard | SQS FIFO |
-|---|---|---|
+| --- | --- | --- |
 | Ordering | Best-effort | Strict per message group |
-| Lambda scaling | Up to 1,000 concurrent (or reserved limit) | 1 concurrent per message group |
+| Lambda scaling | Up to 1,250 concurrent per event source mapping (cap via maximum concurrency or reserved concurrency) | 1 concurrent per message group |
 | Throughput | Nearly unlimited | 300 messages/s (3,000 with batching); up to 70,000 messages/s with high-throughput FIFO mode |
-| Duplicates | Possible | Exactly-once delivery |
+| Duplicates | Possible | Queue-level deduplication (5-minute window) prevents duplicate enqueues; delivery to Lambda is still at-least-once -- handlers must be idempotent |
 
 ### Visibility Timeout alignment
 
-```
+```text
 SQS Visibility Timeout >= 6 x Lambda function timeout
 ```
 
@@ -196,7 +199,7 @@ Configure a DLQ on the SQS queue (not on the Lambda function) for SQS sources:
 **Every stream-processing function must be idempotent.** Duplicate delivery is guaranteed to happen:
 
 - Kinesis/DynamoDB Streams: batch retries on failure deliver duplicates
-- SQS: visibility timeout expiry causes redelivery
+- SQS: visibility timeout expiry causes redelivery (FIFO included -- queue-level deduplication does not make Lambda delivery exactly-once)
 - Partial batch response: successfully processed records in a failed batch may be re-delivered depending on checkpoint behavior
 
-See `function-code.md` for idempotency implementation patterns and key selection by event source.
+See `function-design.md` for idempotency implementation patterns and key selection by event source.


### PR DESCRIPTION
- Add new aws-lambda-best-practices skill with concise SKILL.md (176 lines) and 7 detailed reference files covering function design, configuration, scalability, monitoring, streams, security, and anti-patterns
- Follows the same structure as aws-dynamodb-best-practices: SKILL.md provides concise do/don't guidance with pointers, references hold the deep-dive detail
- All content verified against official AWS Lambda documentation
- Language-agnostic (no code examples tied to a specific runtime)

### Key sections
- Function Design — one function per responsibility, handler design, idempotency, connection management, anti-pattern callouts (monolith, orchestrator, sync chains, recursive loops)
- Function Configuration — memory/CPU tuning, timeout strategy, key quotas
- Function Scalability — concurrency model, reserved/provisioned concurrency decision table, downstream protection
- Metrics and Alarms — EMF over PutMetricData, key alarm thresholds, observability practices
- Working with Streams — batch tuning, partial batch response, stream scaling
- Security — IAM least privilege, VPC with Hyperplane ENI context, secrets management
- Anti-patterns reference — detailed "why it feels right / why it fails" analysis for each pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new AWS Lambda best-practices skill with practical guidance on function design, scaling, monitoring, security, and stream processing.

* **Documentation**
  * Added several reference guides covering common Lambda pitfalls, configuration tuning, concurrency and throttling, logging and alarms, stream/queue behavior, and security recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->