### PR TITLE
feat(registry): add verify-ui skill

### DIFF
--- a/registry/skills/verify-ui/SKILL.md
+++ b/registry/skills/verify-ui/SKILL.md
@@ -29,14 +29,7 @@ it happens all the time, please do not waste tokens on that
 ## Step 2: Navigate to the feature
 - Use page.locator('selector').click() for all interactions
 - Never take page snapshots
-- Never use ref targets
-here what happens when you try to get page snapshot by ref:
-```console
-⏺ playwright - Page snapshot (MCP)(target: "[ref=e31]", depth: 6)
-  ⎿  Error: ### Error
-     Error: "[ref=e31]" does not match any elements.
-```
-it happens all the time, please do not waste tokens on that
+- Never use ref targets (see Step 1)
 
 ## Step 3: Load and run verification scripts
 For EVERY measurement, follow this exact sequence:
@@ -83,7 +76,7 @@ instead of writing custom discovery code each time.
 1. Read: `Read .claude/skills/verify-ui/scripts/check-inventory.js`
 2. Inject into page
 3. Call: `page.evaluate(() => checkInventory({
-     scope: '[data-radix-popper-content-wrapper]',
+     scope: '[data-example]', // e.g.: [data-popover-content], [data-radix-popper-content-wrapper], [role="dialog"]
      include: ['button', '[role="option"]', '[role="radio"]', '[role="group"]']
    }))`
 4. Inspect `summary` for counts, `sections` for labeled groups, `scrollState` for scroll info,
@@ -151,7 +144,7 @@ Use custom skill ONLY when you tried to utilize scripts provided above and you s
 - Only use page snapshot when you genuinely don't know what's on the page
   (e.g., investigating an unknown bug with no code context).
 - When you need to inspect a specific area of the page, use page.locator('css-selector').evaluate()
-- NEVER use ref targets for playwright, neither for snapshots nor for clicks
+- NEVER use ref targets for Playwright, neither for snapshots nor for clicks
 
 ## browser_snapshot rules
   - The `target` parameter MUST be a CSS selector or role query, NEVER a [ref=...] value
@@ -161,6 +154,6 @@ Use custom skill ONLY when you tried to utilize scripts provided above and you s
 
 ## What skill does not do
 - Skill does not verify visual appearance (colors, fonts, spacing and contrast aesthetics), it verifies only if the feature elements behave as it planned by spec and codebase
-- Skill does not test cross-browser behavior and uses only playwright chromium browser
+- Skill does not test cross-browser behavior and uses only Playwright Chromium browser
 - Skill does not verify accessibility features use different skill for that
 - Skill avoids using screenshots and fallbacks to them only in case of low confidence after usage of tools

