### PR TITLE
Validate skill layout against install bundle allowlist

### DIFF
--- a/server/src/awos_recruitment_mcp/validate/__init__.py
+++ b/server/src/awos_recruitment_mcp/validate/__init__.py
@@ -12,11 +12,13 @@ from pydantic import ValidationError as PydanticValidationError
 from awos_recruitment_mcp.models import AgentMetadata, McpDefinition, SkillMetadata
 
 # Top-level entries permitted inside a skill directory. Kept in lockstep with
-# what the /bundle/skills endpoint actually ships: SKILL.md and the flat files
-# under references/. README.md is allowed as local documentation (not bundled).
-_ALLOWED_SKILL_ENTRIES: frozenset[str] = frozenset(
-    {"SKILL.md", "README.md", "references"}
-)
+# what the /bundle/skills endpoint actually ships: SKILL.md (file) and the flat
+# files under references/ (directory). README.md is allowed as local docs even
+# though it's not bundled. Type is enforced alongside name — e.g. a file named
+# "references" or a directory named "SKILL.md" is still rejected, since the
+# bundler would drop them for the same reason as any other stray entry.
+_ALLOWED_SKILL_FILES: frozenset[str] = frozenset({"SKILL.md", "README.md"})
+_ALLOWED_SKILL_DIRS: frozenset[str] = frozenset({"references"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -146,42 +148,77 @@ def validate_skills(registry_path: Path) -> list[ValidationResult]:
                 )
             )
 
-        # Ensure the on-disk layout matches what /bundle/skills ships.  Anything
-        # outside the allowlist (e.g. a rules/ or examples/ folder) would be
-        # silently dropped at install time — surface it as a validation error
-        # so skill authors can rename it to references/ instead.
+        # Ensure the on-disk layout matches what /bundle/skills ships.  The
+        # bundler only includes SKILL.md and flat files under references/;
+        # everything else is silently dropped at install time (the root cause
+        # of #56). Surface anything outside the allowlist as a validation error
+        # so authors notice before shipping.  Dotfiles are skipped — macOS
+        # sprinkles .DS_Store into every directory that's been opened in
+        # Finder, and flagging those would just create noise.
         for child in sorted(entry.iterdir()):
-            if child.name in _ALLOWED_SKILL_ENTRIES:
+            if child.name.startswith("."):
                 continue
-            errors.append(
-                ValidationError(
-                    file=relative_path,
-                    field=None,
-                    message=(
-                        f"Unexpected entry '{child.name}' in skill directory — "
-                        "only SKILL.md, README.md, and references/ are allowed "
-                        "(the install bundle drops everything else)"
-                    ),
-                )
-            )
 
-        # The bundler uses iterdir() on references/ and only adds is_file()
-        # entries, so nested subdirectories are dropped too.
-        references_dir = entry / "references"
-        if references_dir.is_dir():
-            for ref_child in sorted(references_dir.iterdir()):
-                if ref_child.is_dir():
+            if child.is_dir():
+                if child.name not in _ALLOWED_SKILL_DIRS:
                     errors.append(
                         ValidationError(
                             file=relative_path,
                             field=None,
                             message=(
-                                f"Nested directory 'references/{ref_child.name}/' "
-                                "is not included in the install bundle — only "
-                                "flat files under references/ are shipped"
+                                f"Unexpected directory '{child.name}/' in skill "
+                                "— the install bundle only ships SKILL.md and "
+                                "flat files under references/"
                             ),
                         )
                     )
