### PR TITLE
fix(docker): upgrade OS packages in runtime image to patch openssl CVE

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -44,6 +44,12 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 FROM python:3.12-slim AS runtime
 
+# Upgrade OS packages to pull in security patches not yet present in the
+# base image (e.g. openssl CVE fixes flagged by the Trivy image scan).
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+
 # Create a non-root user for running the server.
 RUN groupadd --gid 1000 appuser \
     && useradd --uid 1000 --gid 1000 --create-home appuser


### PR DESCRIPTION
## Summary
- Trivy image scan job fails with 3 HIGH findings: CVE-2026-45447 in `libssl3t64`, `openssl`, and `openssl-provider-legacy` shipped with the `python:3.12-slim` base image (failing run: https://github.com/provectus/awos-recruitment/actions/runs/27264843312/job/80519288820)
- Adds an `apt-get upgrade` layer to the runtime stage so OS security patches are applied ahead of base image rebuilds

## Verification
Ran `apt-get update && apt-get upgrade -y` inside `python:3.12-slim` locally — all three flagged packages upgrade to `3.5.6-1~deb13u2`, the exact fixed version Trivy reports.