### PR TITLE
Bump CLI package version to 0.1.4

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@provectusinc/awos-recruitment",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@provectusinc/awos-recruitment",
-      "version": "0.1.2",
+      "version": "0.1.4",
       "dependencies": {
         "tar": "^7.5.11",
         "yaml": "^2.8.3"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provectusinc/awos-recruitment",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "type": "module",
   "bin": "dist/index.js",
   "files": [


### PR DESCRIPTION
## Summary

Bumps `@provectusinc/awos-recruitment` from 0.1.2 to **0.1.4** so the manifest in git matches what is now on npm.

**Already published to npm manually** (0.1.4 is live) — this PR just records the version bump in `main` so the repo reflects the published state.

## What's in 0.1.4

Picks up the patched runtime-dependency ranges that landed in #54:
- `tar ^7.5.11` (fixes symlink/hardlink path-traversal pair)
- `yaml ^2.8.3` (fixes deeply-nested stack-overflow)

Consumers who `npm install @provectusinc/awos-recruitment` now get the patched versions instead of the vulnerable ranges 0.1.2 was locked to.

## Verification

- [x] `npm view @provectusinc/awos-recruitment version` → `0.1.4`
- [x] `cli/package.json` version field → `0.1.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)