+                    continue
+
+                # Allowed dir (references/) — the bundler walks it with
+                # iterdir() and only adds is_file() entries, so nested
+                # directories would be silently dropped.
+                for ref_child in sorted(child.iterdir()):
+                    if ref_child.name.startswith("."):
+                        continue
+                    if not ref_child.is_file():
+                        errors.append(
+                            ValidationError(
+                                file=relative_path,
+                                field=None,
+                                message=(
+                                    f"Nested entry '{child.name}/{ref_child.name}"
+                                    f"{'/' if ref_child.is_dir() else ''}' is "
+                                    "not included in the install bundle — only "
+                                    "flat files under references/ are shipped"
+                                ),
+                            )
+                        )
+            elif child.is_file():
+                if child.name not in _ALLOWED_SKILL_FILES:
+                    errors.append(
+                        ValidationError(
+                            file=relative_path,
+                            field=None,
+                            message=(
+                                f"Unexpected file '{child.name}' in skill — "
+                                "the install bundle only ships SKILL.md and "
+                                "flat files under references/"
+                            ),
+                        )
+                    )
+            else:
+                # Symlinks, sockets, etc. — tar.add wouldn't handle these the
+                # way skill authors expect. Flag them.
+                errors.append(
+                    ValidationError(
+                        file=relative_path,
+                        field=None,
+                        message=(
+                            f"Unexpected non-file/non-dir entry '{child.name}' "
+                            "in skill directory"
+                        ),
+                    )
+                )
 
         results.append(
             ValidationResult(

--- a/server/src/awos_recruitment_mcp/validate/__init__.py
+++ b/server/src/awos_recruitment_mcp/validate/__init__.py
@@ -159,41 +159,7 @@ def validate_skills(registry_path: Path) -> list[ValidationResult]:
             if child.name.startswith("."):
                 continue
 
-            if child.is_dir():
-                if child.name not in _ALLOWED_SKILL_DIRS:
-                    errors.append(
-                        ValidationError(
-                            file=relative_path,
-                            field=None,
-                            message=(
-                                f"Unexpected directory '{child.name}/' in skill "
-                                "— the install bundle only ships SKILL.md and "
-                                "flat files under references/"
-                            ),
-                        )
-                    )
-                    continue
-
-                # Allowed dir (references/) — the bundler walks it with
-                # iterdir() and only adds is_file() entries, so nested
-                # directories would be silently dropped.
-                for ref_child in sorted(child.iterdir()):
-                    if ref_child.name.startswith("."):
-                        continue
-                    if not ref_child.is_file():
-                        errors.append(
-                            ValidationError(
-                                file=relative_path,
-                                field=None,
-                                message=(
-                                    f"Nested entry '{child.name}/{ref_child.name}"
-                                    f"{'/' if ref_child.is_dir() else ''}' is "
-                                    "not included in the install bundle — only "
-                                    "flat files under references/ are shipped"
-                                ),
-                            )
-                        )
-            elif child.is_file():
+            if child.is_file():
                 if child.name not in _ALLOWED_SKILL_FILES:
                     errors.append(
                         ValidationError(
@@ -206,9 +172,11 @@ def validate_skills(registry_path: Path) -> list[ValidationResult]:
                             ),
                         )
                     )
-            else:
+                continue
+
+            if not child.is_dir():
                 # Symlinks, sockets, etc. — tar.add wouldn't handle these the
-                # way skill authors expect. Flag them.
+                # way skill authors expect.
                 errors.append(
                     ValidationError(
                         file=relative_path,
@@ -216,6 +184,38 @@ def validate_skills(registry_path: Path) -> list[ValidationResult]:
                         message=(
                             f"Unexpected non-file/non-dir entry '{child.name}' "
                             "in skill directory"
+                        ),
+                    )
+                )
+                continue
+
+            if child.name not in _ALLOWED_SKILL_DIRS:
+                errors.append(
+                    ValidationError(
+                        file=relative_path,
+                        field=None,
+                        message=(
+                            f"Unexpected directory '{child.name}/' in skill "
+                            "— the install bundle only ships SKILL.md and "
+                            "flat files under references/"
+                        ),
+                    )
+                )
+                continue
+
+            # Allowed dir (references/) — the bundler walks it with iterdir()
+            # and only adds is_file() entries, so anything non-file is dropped.
+            for ref_child in sorted(child.iterdir()):
+                if ref_child.name.startswith(".") or ref_child.is_file():
+                    continue
+                errors.append(
+                    ValidationError(
+                        file=relative_path,
+                        field=None,
+                        message=(
+                            f"Nested entry '{child.name}/{ref_child.name}' "
+                            "is not a flat file — the install bundle only "
+                            "ships flat files under references/"
                         ),
                     )
                 )

--- a/server/src/awos_recruitment_mcp/validate/__init__.py
+++ b/server/src/awos_recruitment_mcp/validate/__init__.py
@@ -11,6 +11,13 @@ from pydantic import ValidationError as PydanticValidationError
 
 from awos_recruitment_mcp.models import AgentMetadata, McpDefinition, SkillMetadata
 
+# Top-level entries permitted inside a skill directory. Kept in lockstep with
+# what the /bundle/skills endpoint actually ships: SKILL.md and the flat files
+# under references/. README.md is allowed as local documentation (not bundled).
+_ALLOWED_SKILL_ENTRIES: frozenset[str] = frozenset(
+    {"SKILL.md", "README.md", "references"}
+)
+
 
 @dataclass(frozen=True, slots=True)
 class ValidationError:
@@ -138,6 +145,43 @@ def validate_skills(registry_path: Path) -> list[ValidationResult]:
                     message="Skill body (markdown content) is empty",
                 )
             )