--- a/registry/skills/verify-ui/SKILL.md
+++ b/registry/skills/verify-ui/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: verify-ui
+context: fork
+description: >
+  Frontend testing and web UI verification via DOM inspection in a Playwright browser. Verify component behavior, check layout, and test interactive elements after implementing or modifying features. Checks visibility, clickability, alignment, overflow, and state transitions — without screenshots. Use when verifying UI, investigating bugs, or testing acceptance criteria against a live app. Use when user reports a bug or asks to investigate how a feature works. Use BEFORE custom Playwright usage.
+version: '1.0.0'
+---
+
+# Verify UI
+
+Follow this process for every verification. Use the bundled scripts — do not write 
+custom page.evaluate code unless the scripts cannot answer the question.
+
+## Step 1: Understand what to verify
+Read the minimum source code to identify:
+1. How to reach the feature (route, buttons to click)
+2. Key selectors (CSS classes, roles, test-ids)
+3. Expected layout rules from CSS (flex direction, gaps, alignment)
+Stop reading after these three. Do NOT explore the full component tree.
+4. NEVER use ref for snapshots. Target by css class, role, or whatever else
+here what happens when you try to get page snapshot by ref:
+```console
+⏺ playwright - Page snapshot (MCP)(target: "[ref=e31]", depth: 6)
+  ⎿  Error: ### Error
+     Error: "[ref=e31]" does not match any elements.
+```
+it happens all the time, please do not waste tokens on that
+
+## Step 2: Navigate to the feature
+- Use page.locator('selector').click() for all interactions
+- Never take page snapshots
+- Never use ref targets
+here what happens when you try to get page snapshot by ref:
+```console
+⏺ playwright - Page snapshot (MCP)(target: "[ref=e31]", depth: 6)
+  ⎿  Error: ### Error
+     Error: "[ref=e31]" does not match any elements.
+```
+it happens all the time, please do not waste tokens on that
+
+## Step 3: Load and run verification scripts
+For EVERY measurement, follow this exact sequence:
+
+### After-action state checks (THIS IS THE MOST COMMON CHECK YOU SHOULD USE IN MOST CASES)
+This is a 3-stage check: setup observer, perform click with Playwright, collect results.
+1. Read: `Read .claude/skills/verify-ui/scripts/check-after-action.js`
+2. Inject into page: `page.evaluate(scriptContent)`
+3. Setup: `page.evaluate((opts) => setupAfterAction(opts), { scope: '[role="dialog"]', expect: [{ selector: '.success-message', visible: true }, { selector: '.loading-spinner', visible: false }], timeout: 5000 })`
+4. Click with Playwright: `page.locator('.submit-button').click()`
+5. Collect: `page.evaluate(() => collectAfterAction())`
+6. Check overall `pass` and each result's `reason`
+
+Use this for: selection state changes, popup open/close, tab switching,
+form submission results — any click that should change the UI permanently.
+Use checkVisibilityTransition instead when tracking temporary elements
+(spinners, toasts, animations).
+
+### Alignment checks
+1. Read the script: `Read .claude/skills/verify-ui/scripts/check-alignment.js`
+2. Inject into page: `page.evaluate(scriptContent)` where scriptContent is the 
+   full file you just read
+3. Call: `page.evaluate(() => checkAlignment({ containerSelector: '...', scopeSelector: '...' }))`
+4. Interpret the result: check `behavior`, `alignment`, `gaps.uniform`, `gaps.value`
+
+### Clickability checks  
+1. Read: `Read .claude/skills/verify-ui/scripts/check-clickable.js`
+2. Inject into page
+3. Call: `page.evaluate(() => checkClickable({ selectors: [...], scope: '...' }))`
+4. Check each result's `clickable` and `reason`
+
+### Visibility transition checks
+This is a 3-stage check: setup observer, perform click with Playwright, collect results.
+1. Read: `Read .claude/skills/verify-ui/scripts/check-visibility-transition.js`
+2. Inject into page: `page.evaluate(scriptContent)`
+3. Setup: `page.evaluate((opts) => setupVisibilityTransition(opts), { target: '.spinner', scope: '[role="dialog"]', expected: [false, true, false], timeout: 5000 })`
+4. Click with Playwright: `page.locator('.submit-button').click()`
+5. Collect: `page.evaluate(() => collectVisibilityTransition())`
+6. Check `matches` and `reason`
+
+### Container inventory checks
+Use this after opening a popover, dialog, or dropdown to discover everything inside in one call
+instead of writing custom discovery code each time.
+1. Read: `Read .claude/skills/verify-ui/scripts/check-inventory.js`
+2. Inject into page
+3. Call: `page.evaluate(() => checkInventory({
+     scope: '[data-radix-popper-content-wrapper]',
+     include: ['button', '[role="option"]', '[role="radio"]', '[role="group"]']
+   }))`
+4. Inspect `summary` for counts, `sections` for labeled groups, `scrollState` for scroll info,
+   and `elements` for the full list with text/role/ariaState/visible/inViewport per element.
+
+Options:
+- `scope` (required): CSS selector for the container to inventory
+- `include`: array of selectors to search for (defaults to all common interactive roles)
+- `exclude`: array of selectors to skip
+- `maxDepth`: limit DOM traversal depth
+
+### Overflow and reachability checks
+Use this to check whether a container or its children overflow the viewport,
+whether footer content is clipped, and whether interactive elements are still reachable.
+1. Read: `Read .claude/skills/verify-ui/scripts/check-overflow.js`
+2. Inject into page
+3. Call: `page.evaluate(() => checkOverflow({
+     scope: '[data-side]',
+     checkFooter: true
+   }))`
+4. Check `summary` for the quick verdict (`overflows`, `scrollable`, `footerClipped`,
+   `unreachableCount`), `overflow`/`overflowPx` for directional detail, `footer` for
+   last-child clipping, and `unreachable` for any interactive elements that can't be clicked.
+
+Options:
+- `scope` (required): CSS selector for the container to check
+- `checkFooter`: check if the last visible child is clipped (default: true)
+- `checkInteractive`: hit-test all interactive elements for reachability (default: true)
+- `margin`: pixel tolerance for overflow detection (default: 0)
+
+### How to inject scripts
+Scripts live on disk, NOT accessible from the browser. To inject:
+1. Use the Read tool: `Read .claude/skills/verify-ui/scripts/check-alignment.js`
+2. The file content is now in YOUR context (not the browser's)
+3. Inject via: `page.evaluate(fileContent)` — this defines the function in browser scope
+4. Then call: `page.evaluate(() => checkAlignment({...}))`
+NEVER use fetch() or import() to load scripts — the browser cannot access local files
+
+## Step 4: Compile results
+Populate all check in a md format table, with the columns "Elements", "Check", "Result", "Details", "Suggested fix" for instance:
+```
+| Elements | Check | Result | Details | Suggested fix |
+|----------|-------|--------|---------|---------------|
+| .search-input | visible | ✅ | Visible at the very top on the search form | N/A |
+| .search-input | clickable | ✅ | elementFromPoint returns self | N/A |
+| .dropdown | appears on focus | ❌ | MutationObserver: element never became visible within 3s | Add visibility state change on search input focus |
+```
+### Important Notes Towards Details And Summaries
+Instead of providing numeric information, explain what is going on semantically. Imagine that user does not see the skill at all and you have to explain to him being in complete blindness
+
+## General rules
+- For clicking elements, ALWAYS use Playwright's native click via page.locator('selector').click() — never use dispatchEvent or element.click() from page.evaluate. Components often require real pointer events. 
+- For selector, prioritize text which element contains or accessibility attributes (e.g. aria-role)
+- To make selection more precise, instead of selecting element on the whole page, first extract feature box element from page (use text feature contains, classes, test-ids, consider mixing those approaches if you struggle to select single item, example: .locator('\[role="form"\]:has-text("Register Account")')), then use locator from feature element instead of page
+- For tab switching, radio selection, checkbox filling, dropdown element picking and all other user interactions use native clicks: .locator(\<selector\>).click()
+- use .fill() for text input and .press() or page.keyboard.press() for key presses, do not edit DOM value field directly
+- avoid gathering getComputedStyle information other than about visibility/opacity: that is redundant, getBoundingClientRect provides full data about shape and positioning
+
+## Custom scripts
+Use custom skill ONLY when you tried to utilize scripts provided above and you still lack some information/low on confidence
+
+## Navigation efficiency
+- After reading source code, you already know the selectors. Do NOT take page snapshots
+  just to "see" the page — go directly to clicking and measuring.
+- Only use page snapshot when you genuinely don't know what's on the page
+  (e.g., investigating an unknown bug with no code context).
+- When you need to inspect a specific area of the page, use page.locator('css-selector').evaluate()
+- NEVER use ref targets for playwright, neither for snapshots nor for clicks
+
+## browser_snapshot rules
+  - The `target` parameter MUST be a CSS selector or role query, NEVER a [ref=...] value
+  - you MUST map snapshot which contains ref values to source code, to transform ref to css class, text or whatever else
+  - If you need a subtree snapshot, use a CSS selector like '[role="listbox"]' or '.className'
+  - If you don't know the CSS selector, DON'T take a targeted snapshot — use page.evaluate with getBoundingClientRect or DOM queries instead
+
+## What skill does not do
+- Skill does not verify visual appearance (colors, fonts, spacing and contrast aesthetics), it verifies only if the feature elements behave as it planned by spec and codebase
+- Skill does not test cross-browser behavior and uses only playwright chromium browser
+- Skill does not verify accessibility features use different skill for that
+- Skill avoids using screenshots and fallbacks to them only in case of low confidence after usage of tools

--- a/registry/skills/verify-ui/scripts/check-after-action.js
+++ b/registry/skills/verify-ui/scripts/check-after-action.js
@@ -35,19 +35,17 @@ async function collectAfterAction() {
     return rect.width > 0 && rect.height > 0;
   }
 
-  function findTarget(selector, text) {
-    if (!text) return scopeEl.querySelector(selector);
-    const all = scopeEl.querySelectorAll(selector);
-    for (const el of all) {
-      if (el.textContent.includes(text)) return el;
-    }
-    return null;
+  function findTargets(selector, text) {
+    const all = [...scopeEl.querySelectorAll(selector)];
+    if (!text) return all;
+    return all.filter((el) => (el.textContent || "").includes(text));
   }
 
   function checkEntry(entry) {
     const wantVisible = entry.visible !== false;
-    const el = findTarget(entry.selector, entry.text);
-    return (el ? isVisible(el) : false) === wantVisible;
+    const matches = findTargets(entry.selector, entry.text);
+    const anyVisible = matches.some((el) => isVisible(el));
+    return wantVisible ? anyVisible : !anyVisible;
   }
 
   // Poll until expected state or timeout
@@ -64,15 +62,15 @@ async function collectAfterAction() {
 
   const results = expect.map((entry) => {
     const wantVisible = entry.visible !== false;
-    const el = findTarget(entry.selector, entry.text);
-    const actualVisible = el ? isVisible(el) : false;
+    const matches = findTargets(entry.selector, entry.text);
+    const actualVisible = matches.some((el) => isVisible(el));
     const pass = actualVisible === wantVisible;
 
     const result = {
       selector: entry.selector,
       pass,
       expected: wantVisible ? "visible" : "hidden",
-      actual: actualVisible ? "visible" : el ? "hidden" : "not found",
+      actual: actualVisible ? "visible" : matches.length ? "hidden" : "not found",
     };
 
     if (entry.text) result.text = entry.text;
@@ -84,7 +82,7 @@ async function collectAfterAction() {
           : "element is visible"
         : entry.text
           ? `no visible element contains "${entry.text}"`
-          : el
+          : matches.length
             ? "element is hidden"
             : "element not found";
     } else {

--- a/registry/skills/verify-ui/scripts/check-after-action.js
+++ b/registry/skills/verify-ui/scripts/check-after-action.js
@@ -1,0 +1,110 @@
+// check-after-action.js
+// 3-stage after-action state verification.
+// Stage 1: setupAfterAction() — installs polling observer, returns handle
+// Stage 2: Agent performs click via Playwright native click (page.locator().click())
+// Stage 3: collectAfterAction() — waits for expected state and returns results
+//
+// Usage:
+//   1. Inject script: page.evaluate(scriptContent)
+//   2. Setup:  page.evaluate((opts) => setupAfterAction(opts), { scope: '...', expect: [...], timeout: 5000 })
+//   3. Click:  page.locator('.submit-button').click()
+//   4. Collect: page.evaluate(() => collectAfterAction())
+
+function setupAfterAction({ expect, scope, timeout = 5000 } = {}) {
+  if (!expect || !expect.length) return { error: 'Provide an "expect" array' };
+
+  const scopeEl = scope ? document.querySelector(scope) : document.documentElement;
+  if (scope && !scopeEl) return { error: `Scope not found: ${scope}` };
+
+  // Store on window so collectAfterAction can access it
+  window.__afterAction = { expect, scope, scopeEl, timeout, startTime: Date.now() };
+  return { ready: true };
+}
+
+async function collectAfterAction() {
+  const ctx = window.__afterAction;
+  if (!ctx) return { error: 'Call setupAfterAction first' };
+
+  const { expect, scope, scopeEl, timeout, startTime } = ctx;
+
+  function isVisible(el) {
+    if (!el || !el.isConnected) return false;
+    const cs = getComputedStyle(el);
+    if (cs.display === "none" || cs.visibility === "hidden" || cs.opacity === "0") return false;
+    const rect = el.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  }
+
+  function findTarget(selector, text) {
+    if (!text) return scopeEl.querySelector(selector);
+    const all = scopeEl.querySelectorAll(selector);
+    for (const el of all) {
+      if (el.textContent.includes(text)) return el;
+    }
+    return null;
+  }
+
+  function checkEntry(entry) {
+    const wantVisible = entry.visible !== false;
+    const el = findTarget(entry.selector, entry.text);
+    return (el ? isVisible(el) : false) === wantVisible;
+  }
+
+  // Poll until expected state or timeout
+  const remaining = Math.max(0, timeout - (Date.now() - startTime));
+  const deadline = Date.now() + remaining;
+  await new Promise((resolve) => {
+    (function poll() {
+      if (expect.every(checkEntry) || Date.now() >= deadline) return resolve();
+      requestAnimationFrame(poll);
+    })();
+  });
+
+  const duration = Date.now() - startTime;
+
+  const results = expect.map((entry) => {
+    const wantVisible = entry.visible !== false;
+    const el = findTarget(entry.selector, entry.text);
+    const actualVisible = el ? isVisible(el) : false;
+    const pass = actualVisible === wantVisible;
+
+    const result = {
+      selector: entry.selector,
+      pass,
+      expected: wantVisible ? "visible" : "hidden",
+      actual: actualVisible ? "visible" : el ? "hidden" : "not found",
+    };
+
+    if (entry.text) result.text = entry.text;
+
+    if (pass) {
+      result.reason = wantVisible
+        ? entry.text
+          ? `element containing "${entry.text}" is visible`
+          : "element is visible"
+        : entry.text
+          ? `no visible element contains "${entry.text}"`
+          : el
+            ? "element is hidden"
+            : "element not found";
+    } else {
+      result.reason = wantVisible
+        ? entry.text
+          ? `no element matching "${entry.selector}" with text "${entry.text}" became visible within ${timeout}ms`
+          : `element "${entry.selector}" did not become visible within ${timeout}ms`
+        : entry.text
+          ? `element "${entry.selector}" still shows "${entry.text}" after ${timeout}ms`
+          : `element "${entry.selector}" still visible after ${timeout}ms`;
+    }
+
+    return result;
+  });
+
+  delete window.__afterAction;
+
+  return {
+    pass: results.every((r) => r.pass),
+    duration,
+    results,
+  };
+}

--- a/registry/skills/verify-ui/scripts/check-alignment.js
+++ b/registry/skills/verify-ui/scripts/check-alignment.js
@@ -1,5 +1,5 @@
 // check-alignment.js
-// Detects layout behaviour (row, column, line, v-line, grid) and verifies alignment.
+// Detects layout behavior (row, column, line, v-line, grid) and verifies alignment.
 //
 // Usage with Playwright MCP browser_evaluate:
 //   1. Load the function into the page:
@@ -182,7 +182,7 @@ function checkAlignment({ selectors, containerSelector, scopeSelector } = {}) {
   if (elements.length === 1) {
     return {
       count: 1,
-      behaviour: "single",
+      behavior: "single",
       alignment: [],
       lines: [{ elements: [describeElement(0)], gaps: { uniform: true, values: [] } }],
       gaps: { uniform: true, values: [] },
@@ -210,7 +210,7 @@ function checkAlignment({ selectors, containerSelector, scopeSelector } = {}) {
     if (allEqual(idx.map((i) => rects[i].height))) alignment.push("equal-height");
 
     return {
-      behaviour: "row",
+      behavior: "row",
       alignment,
       lines: [{ elements: sorted.map(describeElement), gaps }],
       gaps,
@@ -233,7 +233,7 @@ function checkAlignment({ selectors, containerSelector, scopeSelector } = {}) {
     if (allEqual(idx.map((i) => rects[i].height))) alignment.push("equal-height");
 
     return {
-      behaviour: "column",
+      behavior: "column",
       alignment,
       lines: [{ elements: sorted.map(describeElement), gaps }],
       gaps,
@@ -288,7 +288,7 @@ function checkAlignment({ selectors, containerSelector, scopeSelector } = {}) {
       if (allEqual(idx.map((i) => rects[i].width))) alignment.push("equal-width");
 
       return {
-        behaviour: "line",
+        behavior: "line",
         alignment,
         lines: rows.map((row) => ({
           elements: row.map(describeElement),
@@ -348,7 +348,7 @@ function checkAlignment({ selectors, containerSelector, scopeSelector } = {}) {
       if (allEqual(idx.map((i) => rects[i].height))) alignment.push("equal-height");
 
       return {
-        behaviour: "v-line",
+        behavior: "v-line",
         alignment,
         lines: cols.map((col) => ({
           elements: col.map(describeElement),
@@ -386,7 +386,7 @@ function checkAlignment({ selectors, containerSelector, scopeSelector } = {}) {
       const alignment = [edgeLabel(edge)];
 
       return {
-        behaviour: "grid",
+        behavior: "grid",
         alignment,
         lines: rows.map((row) => ({
           elements: row.map(describeElement),
@@ -414,7 +414,7 @@ function checkAlignment({ selectors, containerSelector, scopeSelector } = {}) {
 
   return {
     count: elements.length,
-    behaviour: "unknown",
+    behavior: "unknown",
     alignment: [],
     lines: [],
     gaps: { uniform: false, values: [] },

--- a/registry/skills/verify-ui/scripts/check-alignment.js
+++ b/registry/skills/verify-ui/scripts/check-alignment.js
@@ -1,0 +1,423 @@
+// check-alignment.js
+// Detects layout behaviour (row, column, line, v-line, grid) and verifies alignment.
+//
+// Usage with Playwright MCP browser_evaluate:
+//   1. Load the function into the page:
+//      browser_evaluate({ function: "<paste checkAlignment function>" })
+//   2. Call it:
+//      browser_evaluate({ function: "() => checkAlignment({ containerSelector: '[role=\"tablist\"]' })" })
+//
+// Or with browser_run_code_unsafe:
+//   async (page) => page.evaluate((opts) => checkAlignment(opts), { containerSelector: '...' })
+
+function checkAlignment({ selectors, containerSelector, scopeSelector } = {}) {
+  // --- Resolve scope ---
+  const scopeEl = scopeSelector
+    ? document.querySelector(scopeSelector)
+    : document.documentElement;
+  if (scopeSelector && !scopeEl) {
+    return { error: `Scope not found: ${scopeSelector}` };
+  }
+
+  // --- Helper: find container (handles scope === container case) ---
+  const findInScope = (selector) => {
+    if (!selector) return null;
+    if (scopeEl !== document.documentElement && scopeEl.matches(selector)) return scopeEl;
+    return scopeEl.querySelector(selector);
+  };
+
+  // --- Resolve elements and container ---
+  let elements = [];
+  let containerEl = null;
+
+  if (selectors && selectors.length) {
+    for (const sel of selectors) {
+      const el = findInScope(sel);
+      if (!el) return { error: `Element not found: ${sel}` };
+      elements.push(el);
+    }
+    if (containerSelector) {
+      containerEl = findInScope(containerSelector);
+    }
+  } else if (containerSelector) {
+    containerEl = findInScope(containerSelector);
+    if (!containerEl) return { error: `Container not found: ${containerSelector}` };
+    elements = Array.from(containerEl.children).filter((el) => {
+      const r = el.getBoundingClientRect();
+      return r.width > 0 && r.height > 0;
+    });
+  } else {
+    return { error: "Provide selectors or containerSelector" };
+  }
+
+  if (elements.length === 0) {
+    return { count: 0, error: "No visible elements found" };
+  }
+
+  // --- Gather rects and container rect ---
+  const rects = elements.map((el) => el.getBoundingClientRect());
+  const refEl = containerEl || elements[0].parentElement;
+  const containerRect = refEl ? refEl.getBoundingClientRect() : null;
+
+  // ============================================================
+  // Helpers
+  // ============================================================
+
+  const yOf = (r, edge) =>
+    edge === "top" ? r.top : edge === "bottom" ? r.bottom : r.top + r.height / 2;
+
+  const xOf = (r, edge) =>
+    edge === "left" ? r.left : edge === "right" ? r.right : r.left + r.width / 2;
+
+  const allEqual = (arr) => arr.length > 1 && arr.every((v) => v === arr[0]);
+
+  const groupByValue = (indices, valueFn) => {
+    const map = new Map();
+    for (const i of indices) {
+      const key = valueFn(i);
+      if (!map.has(key)) map.set(key, []);
+      map.get(key).push(i);
+    }
+    return [...map.values()];
+  };
+
+  const edgeLabel = (edge) => (edge.includes("center") ? edge : `${edge}-aligned`);
+
+  const Y_EDGES = ["top", "bottom", "center-y"];
+  const X_EDGES = ["left", "right", "center-x"];
+  const idx = rects.map((_, i) => i);
+
+  // --- Element descriptor ---
+  const buildSelector = (el) => {
+    if (el.id) return `#${el.id}`;
+    const role = el.getAttribute("role");
+    const tag = el.tagName.toLowerCase();
+    const cls =
+      el.className && typeof el.className === "string"
+        ? el.className
+            .split(" ")
+            .filter(Boolean)
+            .map((c) => `.${c}`)
+            .join("")
+        : "";
+    return role ? `${tag}[role="${role}"]${cls}` : `${tag}${cls}`;
+  };
+
+  const describeElement = (i) => ({
+    selector: buildSelector(elements[i]),
+    width: Math.round(rects[i].width * 10) / 10,
+    height: Math.round(rects[i].height * 10) / 10,
+    text: (elements[i].textContent || "").trim().substring(0, 50),
+  });
+
+  // --- Gap calculation ---
+  const calcGaps = (sortedIndices, axis) => {
+    if (sortedIndices.length < 2) return { uniform: true, values: [] };
+    const vals = [];
+    for (let i = 1; i < sortedIndices.length; i++) {
+      const prev = rects[sortedIndices[i - 1]];
+      const curr = rects[sortedIndices[i]];
+      vals.push(Math.round(axis === "x" ? curr.left - prev.right : curr.top - prev.bottom));
+    }
+    const uniform = vals.every((v) => v === vals[0]);
+    const result = { uniform, values: vals.map((v) => `${v}px`) };
+    if (uniform) result.value = `${vals[0]}px`;
+    return result;
+  };
+
+  const aggregateGaps = (groups, axis) => {
+    const all = [];
+    for (const g of groups) {
+      for (let i = 1; i < g.length; i++) {
+        const prev = rects[g[i - 1]];
+        const curr = rects[g[i]];
+        all.push(Math.round(axis === "x" ? curr.left - prev.right : curr.top - prev.bottom));
+      }
+    }
+    if (all.length === 0) return { uniform: true, values: [] };
+    const uniform = all.every((v) => v === all[0]);
+    const result = { uniform, values: all.map((v) => `${v}px`) };
+    if (uniform) result.value = `${all[0]}px`;
+    return result;
+  };
+
+  const calcLineGaps = (groups, axis) => {
+    if (groups.length < 2) return { uniform: true, values: [] };
+    const vals = [];
+    for (let i = 1; i < groups.length; i++) {
+      if (axis === "y") {
+        const prevBottom = Math.max(...groups[i - 1].map((j) => rects[j].bottom));
+        const currTop = Math.min(...groups[i].map((j) => rects[j].top));
+        vals.push(Math.round(currTop - prevBottom));
+      } else {
+        const prevRight = Math.max(...groups[i - 1].map((j) => rects[j].right));
+        const currLeft = Math.min(...groups[i].map((j) => rects[j].left));
+        vals.push(Math.round(currLeft - prevRight));
+      }
+    }
+    const uniform = vals.every((v) => v === vals[0]);
+    const result = { uniform, values: vals.map((v) => `${v}px`) };
+    if (uniform) result.value = `${vals[0]}px`;
+    return result;
+  };
+
+  // --- Collect alignment labels ---
+  const collectAlignments = (indices, yEdges, xEdges) => {
+    const labels = [];
+    for (const edge of yEdges) {
+      if (allEqual(indices.map((i) => yOf(rects[i], edge)))) labels.push(edgeLabel(edge));
+    }
+    for (const edge of xEdges) {
+      if (allEqual(indices.map((i) => xOf(rects[i], edge)))) labels.push(edgeLabel(edge));
+    }
+    if (allEqual(indices.map((i) => rects[i].width))) labels.push("equal-width");
+    if (allEqual(indices.map((i) => rects[i].height))) labels.push("equal-height");
+    return labels;
+  };
+
+  // ============================================================
+  // Single element
+  // ============================================================
+
+  if (elements.length === 1) {
+    return {
+      count: 1,
+      behaviour: "single",
+      alignment: [],
+      lines: [{ elements: [describeElement(0)], gaps: { uniform: true, values: [] } }],
+      gaps: { uniform: true, values: [] },
+      elements: [describeElement(0)],
+    };
+  }
+
+  // ============================================================
+  // Behaviour checkers
+  // ============================================================
+
+  // --- Row: all elements share same Y coordinate ---
+  function tryRow() {
+    const yAlignments = [];
+    for (const edge of Y_EDGES) {
+      if (allEqual(idx.map((i) => yOf(rects[i], edge)))) yAlignments.push(edgeLabel(edge));
+    }
+    if (yAlignments.length === 0) return null;
+
+    const sorted = [...idx].sort((a, b) => rects[a].left - rects[b].left);
+    const gaps = calcGaps(sorted, "x");
+
+    const alignment = [...yAlignments];
+    if (allEqual(idx.map((i) => rects[i].width))) alignment.push("equal-width");
+    if (allEqual(idx.map((i) => rects[i].height))) alignment.push("equal-height");
+
+    return {
+      behaviour: "row",
+      alignment,
+      lines: [{ elements: sorted.map(describeElement), gaps }],
+      gaps,
+    };
+  }
+
+  // --- Column: all elements share same X coordinate ---
+  function tryColumn() {
+    const xAlignments = [];
+    for (const edge of X_EDGES) {
+      if (allEqual(idx.map((i) => xOf(rects[i], edge)))) xAlignments.push(edgeLabel(edge));
+    }
+    if (xAlignments.length === 0) return null;
+
+    const sorted = [...idx].sort((a, b) => rects[a].top - rects[b].top);
+    const gaps = calcGaps(sorted, "y");
+
+    const alignment = [...xAlignments];
+    if (allEqual(idx.map((i) => rects[i].width))) alignment.push("equal-width");
+    if (allEqual(idx.map((i) => rects[i].height))) alignment.push("equal-height");
+
+    return {
+      behaviour: "column",
+      alignment,
+      lines: [{ elements: sorted.map(describeElement), gaps }],
+      gaps,
+    };
+  }
+
+  // --- Line: elements wrap into horizontal rows within container width ---
+  function tryLine() {
+    if (!containerRect) return null;
+
+    for (const edge of Y_EDGES) {
+      const rows = groupByValue(idx, (i) => yOf(rects[i], edge));
+      if (rows.length < 2) continue;
+
+      // Sort rows top-to-bottom, elements within each row left-to-right
+      rows.sort((a, b) => rects[a[0]].top - rects[b[0]].top);
+      for (const row of rows) row.sort((a, b) => rects[a].left - rects[b].left);
+
+      // Find reference gap from first multi-element row
+      let refGap = 0;
+      for (const row of rows) {
+        if (row.length > 1) {
+          refGap = rects[row[1]].left - rects[row[0]].right;
+          break;
+        }
+      }
+
+      // Validate each row
+      let valid = true;
+      for (let r = 0; r < rows.length; r++) {
+        const row = rows[r];
+        const rowWidth = rects[row[row.length - 1]].right - rects[row[0]].left;
+
+        // Row must fit inside container
+        if (rowWidth > containerRect.width) {
+          valid = false;
+          break;
+        }
+
+        // Single-element row (not last): wrapping must be justified
+        if (row.length === 1 && r < rows.length - 1) {
+          const nextFirst = rects[rows[r + 1][0]];
+          if (rects[row[0]].width + refGap + nextFirst.width <= containerRect.width) {
+            valid = false;
+            break;
+          }
+        }
+      }
+      if (!valid) continue;
+
+      const alignment = [edgeLabel(edge)];
+      if (allEqual(idx.map((i) => rects[i].width))) alignment.push("equal-width");
+
+      return {
+        behaviour: "line",
+        alignment,
+        lines: rows.map((row) => ({
+          elements: row.map(describeElement),
+          gaps: calcGaps(row, "x"),
+        })),
+        gaps: aggregateGaps(rows, "x"),
+        lineGaps: calcLineGaps(rows, "y"),
+      };
+    }
+    return null;
+  }
+
+  // --- V-line: elements wrap into vertical columns within container height ---
+  function tryVLine() {
+    if (!containerRect) return null;
+
+    for (const edge of X_EDGES) {
+      const cols = groupByValue(idx, (i) => xOf(rects[i], edge));
+      if (cols.length < 2) continue;
+
+      // Sort columns left-to-right, elements within each column top-to-bottom
+      cols.sort((a, b) => rects[a[0]].left - rects[b[0]].left);
+      for (const col of cols) col.sort((a, b) => rects[a].top - rects[b].top);
+
+      // Find reference gap from first multi-element column
+      let refGap = 0;
+      for (const col of cols) {
+        if (col.length > 1) {
+          refGap = rects[col[1]].top - rects[col[0]].bottom;
+          break;
+        }
+      }
+
+      // Validate each column
+      let valid = true;
+      for (let c = 0; c < cols.length; c++) {
+        const col = cols[c];
+        const colHeight = rects[col[col.length - 1]].bottom - rects[col[0]].top;
+
+        if (colHeight > containerRect.height) {
+          valid = false;
+          break;
+        }
+
+        // Single-element column (not last): wrapping must be justified
+        if (col.length === 1 && c < cols.length - 1) {
+          const nextFirst = rects[cols[c + 1][0]];
+          if (rects[col[0]].height + refGap + nextFirst.height <= containerRect.height) {
+            valid = false;
+            break;
+          }
+        }
+      }
+      if (!valid) continue;
+
+      const alignment = [edgeLabel(edge)];
+      if (allEqual(idx.map((i) => rects[i].height))) alignment.push("equal-height");
+
+      return {
+        behaviour: "v-line",
+        alignment,
+        lines: cols.map((col) => ({
+          elements: col.map(describeElement),
+          gaps: calcGaps(col, "y"),
+        })),
+        gaps: aggregateGaps(cols, "y"),
+        lineGaps: calcLineGaps(cols, "x"),
+      };
+    }
+    return null;
+  }
+
+  // --- Grid: multiple rows with non-intersecting Y ranges ---
+  function tryGrid() {
+    for (const edge of Y_EDGES) {
+      const rows = groupByValue(idx, (i) => yOf(rects[i], edge));
+      if (rows.length < 2) continue;
+
+      rows.sort((a, b) => rects[a[0]].top - rects[b[0]].top);
+
+      // Rows must not intersect vertically
+      let valid = true;
+      for (let i = 1; i < rows.length; i++) {
+        const prevBottom = Math.max(...rows[i - 1].map((j) => rects[j].bottom));
+        const currTop = Math.min(...rows[i].map((j) => rects[j].top));
+        if (currTop < prevBottom) {
+          valid = false;
+          break;
+        }
+      }
+      if (!valid) continue;
+
+      for (const row of rows) row.sort((a, b) => rects[a].left - rects[b].left);
+
+      const alignment = [edgeLabel(edge)];
+
+      return {
+        behaviour: "grid",
+        alignment,
+        lines: rows.map((row) => ({
+          elements: row.map(describeElement),
+          gaps: calcGaps(row, "x"),
+          alignment: collectAlignments(row, Y_EDGES, []),
+        })),
+        gaps: aggregateGaps(rows, "x"),
+        lineGaps: calcLineGaps(rows, "y"),
+      };
+    }
+    return null;
+  }
+
+  // ============================================================
+  // Run detection: most specific first
+  // ============================================================
+
+  const result = tryRow() || tryColumn() || tryLine() || tryVLine() || tryGrid();
+
+  if (result) {
+    result.count = elements.length;
+    result.elements = idx.map(describeElement);
+    return result;
+  }
+
+  return {
+    count: elements.length,
+    behaviour: "unknown",
+    alignment: [],
+    lines: [],
+    gaps: { uniform: false, values: [] },
+    elements: idx.map(describeElement),
+  };
+}

--- a/registry/skills/verify-ui/scripts/check-clickable.js
+++ b/registry/skills/verify-ui/scripts/check-clickable.js
@@ -1,0 +1,106 @@
+// check-clickable.js
+// Checks whether elements are clickable by combining viewport bounds,
+// visibility styles, and elementFromPoint hit-testing.
+//
+// Usage with Playwright MCP browser_evaluate:
+//   browser_evaluate({ function: "() => checkClickable({ selectors: ['button'], scope: '[role=\"dialog\"]' })" })
+
+function checkClickable({ selectors, scope } = {}) {
+  if (!selectors || selectors.length === 0) {
+    return { error: 'Provide a "selectors" array' };
+  }
+
+  const scopeEl = scope ? document.querySelector(scope) : document.documentElement;
+  if (!scopeEl) {
+    return { error: `Scope element not found: ${scope}` };
+  }
+
+  const viewport = { width: window.innerWidth, height: window.innerHeight };
+
+  function test(element) {
+    const rect = element.getBoundingClientRect();
+
+    // Zero dimensions
+    if (rect.width === 0 || rect.height === 0) {
+      return { clickable: false, reason: "element has zero dimensions", blocked_by: null };
+    }
+
+    // Outside viewport
+    if (
+      rect.bottom < 0 ||
+      rect.top > viewport.height ||
+      rect.right < 0 ||
+      rect.left > viewport.width
+    ) {
+      const axis = rect.top > viewport.height || rect.bottom < 0 ? "y" : "x";
+      const coord = axis === "y" ? Math.round(rect.top) : Math.round(rect.left);
+      const limit = axis === "y" ? viewport.height : viewport.width;
+      return {
+        clickable: false,
+        reason: `element is outside viewport (${axis}: ${coord}, viewport ${axis === "y" ? "height" : "width"}: ${limit})`,
+        blocked_by: null,
+      };
+    }
+
+    // Visibility checks (only the four properties the skill permits)
+    const cs = getComputedStyle(element);
+    if (cs.display === "none")
+      return { clickable: false, reason: "display: none", blocked_by: null };
+    if (cs.visibility === "hidden")
+      return { clickable: false, reason: "visibility: hidden", blocked_by: null };
+    if (cs.opacity === "0")
+      return { clickable: false, reason: "opacity: 0", blocked_by: null };
+    if (cs.pointerEvents === "none")
+      return { clickable: false, reason: "pointer-events: none", blocked_by: null };
+
+    // Hit-test from center
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const topEl = document.elementFromPoint(cx, cy);
+
+    if (!topEl) {
+      return { clickable: false, reason: "elementFromPoint returned null", blocked_by: null };
+    }
+
+    if (element === topEl || element.contains(topEl)) {
+      return { clickable: true, reason: "elementFromPoint returns self" };
+    }
+
+    // Covered by something else
+    const tag = topEl.tagName.toLowerCase();
+    const cls =
+      topEl.className && typeof topEl.className === "string"
+        ? "." + topEl.className.split(" ").filter(Boolean)[0]
+        : "";
+    return {
+      clickable: false,
+      reason: "covered by another element",
+      blocked_by: `${tag}${cls}`,
+    };
+  }
+
+  const results = [];
+
+  for (const sel of selectors) {
+    const el = scopeEl.querySelector(sel);
+    if (!el) {
+      results.push({
+        selector: sel,
+        text: null,
+        clickable: false,
+        reason: `element not found within scope`,
+        blocked_by: null,
+      });
+      continue;
+    }
+
+    const verdict = test(el);
+    results.push({
+      selector: sel,
+      text: (el.textContent || "").trim().substring(0, 50),
+      ...verdict,
+    });
+  }
+
+  return { results };
+}

--- a/registry/skills/verify-ui/scripts/check-inventory.js
+++ b/registry/skills/verify-ui/scripts/check-inventory.js
@@ -1,0 +1,285 @@
+// check-inventory.js
+// Returns a structured map of what's inside a scoped container:
+// interactive elements (buttons, inputs, links) with their text, roles,
+// aria states, and the container's scroll state.
+//
+// Usage with Playwright MCP browser_evaluate:
+//   1. Inject: browser_evaluate({ function: "<paste checkInventory function>" })
+//   2. Call:   browser_evaluate({ function: "() => checkInventory({ scope: '[data-radix-popper-content-wrapper]' })" })
+//
+// Or with browser_run_code_unsafe:
+//   async (page) => page.evaluate((opts) => checkInventory(opts), { scope: '...' })
+
+function checkInventory({ scope, include, exclude, maxDepth } = {}) {
+  if (!scope) {
+    return { error: 'Provide a "scope" selector' };
+  }
+
+  const scopeEl = document.querySelector(scope);
+  if (!scopeEl) {
+    return { error: `Scope element not found: ${scope}` };
+  }
+
+  // Default interactive selectors when include is not provided
+  const defaultInclude = [
+    "button",
+    "a[href]",
+    "input",
+    "select",
+    "textarea",
+    '[role="button"]',
+    '[role="link"]',
+    '[role="option"]',
+    '[role="radio"]',
+    '[role="checkbox"]',
+    '[role="switch"]',
+    '[role="tab"]',
+    '[role="menuitem"]',
+    '[role="menuitemcheckbox"]',
+    '[role="menuitemradio"]',
+    '[role="slider"]',
+    '[role="spinbutton"]',
+    '[role="combobox"]',
+    '[role="searchbox"]',
+    '[role="listbox"]',
+  ];
+
+  const selectors = include && include.length ? include : defaultInclude;
+  const excludeSet = new Set(exclude || []);
+
+  const viewport = { width: window.innerWidth, height: window.innerHeight };
+  const scopeRect = scopeEl.getBoundingClientRect();
+
+  // --- Collect all matching elements, deduped ---
+  const seen = new Set();
+  const elements = [];
+
+  for (const sel of selectors) {
+    if (excludeSet.has(sel)) continue;
+    const matches = scopeEl.querySelectorAll(sel);
+    for (const el of matches) {
+      if (seen.has(el)) continue;
+      seen.add(el);
+      elements.push(el);
+    }
+  }
+
+  // --- Build element descriptors ---
+  function describeElement(el) {
+    const rect = el.getBoundingClientRect();
+    const cs = getComputedStyle(el);
+    const tag = el.tagName.toLowerCase();
+    const role = el.getAttribute("role") || implicitRole(el);
+    const text = (el.textContent || "").trim().substring(0, 80);
+
+    // Collect all aria-* attributes
+    const ariaState = {};
+    for (const attr of el.attributes) {
+      if (attr.name.startsWith("aria-")) {
+        ariaState[attr.name] = attr.value;
+      }
+    }
+
+    // Add checked/disabled/selected for native form elements
+    if (el.disabled !== undefined && el.disabled) ariaState["disabled"] = "true";
+    if (el.checked !== undefined && el.checked) ariaState["checked"] = "true";
+
+    // Visibility
+    const visible =
+      cs.display !== "none" &&
+      cs.visibility !== "hidden" &&
+      cs.opacity !== "0" &&
+      rect.width > 0 &&
+      rect.height > 0;
+
+    // Within viewport
+    const inViewport =
+      rect.top < viewport.height &&
+      rect.bottom > 0 &&
+      rect.left < viewport.width &&
+      rect.right > 0;
+
+    // Build a usable selector
+    const selector = buildSelector(el);
+
+    return {
+      selector,
+      tag,
+      role,
+      text: text || null,
+      ariaState: Object.keys(ariaState).length ? ariaState : null,
+      visible,
+      inViewport: visible ? inViewport : false,
+      rect: {
+        top: Math.round(rect.top),
+        left: Math.round(rect.left),
+        width: Math.round(rect.width),
+        height: Math.round(rect.height),
+      },
+    };
+  }
+
+  function implicitRole(el) {
+    const tag = el.tagName.toLowerCase();
+    const type = el.getAttribute("type");
+    if (tag === "button") return "button";
+    if (tag === "a" && el.hasAttribute("href")) return "link";
+    if (tag === "input" && type === "checkbox") return "checkbox";
+    if (tag === "input" && type === "radio") return "radio";
+    if (tag === "input" && type === "range") return "slider";
+    if (tag === "input") return "textbox";
+    if (tag === "select") return "combobox";
+    if (tag === "textarea") return "textbox";
+    return null;
+  }
+
+  function buildSelector(el) {
+    if (el.id) return `#${el.id}`;
+    const testId =
+      el.getAttribute("data-testid") || el.getAttribute("data-test-id");
+    if (testId) return `[data-testid="${testId}"]`;
+    const tag = el.tagName.toLowerCase();
+    const role = el.getAttribute("role");
+    const text = (el.textContent || "").trim().substring(0, 30);
+    if (role) {
+      const pressed = el.getAttribute("aria-pressed");
+      const selected = el.getAttribute("aria-selected");
+      const label = el.getAttribute("aria-label");
+      if (label) return `${tag}[role="${role}"][aria-label="${label}"]`;
+      if (pressed !== null)
+        return `${tag}[role="${role}"][aria-pressed="${pressed}"]:text("${text}")`;
+      if (selected !== null)
+        return `${tag}[role="${role}"][aria-selected="${selected}"]:text("${text}")`;
+      if (text) return `${tag}[role="${role}"]:text("${text}")`;
+      return `${tag}[role="${role}"]`;
+    }
+    const cls =
+      el.className && typeof el.className === "string"
+        ? "." + el.className.split(" ").filter(Boolean).slice(0, 2).join(".")
+        : "";
+    if (text) return `${tag}${cls}:text("${text}")`;
+    return `${tag}${cls}`;
+  }
+
+  // --- Detect groups/sections ---
+  const groupSelectors = [
+    '[role="group"]',
+    '[role="radiogroup"]',
+    '[role="tablist"]',
+    '[role="listbox"]',
+    '[role="menu"]',
+    "fieldset",
+  ];
+
+  const sections = [];
+  for (const gSel of groupSelectors) {
+    const groups = scopeEl.querySelectorAll(gSel);
+    for (const g of groups) {
+      const labelledBy = g.getAttribute("aria-labelledby");
+      const resolvedLabelledBy = labelledBy
+        ? labelledBy.split(/\s+/).map(id => document.getElementById(id)?.textContent?.trim()).filter(Boolean).join(" ")
+        : null;
+      const label =
+        g.getAttribute("aria-label") ||
+        resolvedLabelledBy ||
+        (g.querySelector("legend") || {}).textContent ||
+        null;
+      const role = g.getAttribute("role") || g.tagName.toLowerCase();
+      const childCount = g.querySelectorAll(
+        selectors.join(",")
+      ).length;
+      sections.push({
+        role,
+        label: label ? label.trim().substring(0, 60) : null,
+        childCount,
+        selector: buildSelector(g),
+      });
+    }
+  }
+
+  // --- Scroll state ---
+  function getScrollState(el) {
+    const cs = getComputedStyle(el);
+    const overflowY = cs.overflowY;
+    const overflowX = cs.overflowX;
+    const scrollableY =
+      (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") &&
+      el.scrollHeight > el.clientHeight;
+    const scrollableX =
+      (overflowX === "auto" || overflowX === "scroll" || overflowX === "overlay") &&
+      el.scrollWidth > el.clientWidth;
+
+    if (!scrollableY && !scrollableX) return null;
+
+    return {
+      scrollableY,
+      scrollableX,
+      scrollTop: Math.round(el.scrollTop),
+      scrollLeft: Math.round(el.scrollLeft),
+      scrollHeight: el.scrollHeight,
+      scrollWidth: el.scrollWidth,
+      clientHeight: el.clientHeight,
+      clientWidth: el.clientWidth,
+      atTop: el.scrollTop <= 0,
+      atBottom: el.scrollTop + el.clientHeight >= el.scrollHeight - 1,
+      atLeft: el.scrollLeft <= 0,
+      atRight: el.scrollLeft + el.clientWidth >= el.scrollWidth - 1,
+    };
+  }
+
+  // Check the scope element and its direct children for scrollability
+  const scrollState = getScrollState(scopeEl);
+  let scrollableChild = null;
+  if (!scrollState) {
+    for (const child of scopeEl.children) {
+      const childScroll = getScrollState(child);
+      if (childScroll) {
+        scrollableChild = {
+          selector: buildSelector(child),
+          ...childScroll,
+        };
+        break;
+      }
+    }
+  }
+
+  // --- Detect depth limit ---
+  let depth = 0;
+  if (maxDepth) {
+    let current = scopeEl;
+    function walk(el, d) {
+      if (d > depth) depth = d;
+      if (d >= maxDepth) return;
+      for (const child of el.children) walk(child, d + 1);
+    }
+    walk(scopeEl, 0);
+  }
+
+  // --- Summary counts ---
+  const described = elements.map(describeElement);
+  const visibleCount = described.filter((e) => e.visible).length;
+  const inViewportCount = described.filter((e) => e.inViewport).length;
+
+  return {
+    scope,
+    scopeRect: {
+      top: Math.round(scopeRect.top),
+      left: Math.round(scopeRect.left),
+      width: Math.round(scopeRect.width),
+      height: Math.round(scopeRect.height),
+      bottom: Math.round(scopeRect.bottom),
+      right: Math.round(scopeRect.right),
+    },
+    viewport,
+    summary: {
+      total: described.length,
+      visible: visibleCount,
+      inViewport: inViewportCount,
+      hidden: described.length - visibleCount,
+      sections: sections.length,
+    },
+    scrollState: scrollState || scrollableChild || null,
+    sections,
+    elements: described,
+  };
+}

--- a/registry/skills/verify-ui/scripts/check-inventory.js
+++ b/registry/skills/verify-ui/scripts/check-inventory.js
@@ -135,9 +135,10 @@ function checkInventory({ scope, include, exclude, maxDepth } = {}) {
 
   function buildSelector(el) {
     if (el.id) return `#${el.id}`;
-    const testId =
-      el.getAttribute("data-testid") || el.getAttribute("data-test-id");
-    if (testId) return `[data-testid="${testId}"]`;
+    const dataTestId = el.getAttribute("data-testid");
+    if (dataTestId) return `[data-testid="${dataTestId}"]`;
+    const dataTestIdAlt = el.getAttribute("data-test-id");
+    if (dataTestIdAlt) return `[data-test-id="${dataTestIdAlt}"]`;
     const tag = el.tagName.toLowerCase();
     const role = el.getAttribute("role");
     const text = (el.textContent || "").trim().substring(0, 30);

--- a/registry/skills/verify-ui/scripts/check-overflow.js
+++ b/registry/skills/verify-ui/scripts/check-overflow.js
@@ -207,8 +207,30 @@ function checkOverflow({ scope, checkFooter, checkInteractive, margin } = {}) {
       if (rect.width === 0 || rect.height === 0) continue;
 
       const elCs = getComputedStyle(el);
-      if (elCs.display === "none" || elCs.visibility === "hidden" || elCs.opacity === "0")
+      if (elCs.display === "none" || elCs.visibility === "hidden" || elCs.opacity === "0") {
+        unreachableList.push({
+          selector: buildSelector(el),
+          text: (el.textContent || "").trim().substring(0, 50),
+          role: el.getAttribute("role") || el.tagName.toLowerCase(),
+          reason: "invisible",
+          reachable: false,
+        });
         continue;
+      }
+      if (
+        elCs.pointerEvents === "none" ||
+        el.disabled === true ||
+        el.getAttribute("aria-disabled") === "true"
+      ) {
+        unreachableList.push({
+          selector: buildSelector(el),
+          text: (el.textContent || "").trim().substring(0, 50),
+          role: el.getAttribute("role") || el.tagName.toLowerCase(),
+          reason: "not interactive",
+          reachable: false,
+        });
+        continue;
+      }
 
       const issue = testReachability(el, rect);
       if (issue) {
@@ -261,7 +283,7 @@ function checkOverflow({ scope, checkFooter, checkInteractive, margin } = {}) {
 
     const topEl = document.elementFromPoint(cx, cy);
     if (!topEl) return { reason: "elementFromPoint returned null", reachable: false };
-    if (el === topEl || el.contains(topEl) || topEl.closest(buildSelector(el)))
+    if (el === topEl || el.contains(topEl))
       return null; // reachable
 
     const tag = topEl.tagName.toLowerCase();

--- a/registry/skills/verify-ui/scripts/check-overflow.js
+++ b/registry/skills/verify-ui/scripts/check-overflow.js
@@ -1,0 +1,327 @@
+// check-overflow.js
+// Checks whether a container or any of its children extend beyond the viewport,
+// whether it's scrollable, and whether all interactive elements inside remain reachable.
+//
+// Usage with Playwright MCP browser_evaluate:
+//   1. Inject: browser_evaluate({ function: "<paste checkOverflow function>" })
+//   2. Call:   browser_evaluate({ function: "() => checkOverflow({ scope: '[data-side]' })" })
+//
+// Or with browser_run_code_unsafe:
+//   async (page) => page.evaluate((opts) => checkOverflow(opts), { scope: '...', checkFooter: true })
+
+function checkOverflow({ scope, checkFooter, checkInteractive, margin } = {}) {
+  if (!scope) {
+    return { error: 'Provide a "scope" selector' };
+  }
+
+  const scopeEl = document.querySelector(scope);
+  if (!scopeEl) {
+    return { error: `Scope element not found: ${scope}` };
+  }
+
+  const viewport = { width: window.innerWidth, height: window.innerHeight };
+  const scopeRect = scopeEl.getBoundingClientRect();
+  const edgeMargin = margin || 0;
+
+  // --- Container overflow ---
+  const overflow = {
+    top: scopeRect.top < (0 - edgeMargin),
+    right: scopeRect.right > (viewport.width + edgeMargin),
+    bottom: scopeRect.bottom > (viewport.height + edgeMargin),
+    left: scopeRect.left < (0 - edgeMargin),
+  };
+
+  const overflows = overflow.top || overflow.right || overflow.bottom || overflow.left;
+
+  const overflowPx = {
+    top: overflow.top ? Math.round(0 - scopeRect.top) : 0,
+    right: overflow.right ? Math.round(scopeRect.right - viewport.width) : 0,
+    bottom: overflow.bottom ? Math.round(scopeRect.bottom - viewport.height) : 0,
+    left: overflow.left ? Math.round(0 - scopeRect.left) : 0,
+  };
+
+  // --- Scrollability of scope and its children ---
+  function getScrollInfo(el) {
+    const cs = getComputedStyle(el);
+    const overflowY = cs.overflowY;
+    const overflowX = cs.overflowX;
+    const scrollableY =
+      (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") &&
+      el.scrollHeight > el.clientHeight;
+    const scrollableX =
+      (overflowX === "auto" || overflowX === "scroll" || overflowX === "overlay") &&
+      el.scrollWidth > el.clientWidth;
+
+    if (!scrollableY && !scrollableX) return null;
+
+    return {
+      scrollableY,
+      scrollableX,
+      overflowY,
+      overflowX,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+      hiddenPxY: scrollableY ? el.scrollHeight - el.clientHeight : 0,
+      hiddenPxX: scrollableX ? el.scrollWidth - el.clientWidth : 0,
+    };
+  }
+
+  const scopeScroll = getScrollInfo(scopeEl);
+
+  // Check direct children for scrollable containers
+  let scrollableChildren = [];
+  for (const child of scopeEl.children) {
+    const info = getScrollInfo(child);
+    if (info) {
+      const tag = child.tagName.toLowerCase();
+      const cls =
+        child.className && typeof child.className === "string"
+          ? "." + child.className.split(" ").filter(Boolean).slice(0, 2).join(".")
+          : "";
+      scrollableChildren.push({
+        selector: tag + cls,
+        ...info,
+      });
+    }
+  }
+
+  const scrollable = !!(scopeScroll || scrollableChildren.length);
+
+  // --- Max-height / constraint detection ---
+  const cs = getComputedStyle(scopeEl);
+  const constraints = {
+    maxHeight: cs.maxHeight !== "none" ? cs.maxHeight : null,
+    maxWidth: cs.maxWidth !== "none" ? cs.maxWidth : null,
+    overflow: cs.overflow,
+    overflowY: cs.overflowY,
+    overflowX: cs.overflowX,
+  };
+
+  // --- Child overflow scan ---
+  // Find children that overflow the scope container's bounds
+  const clippedChildren = [];
+  const scopeBottom = scopeRect.bottom;
+  const scopeRight = scopeRect.right;
+
+  function scanChildren(el, depth) {
+    if (depth > 5) return; // limit depth
+    for (const child of el.children) {
+      const rect = child.getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) continue;
+
+      const clipped = {
+        bottom: rect.bottom > Math.min(scopeBottom, viewport.height) + edgeMargin,
+        right: rect.right > Math.min(scopeRight, viewport.width) + edgeMargin,
+        top: rect.top < Math.max(scopeRect.top, 0) - edgeMargin,
+        left: rect.left < Math.max(scopeRect.left, 0) - edgeMargin,
+      };
+
+      if (clipped.bottom || clipped.right || clipped.top || clipped.left) {
+        const tag = child.tagName.toLowerCase();
+        const text = (child.textContent || "").trim().substring(0, 50);
+        const role = child.getAttribute("role");
+        clippedChildren.push({
+          selector: buildSelector(child),
+          tag,
+          role,
+          text: text || null,
+          clipped,
+          rect: {
+            top: Math.round(rect.top),
+            left: Math.round(rect.left),
+            bottom: Math.round(rect.bottom),
+            right: Math.round(rect.right),
+            width: Math.round(rect.width),
+            height: Math.round(rect.height),
+          },
+        });
+      }
+
+      scanChildren(child, depth + 1);
+    }
+  }
+
+  scanChildren(scopeEl, 0);
+
+  // --- Footer check ---
+  let footer = null;
+  if (checkFooter !== false) {
+    // Find the last meaningful child (skip empty text nodes)
+    const children = Array.from(scopeEl.children).filter((c) => {
+      const r = c.getBoundingClientRect();
+      return r.width > 0 && r.height > 0;
+    });
+
+    if (children.length > 0) {
+      const lastChild = children[children.length - 1];
+      const lastRect = lastChild.getBoundingClientRect();
+      const clippedBottom = lastRect.bottom > viewport.height + edgeMargin;
+      const clippedRight = lastRect.right > viewport.width + edgeMargin;
+
+      footer = {
+        selector: buildSelector(lastChild),
+        text: (lastChild.textContent || "").trim().substring(0, 80),
+        clipped: clippedBottom || clippedRight,
+        clippedBottom,
+        clippedRight,
+        rect: {
+          top: Math.round(lastRect.top),
+          bottom: Math.round(lastRect.bottom),
+          height: Math.round(lastRect.height),
+        },
+        overflowPx: clippedBottom
+          ? Math.round(lastRect.bottom - viewport.height)
+          : 0,
+      };
+    }
+  }
+
+  // --- Interactive element reachability ---
+  let unreachable = null;
+  if (checkInteractive !== false) {
+    const interactiveSelectors = [
+      "button",
+      "a[href]",
+      "input",
+      "select",
+      "textarea",
+      '[role="button"]',
+      '[role="link"]',
+      '[role="option"]',
+      '[role="radio"]',
+      '[role="checkbox"]',
+      '[role="switch"]',
+      '[role="tab"]',
+      '[role="menuitem"]',
+    ];
+
+    const allInteractive = scopeEl.querySelectorAll(
+      interactiveSelectors.join(",")
+    );
+    const unreachableList = [];
+
+    for (const el of allInteractive) {
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) continue;
+
+      const elCs = getComputedStyle(el);
+      if (elCs.display === "none" || elCs.visibility === "hidden" || elCs.opacity === "0")
+        continue;
+
+      const issue = testReachability(el, rect);
+      if (issue) {
+        unreachableList.push({
+          selector: buildSelector(el),
+          text: (el.textContent || "").trim().substring(0, 50),
+          role: el.getAttribute("role") || el.tagName.toLowerCase(),
+          ...issue,
+        });
+      }
+    }
+
+    if (unreachableList.length > 0) {
+      unreachable = unreachableList;
+    }
+  }
+
+  function testReachability(el, rect) {
+    // Outside viewport entirely
+    if (
+      rect.bottom < 0 ||
+      rect.top > viewport.height ||
+      rect.right < 0 ||
+      rect.left > viewport.width
+    ) {
+      return { reason: "outside viewport", reachable: false };
+    }
+
+    // Partially outside viewport (clipped)
+    if (rect.bottom > viewport.height || rect.right > viewport.width) {
+      // Check if center is still within viewport
+      const cx = rect.left + rect.width / 2;
+      const cy = rect.top + rect.height / 2;
+      if (cx > viewport.width || cy > viewport.height) {
+        return {
+          reason: "center outside viewport",
+          reachable: false,
+          clippedPx: {
+            bottom: rect.bottom > viewport.height ? Math.round(rect.bottom - viewport.height) : 0,
+            right: rect.right > viewport.width ? Math.round(rect.right - viewport.width) : 0,
+          },
+        };
+      }
+    }
+
+    // Hit-test from center
+    const cx = Math.min(rect.left + rect.width / 2, viewport.width - 1);
+    const cy = Math.min(rect.top + rect.height / 2, viewport.height - 1);
+    if (cx < 0 || cy < 0) return { reason: "center outside viewport", reachable: false };
+
+    const topEl = document.elementFromPoint(cx, cy);
+    if (!topEl) return { reason: "elementFromPoint returned null", reachable: false };
+    if (el === topEl || el.contains(topEl) || topEl.closest(buildSelector(el)))
+      return null; // reachable
+
+    const tag = topEl.tagName.toLowerCase();
+    const cls =
+      topEl.className && typeof topEl.className === "string"
+        ? "." + CSS.escape(topEl.className.split(" ").filter(Boolean)[0] || "")
+        : "";
+    return {
+      reason: "covered by another element",
+      reachable: false,
+      coveredBy: `${tag}${cls}`,
+    };
+  }
+
+  function buildSelector(el) {
+    if (el.id) return `#${CSS.escape(el.id)}`;
+    const testId =
+      el.getAttribute("data-testid") || el.getAttribute("data-test-id");
+    if (testId) return `[data-testid="${CSS.escape(testId)}"]`;
+    const tag = el.tagName.toLowerCase();
+    const role = el.getAttribute("role");
+    const ariaLabel = el.getAttribute("aria-label");
+    const cls =
+      el.className && typeof el.className === "string"
+        ? "." + el.className.split(" ").filter(Boolean).slice(0, 2).map(c => CSS.escape(c)).join(".")
+        : "";
+    if (role && ariaLabel)
+      return `${tag}[role="${CSS.escape(role)}"][aria-label="${CSS.escape(ariaLabel)}"]`;
+    if (role) return `${tag}[role="${CSS.escape(role)}"]${cls}`;
+    return `${tag}${cls}`;
+  }
+
+  // --- Summary ---
+  return {
+    scope,
+    scopeRect: {
+      top: Math.round(scopeRect.top),
+      left: Math.round(scopeRect.left),
+      width: Math.round(scopeRect.width),
+      height: Math.round(scopeRect.height),
+      bottom: Math.round(scopeRect.bottom),
+      right: Math.round(scopeRect.right),
+    },
+    viewport,
+    overflows,
+    overflow,
+    overflowPx,
+    scrollable,
+    scrollState: scopeScroll || null,
+    scrollableChildren: scrollableChildren.length ? scrollableChildren : null,
+    constraints,
+    footer,
+    clippedChildren: clippedChildren.length ? clippedChildren : null,
+    unreachable,
+    summary: {
+      overflows,
+      scrollable,
+      footerClipped: footer ? footer.clipped : false,
+      unreachableCount: unreachable ? unreachable.length : 0,
+      clippedChildCount: clippedChildren.length,
+    },
+  };
+}

--- a/registry/skills/verify-ui/scripts/check-visibility-transition.js
+++ b/registry/skills/verify-ui/scripts/check-visibility-transition.js
@@ -1,0 +1,128 @@
+// check-visibility-transition.js
+// 3-stage visibility transition observation.
+// Stage 1: setupVisibilityTransition() — installs MutationObserver, records initial state
+// Stage 2: Agent performs click via Playwright native click (page.locator().click())
+// Stage 3: collectVisibilityTransition() — waits for expected sequence and returns results
+//
+// Usage:
+//   1. Inject script: page.evaluate(scriptContent)
+//   2. Setup:  page.evaluate((opts) => setupVisibilityTransition(opts), { target: '.spinner', scope: '[role="dialog"]', expected: [false, true, false], timeout: 5000 })
+//   3. Click:  page.locator('.submit-button').click()
+//   4. Collect: page.evaluate(() => collectVisibilityTransition())
+
+function setupVisibilityTransition({
+  target: targetSelector,
+  scope,
+  expected = [false, true, false],
+  timeout = 5000,
+} = {}) {
+  if (!targetSelector) {
+    return { error: 'Provide a "target" selector for the element to observe' };
+  }
+
+  const scopeEl = scope
+    ? document.querySelector(scope)
+    : document.documentElement;
+  if (!scopeEl) {
+    return { error: `Scope element not found: ${scope}` };
+  }
+
+  function isVisible(el) {
+    if (!el || !el.isConnected) return false;
+    const cs = getComputedStyle(el);
+    if (cs.display === "none" || cs.visibility === "hidden" || cs.opacity === "0")
+      return false;
+    const rect = el.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  }
+
+  let targetEl = scopeEl.querySelector(targetSelector);
+  const sequence = [isVisible(targetEl)];
+
+  const observer = new MutationObserver(() => {
+    targetEl = scopeEl.querySelector(targetSelector);
+    const currentlyVisible = isVisible(targetEl);
+    const lastRecorded = sequence[sequence.length - 1];
+    if (currentlyVisible !== lastRecorded) {
+      sequence.push(currentlyVisible);
+    }
+  });
+
+  observer.observe(scopeEl, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["style", "class", "hidden", "aria-hidden", "data-state", "open"],
+  });
+
+  window.__visTransition = {
+    observer, sequence, expected, targetSelector, scopeEl, isVisible,
+    startTime: Date.now(), timeout,
+  };
+
+  return { ready: true, initialVisible: sequence[0] };
+}
+
+async function collectVisibilityTransition() {
+  const ctx = window.__visTransition;
+  if (!ctx) return { error: 'Call setupVisibilityTransition first' };
+
+  const { observer, sequence, expected, targetSelector, timeout, startTime } = ctx;
+
+  const remaining = Math.max(0, timeout - (Date.now() - startTime));
+  const deadline = Date.now() + remaining;
+  await new Promise((resolve) => {
+    const check = setInterval(() => {
+      if (
+        JSON.stringify(sequence) === JSON.stringify(expected) ||
+        Date.now() >= deadline
+      ) {
+        clearInterval(check);
+        resolve();
+      }
+    }, 100);
+  });
+
+  observer.disconnect();
+  delete window.__visTransition;
+
+  const matches = JSON.stringify(sequence) === JSON.stringify(expected);
+  const duration = Date.now() - startTime;
+
+  return {
+    selector: targetSelector,
+    sequence,
+    expected,
+    matches,
+    duration,
+    reason: matches
+      ? describeTransition(expected)
+      : `timeout: ${describeFailure(sequence, expected, timeout)}`,
+  };
+}
+
+function describeTransition(seq) {
+  const key = JSON.stringify(seq);
+  if (key === "[false,true,false]") return "element appeared then disappeared as expected";
+  if (key === "[true,false,true]") return "element hid then reappeared as expected";
+  if (key === "[false,true]") return "element appeared and stayed visible as expected";
+  if (key === "[true,false]") return "element disappeared and stayed hidden as expected";
+  return `visibility sequence ${key} matched expected`;
+}
+
+function describeFailure(actual, expected, timeout) {
+  const last = actual[actual.length - 1];
+  if (actual.length === 1 && !actual[0] && expected[1] === true) {
+    return `element never became visible within ${timeout}ms`;
+  }
+  if (actual.length === 1 && actual[0] && expected[1] === false) {
+    return `element never became hidden within ${timeout}ms`;
+  }
+  if (actual.length === 2 && actual[1] && expected.length === 3 && !expected[2]) {
+    return `element appeared but never disappeared within ${timeout}ms`;
+  }
+  if (actual.length === 2 && !actual[1] && expected.length === 3 && expected[2]) {
+    return `element disappeared but never reappeared within ${timeout}ms`;
+  }
+  return `expected sequence ${JSON.stringify(expected)} but got ${JSON.stringify(actual)} within ${timeout}ms`;
+}

--- a/server/src/awos_recruitment_mcp/server.py
+++ b/server/src/awos_recruitment_mcp/server.py
@@ -25,6 +25,7 @@ from awos_recruitment_mcp.registry import (
     resolve_skill_paths,
 )
 from awos_recruitment_mcp.search_index import build_index
+from awos_recruitment_mcp.validate import _ALLOWED_SCRIPT_EXTENSIONS
 
 config = Config.from_env()
 
@@ -72,7 +73,7 @@ async def bundle_skills(request: Request) -> Response:
     Expects a JSON body matching :class:`BundleRequest`.  Resolves each
     requested skill name to its on-disk directory, then streams back a
     gzip-compressed tar archive containing ``<name>/SKILL.md`` and any
-    ``<name>/references/*.md`` files found for each skill.
+    ``<name>/references/*`` or ``<name>/scripts/*`` files found for each skill.
 
     Returns 400 with a JSON error body when the request fails validation.
     """
@@ -102,13 +103,20 @@ async def bundle_skills(request: Request) -> Response:
             if skill_md.is_file():
                 tar.add(str(skill_md), arcname=f"{skill_name}/SKILL.md")
 
-            references_dir = skill_dir / "references"
-            if references_dir.is_dir():
-                for ref_file in sorted(references_dir.iterdir()):
-                    if ref_file.is_file():
+            for subdir_name in ("references", "scripts"):
+                subdir = skill_dir / subdir_name
+                if subdir.is_dir():
+                    for sub_file in sorted(subdir.iterdir()):
+                        if not sub_file.is_file() or sub_file.name.startswith("."):
+                            continue
+                        if (
+                            subdir_name == "scripts"
+                            and sub_file.suffix not in _ALLOWED_SCRIPT_EXTENSIONS
+                        ):
+                            continue
                         tar.add(
-                            str(ref_file),
-                            arcname=f"{skill_name}/references/{ref_file.name}",
+                            str(sub_file),
+                            arcname=f"{skill_name}/{subdir_name}/{sub_file.name}",
                         )
 
     return Response(content=buf.getvalue(), media_type="application/gzip")

--- a/server/src/awos_recruitment_mcp/validate/__init__.py
+++ b/server/src/awos_recruitment_mcp/validate/__init__.py
@@ -13,12 +13,14 @@ from awos_recruitment_mcp.models import AgentMetadata, McpDefinition, SkillMetad
 
 # Top-level entries permitted inside a skill directory. Kept in lockstep with
 # what the /bundle/skills endpoint actually ships: SKILL.md (file) and the flat
-# files under references/ (directory). README.md is allowed as local docs even
-# though it's not bundled. Type is enforced alongside name — e.g. a file named
-# "references" or a directory named "SKILL.md" is still rejected, since the
-# bundler would drop them for the same reason as any other stray entry.
+# files under references/ or scripts/ (directories). README.md is allowed as
+# local docs even though it's not bundled. Type is enforced alongside name —
+# e.g. a file named "references" or a directory named "SKILL.md" is still
+# rejected, since the bundler would drop them for the same reason as any other
+# stray entry. The scripts/ directory only allows .js, .ts, .py files.
 _ALLOWED_SKILL_FILES: frozenset[str] = frozenset({"SKILL.md", "README.md"})
-_ALLOWED_SKILL_DIRS: frozenset[str] = frozenset({"references"})
+_ALLOWED_SKILL_DIRS: frozenset[str] = frozenset({"references", "scripts"})
+_ALLOWED_SCRIPT_EXTENSIONS: frozenset[str] = frozenset({".js", ".ts", ".py"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -168,7 +170,7 @@ def validate_skills(registry_path: Path) -> list[ValidationResult]:
                             message=(
                                 f"Unexpected file '{child.name}' in skill — "
                                 "the install bundle only ships SKILL.md and "
-                                "flat files under references/"
+                                "flat files under references/ or scripts/"
                             ),
                         )
                     )
@@ -203,22 +205,38 @@ def validate_skills(registry_path: Path) -> list[ValidationResult]:
                 )
                 continue
 
-            # Allowed dir (references/) — the bundler walks it with iterdir()
-            # and only adds is_file() entries, so anything non-file is dropped.
+            # Allowed dir — the bundler walks it with iterdir() and only
+            # adds is_file() entries, so anything non-file is dropped.
             for ref_child in sorted(child.iterdir()):
-                if ref_child.name.startswith(".") or ref_child.is_file():
+                if ref_child.name.startswith("."):
                     continue
-                errors.append(
-                    ValidationError(
-                        file=relative_path,
-                        field=None,
-                        message=(
-                            f"Nested entry '{child.name}/{ref_child.name}' "
-                            "is not a flat file — the install bundle only "
-                            "ships flat files under references/"
-                        ),
+                if not ref_child.is_file():
+                    errors.append(
+                        ValidationError(
+                            file=relative_path,
+                            field=None,
+                            message=(
+                                f"Nested entry '{child.name}/{ref_child.name}' "
+                                f"is not a flat file — only flat files are "
+                                f"allowed under {child.name}/"
+                            ),
+                        )
                     )
-                )
+                    continue
+                # scripts/ only allows .js, .ts, .py files.
+                if child.name == "scripts":
+                    if ref_child.suffix not in _ALLOWED_SCRIPT_EXTENSIONS:
+                        errors.append(
+                            ValidationError(
+                                file=relative_path,
+                                field=None,
+                                message=(
+                                    f"File '{child.name}/{ref_child.name}' has "
+                                    f"disallowed extension — scripts/ only "
+                                    f"allows {', '.join(sorted(_ALLOWED_SCRIPT_EXTENSIONS))}"
+                                ),
+                            )
+                        )
 
         results.append(
             ValidationResult(


### PR DESCRIPTION
## Summary
- Adds `verify-ui` skill for frontend testing and UI verification via DOM inspection in a Playwright browser
- Includes 6 verification scripts (visibility, clickability, alignment, overflow, inventory, state transitions) loaded on demand from disk
- Token-efficient design: ~166-line prompt + lazy-loaded scripts vs ~1,673-line embedded agent alternative

## What it does
Skill for verifying web UI behavior, layout, and interactivity by running DOM inspection scripts in a Playwright browser. Checks element visibility, clickability, alignment, overflow, and state transitions — without screenshots.

## Test plan
- [ ] `just validate-registry` passes with the new skill
- [ ] `search_capabilities` query "frontend testing" returns `verify-ui` as top result
- [ ] `search_capabilities` query "UI verification" returns `verify-ui` as top result
- [ ] CLI `awos skill verify-ui` installs SKILL.md and scripts/ to `.claude/skills/verify-ui/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New UI verification skill with runnable in-browser checks: visibility transitions, alignment/layout detection, clickability hit-tests, interactive-element inventory, overflow/reachability diagnostics, and after-action state verification.

* **Documentation**
  * Detailed workflow guidance covering interaction/navigation rules, how to inject/run verification scripts, result formatting, required report columns, and exclusions/constraints.

* **Chores**
  * Bundles now include verification scripts alongside reference docs; validation updated to allow script files (restricted extensions) and enforce flat file layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->