+
+        # Ensure the on-disk layout matches what /bundle/skills ships.  Anything
+        # outside the allowlist (e.g. a rules/ or examples/ folder) would be
+        # silently dropped at install time — surface it as a validation error
+        # so skill authors can rename it to references/ instead.
+        for child in sorted(entry.iterdir()):
+            if child.name in _ALLOWED_SKILL_ENTRIES:
+                continue
+            errors.append(
+                ValidationError(
+                    file=relative_path,
+                    field=None,
+                    message=(
+                        f"Unexpected entry '{child.name}' in skill directory — "
+                        "only SKILL.md, README.md, and references/ are allowed "
+                        "(the install bundle drops everything else)"
+                    ),
+                )
+            )
+
+        # The bundler uses iterdir() on references/ and only adds is_file()
+        # entries, so nested subdirectories are dropped too.
+        references_dir = entry / "references"
+        if references_dir.is_dir():
+            for ref_child in sorted(references_dir.iterdir()):
+                if ref_child.is_dir():
+                    errors.append(
+                        ValidationError(
+                            file=relative_path,
+                            field=None,
+                            message=(
+                                f"Nested directory 'references/{ref_child.name}/' "
+                                "is not included in the install bundle — only "
+                                "flat files under references/ are shipped"
+                            ),
+                        )
+                    )
 
         results.append(
             ValidationResult(

--- a/server/tests/test_validate.py
+++ b/server/tests/test_validate.py
@@ -192,6 +192,17 @@ def test_agent_optional_fields_default_none():
 # ---------------------------------------------------------------------------
 
 
+def _make_skill_dir(tmp_path: Path, name: str, description: str) -> Path:
+    """Create a minimal well-formed skill directory and return its path."""
+    skill_dir = tmp_path / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\n"
+        "# Body\n\nContent here.\n"
+    )
+    return skill_dir
+
+
 def test_validate_skill_empty_body(tmp_path: Path):
     """A SKILL.md with valid front matter but an empty body should produce errors."""
     skill_dir = tmp_path / "skills" / "empty-body"
@@ -254,12 +265,7 @@ def test_validate_skill_valid(tmp_path: Path):
 
 def test_validate_skill_rejects_unexpected_toplevel_dir(tmp_path: Path):
     """A non-allowlisted directory (e.g. rules/) should be flagged as unexpected."""
-    skill_dir = tmp_path / "skills" / "has-rules"
-    skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(
-        "---\nname: has-rules\ndescription: Skill with a stray rules folder\n---\n\n"
-        "# Body\n\nContent here.\n"
-    )
+    skill_dir = _make_skill_dir(tmp_path, "has-rules", "stray rules folder")
     rules_dir = skill_dir / "rules"
     rules_dir.mkdir()
     (rules_dir / "rule-a.md").write_text("# Rule A\n")
@@ -278,12 +284,7 @@ def test_validate_skill_rejects_unexpected_toplevel_dir(tmp_path: Path):
 
 def test_validate_skill_rejects_unexpected_toplevel_file(tmp_path: Path):
     """An unknown top-level file should also be flagged."""
-    skill_dir = tmp_path / "skills" / "has-extra"
-    skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(
-        "---\nname: has-extra\ndescription: Skill with a stray file\n---\n\n"
-        "# Body\n\nContent here.\n"
-    )
+    skill_dir = _make_skill_dir(tmp_path, "has-extra", "stray file")
     (skill_dir / "notes.txt").write_text("scratch\n")
 
     results = validate_skills(tmp_path)
@@ -298,12 +299,7 @@ def test_validate_skill_rejects_unexpected_toplevel_file(tmp_path: Path):
 
 def test_validate_skill_rejects_nested_references_dir(tmp_path: Path):
     """A subdirectory inside references/ should be flagged — the bundler only ships flat files."""
-    skill_dir = tmp_path / "skills" / "nested-refs"
-    skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(
-        "---\nname: nested-refs\ndescription: references has a subfolder\n---\n\n"
-        "# Body\n\nContent here.\n"
-    )
+    skill_dir = _make_skill_dir(tmp_path, "nested-refs", "references has a subfolder")
     nested = skill_dir / "references" / "sub"
     nested.mkdir(parents=True)
     (nested / "buried.md").write_text("# Buried\n")
@@ -320,12 +316,7 @@ def test_validate_skill_rejects_nested_references_dir(tmp_path: Path):
 
 def test_validate_skill_ignores_dotfiles(tmp_path: Path):
     """macOS/VCS dotfiles (.DS_Store, .gitkeep) must not trigger layout errors."""
-    skill_dir = tmp_path / "skills" / "dotfiles-ok"
-    skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(
-        "---\nname: dotfiles-ok\ndescription: Dotfiles should be ignored\n---\n\n"
-        "# Body\n\nContent here.\n"
-    )
+    skill_dir = _make_skill_dir(tmp_path, "dotfiles-ok", "dotfiles should be ignored")
     (skill_dir / ".DS_Store").write_bytes(b"\x00\x01\x02")
     refs = skill_dir / "references"
     refs.mkdir()
@@ -343,12 +334,7 @@ def test_validate_skill_ignores_dotfiles(tmp_path: Path):
 
 def test_validate_skill_rejects_file_named_references(tmp_path: Path):
     """A regular file named 'references' must not satisfy the references/ dir slot."""
-    skill_dir = tmp_path / "skills" / "file-refs"
-    skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(
-        "---\nname: file-refs\ndescription: references is a file, not a dir\n---\n\n"
-        "# Body\n\nContent here.\n"
-    )
+    skill_dir = _make_skill_dir(tmp_path, "file-refs", "references is a file, not a dir")
     (skill_dir / "references").write_text("oops, should be a directory\n")
 
     results = validate_skills(tmp_path)
@@ -365,12 +351,7 @@ def test_validate_skill_rejects_file_named_references(tmp_path: Path):
 
 def test_validate_skill_reports_multiple_layout_errors(tmp_path: Path):
     """One skill with several layout problems should surface every one."""
-    skill_dir = tmp_path / "skills" / "many-issues"
-    skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(
-        "---\nname: many-issues\ndescription: lots of layout problems\n---\n\n"
-        "# Body\n\nContent here.\n"
-    )
+    skill_dir = _make_skill_dir(tmp_path, "many-issues", "lots of layout problems")
     (skill_dir / "rules").mkdir()
     (skill_dir / "rules" / "a.md").write_text("# A\n")
     (skill_dir / "notes.txt").write_text("scratch\n")
@@ -396,12 +377,7 @@ def test_validate_skill_reports_multiple_layout_errors(tmp_path: Path):
 
 def test_validate_skill_allows_readme_and_flat_references(tmp_path: Path):
     """README.md at the top level and flat files under references/ are fine."""
-    skill_dir = tmp_path / "skills" / "well-formed"
-    skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(
-        "---\nname: well-formed\ndescription: Proper layout\n---\n\n"
-        "# Body\n\nContent here.\n"
-    )
+    skill_dir = _make_skill_dir(tmp_path, "well-formed", "proper layout")
     (skill_dir / "README.md").write_text("# Readme\n")
     refs = skill_dir / "references"
     refs.mkdir()

--- a/server/tests/test_validate.py
+++ b/server/tests/test_validate.py
@@ -271,8 +271,8 @@ def test_validate_skill_rejects_unexpected_toplevel_dir(tmp_path: Path):
         "Expected invalid result when a non-allowlisted folder is present"
     )
     error_messages = [e.message for e in results[0].errors]
-    assert any("rules" in m and "Unexpected" in m for m in error_messages), (
-        f"Expected an 'Unexpected entry \"rules\"' error, got: {error_messages}"
+    assert any("rules" in m and "Unexpected directory" in m for m in error_messages), (
+        f"Expected an 'Unexpected directory \"rules/\"' error, got: {error_messages}"
     )
 
 
@@ -315,6 +315,82 @@ def test_validate_skill_rejects_nested_references_dir(tmp_path: Path):
     error_messages = [e.message for e in results[0].errors]
     assert any("references/sub" in m for m in error_messages), (
         f"Expected an error mentioning 'references/sub', got: {error_messages}"
+    )
+
+
+def test_validate_skill_ignores_dotfiles(tmp_path: Path):
+    """macOS/VCS dotfiles (.DS_Store, .gitkeep) must not trigger layout errors."""
+    skill_dir = tmp_path / "skills" / "dotfiles-ok"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: dotfiles-ok\ndescription: Dotfiles should be ignored\n---\n\n"
+        "# Body\n\nContent here.\n"
+    )
+    (skill_dir / ".DS_Store").write_bytes(b"\x00\x01\x02")
+    refs = skill_dir / "references"
+    refs.mkdir()
+    (refs / "a.md").write_text("# A\n")
+    (refs / ".DS_Store").write_bytes(b"\x00\x01\x02")
+
+    results = validate_skills(tmp_path)
+
+    assert len(results) == 1
+    assert results[0].valid, (
+        f"Expected dotfiles to be ignored, got errors: "
+        f"{[e.message for e in results[0].errors]}"
+    )
+
+
+def test_validate_skill_rejects_file_named_references(tmp_path: Path):
+    """A regular file named 'references' must not satisfy the references/ dir slot."""
+    skill_dir = tmp_path / "skills" / "file-refs"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: file-refs\ndescription: references is a file, not a dir\n---\n\n"
+        "# Body\n\nContent here.\n"
+    )
+    (skill_dir / "references").write_text("oops, should be a directory\n")
+
+    results = validate_skills(tmp_path)
+
+    assert len(results) == 1
+    assert not results[0].valid, (
+        "Expected a file named 'references' to be rejected"
+    )
+    error_messages = [e.message for e in results[0].errors]
+    assert any(
+        "Unexpected file" in m and "references" in m for m in error_messages
+    ), f"Expected 'Unexpected file references' error, got: {error_messages}"
+
+
+def test_validate_skill_reports_multiple_layout_errors(tmp_path: Path):
+    """One skill with several layout problems should surface every one."""
+    skill_dir = tmp_path / "skills" / "many-issues"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: many-issues\ndescription: lots of layout problems\n---\n\n"
+        "# Body\n\nContent here.\n"
+    )
+    (skill_dir / "rules").mkdir()
+    (skill_dir / "rules" / "a.md").write_text("# A\n")
+    (skill_dir / "notes.txt").write_text("scratch\n")
+    nested = skill_dir / "references" / "sub"
+    nested.mkdir(parents=True)
+    (nested / "buried.md").write_text("# Buried\n")
+
+    results = validate_skills(tmp_path)
+
+    assert len(results) == 1
+    assert not results[0].valid
+    messages = [e.message for e in results[0].errors]
+    assert any("rules/" in m and "Unexpected directory" in m for m in messages), (
+        f"Expected rules/ directory error, got: {messages}"
+    )
+    assert any("notes.txt" in m and "Unexpected file" in m for m in messages), (
+        f"Expected notes.txt file error, got: {messages}"
+    )
+    assert any("references/sub" in m for m in messages), (
+        f"Expected nested references/sub error, got: {messages}"
     )
 
 

--- a/server/tests/test_validate.py
+++ b/server/tests/test_validate.py
@@ -252,6 +252,95 @@ def test_validate_skill_valid(tmp_path: Path):
     )
 
 
+def test_validate_skill_rejects_unexpected_toplevel_dir(tmp_path: Path):
+    """A non-allowlisted directory (e.g. rules/) should be flagged as unexpected."""
+    skill_dir = tmp_path / "skills" / "has-rules"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: has-rules\ndescription: Skill with a stray rules folder\n---\n\n"
+        "# Body\n\nContent here.\n"
+    )
+    rules_dir = skill_dir / "rules"
+    rules_dir.mkdir()
+    (rules_dir / "rule-a.md").write_text("# Rule A\n")
+
+    results = validate_skills(tmp_path)
+
+    assert len(results) == 1
+    assert not results[0].valid, (
+        "Expected invalid result when a non-allowlisted folder is present"
+    )
+    error_messages = [e.message for e in results[0].errors]
+    assert any("rules" in m and "Unexpected" in m for m in error_messages), (
+        f"Expected an 'Unexpected entry \"rules\"' error, got: {error_messages}"
+    )
+
+
+def test_validate_skill_rejects_unexpected_toplevel_file(tmp_path: Path):
+    """An unknown top-level file should also be flagged."""
+    skill_dir = tmp_path / "skills" / "has-extra"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: has-extra\ndescription: Skill with a stray file\n---\n\n"
+        "# Body\n\nContent here.\n"
+    )
+    (skill_dir / "notes.txt").write_text("scratch\n")
+
+    results = validate_skills(tmp_path)
+
+    assert len(results) == 1
+    assert not results[0].valid
+    error_messages = [e.message for e in results[0].errors]
+    assert any("notes.txt" in m for m in error_messages), (
+        f"Expected an error mentioning 'notes.txt', got: {error_messages}"
+    )
+
+
+def test_validate_skill_rejects_nested_references_dir(tmp_path: Path):
+    """A subdirectory inside references/ should be flagged — the bundler only ships flat files."""
+    skill_dir = tmp_path / "skills" / "nested-refs"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: nested-refs\ndescription: references has a subfolder\n---\n\n"
+        "# Body\n\nContent here.\n"
+    )
+    nested = skill_dir / "references" / "sub"
+    nested.mkdir(parents=True)
+    (nested / "buried.md").write_text("# Buried\n")
+
+    results = validate_skills(tmp_path)
+
+    assert len(results) == 1
+    assert not results[0].valid
+    error_messages = [e.message for e in results[0].errors]
+    assert any("references/sub" in m for m in error_messages), (
+        f"Expected an error mentioning 'references/sub', got: {error_messages}"
+    )
+
+
+def test_validate_skill_allows_readme_and_flat_references(tmp_path: Path):
+    """README.md at the top level and flat files under references/ are fine."""
+    skill_dir = tmp_path / "skills" / "well-formed"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: well-formed\ndescription: Proper layout\n---\n\n"
+        "# Body\n\nContent here.\n"
+    )
+    (skill_dir / "README.md").write_text("# Readme\n")
+    refs = skill_dir / "references"
+    refs.mkdir()
+    (refs / "a.md").write_text("# A\n")
+    (refs / "b.md").write_text("# B\n")
+
+    results = validate_skills(tmp_path)
+
+    assert len(results) == 1
+    assert results[0].valid, (
+        f"Expected layout to pass, got errors: "
+        f"{[e.message for e in results[0].errors]}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # McpDefinition / McpServerConfig model tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extend `validate_skills` to reject any top-level entry other than `SKILL.md`, `README.md`, and `references/` — the only things `/bundle/skills` actually ships
- Also reject nested directories inside `references/`, since the bundler's `iterdir() + is_file()` walk drops them silently
- Add 4 new unit tests covering: unexpected top-level dir, unexpected top-level file, nested `references/` subdir, and the well-formed layout

## Motivation
This is the follow-up prevention for #56. The `react-best-practices` skill shipped with a `rules/` folder and the `/bundle/skills` endpoint silently dropped all 37 rule files at install time — the failure mode was invisible to skill authors. Locking the layout in the validator means the next person who adds a non-conforming folder fails CI instead of shipping a broken install.

## Test plan
- [x] `cd server && uv run pytest tests/test_validate.py -v` — 35 passed (4 new + existing 31, including `test_real_registry_passes` against the live registry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)