### PR TITLE
refactor(testing-expert): remove context/qa/list-of-tests.md artifact

### DIFF
--- a/registry/agents/testing-expert.md
+++ b/registry/agents/testing-expert.md
@@ -49,7 +49,7 @@ For every positive case, define at least one negative counterpart. Negative case
 
 ### Step 3: Write tests with RED validation
 
-Before writing, scan the existing test tree (the project's `tests/` directory and any co-located test files) for a test already covering the same acceptance criterion in the same layer for this spec. The test files' own `@spec` / `@layer` / `@regression` annotations are the source of truth for what is already covered — there is no separate registry. If an equivalent test already exists, UPDATE it in place instead of adding a duplicate; if a broader test should be split into focused cases, annotate the old one with `@deprecated` (using the language's comment syntax) and add the replacements.
+If a test already covers the same acceptance criterion in the same layer for this spec, update the existing test in place instead of adding a duplicate.
 
 Write tests following this discipline (borrowed from TDD red-green-refactor):
 

--- a/registry/agents/testing-expert.md
+++ b/registry/agents/testing-expert.md
@@ -28,12 +28,11 @@ You are an expert QA Engineer and Test Automation Specialist. You write comprehe
 - `technical-considerations.md` from the target spec directory
 - `context/product/architecture.md` — **required**; the declared testing stack lives here
 - The implementation code written for the feature
-- Current `context/qa/list-of-tests.md` (if it exists)
 
 ### Step 1: Resolve the testing stack
 
 1. Read `context/product/architecture.md` to find the declared testing stack per layer (unit / integration / e2e / contract).
-2. If `context/product/architecture.md` is missing, does not declare a testing stack, or the stack is ambiguous: stop and return `STATUS: BLOCKED — testing stack not declared in context/product/architecture.md` (see Step 7). Do **not** guess by sniffing `package.json`, `pyproject.toml`, or other dependency files — AWOS treats architecture.md as the single source of truth for tech-stack decisions.
+2. If `context/product/architecture.md` is missing, does not declare a testing stack, or the stack is ambiguous: stop and return `STATUS: BLOCKED — testing stack not declared in context/product/architecture.md` (see Step 6). Do **not** guess by sniffing `package.json`, `pyproject.toml`, or other dependency files — AWOS treats architecture.md as the single source of truth for tech-stack decisions.
 
 ### Step 2: Map acceptance criteria to test layers
 
@@ -87,27 +86,11 @@ If tests reveal that the implementation is incomplete:
 - Do NOT invoke `/awos:implement` directly.
 - Append an HTML comment marker to this task's entry in `tasks.md`:
   `<!-- GAP: [description of missing behavior] — needs refactoring-slice follow-up -->`
-- Return `STATUS: BLOCKED` (see Step 7).
+- Return `STATUS: BLOCKED` (see Step 6).
 
 The HTML comment is intentionally informational — it survives in raw source for future spec readers and for `/awos:verify` to escalate into a proper task in a new "refactoring" slice. Do not insert a new `- [ ]` task into a slice that is already in progress; slice composition is managed by `/awos:verify`, not by this agent.
 
-### Step 6: Update `context/qa/list-of-tests.md`
-
-Before appending new entries, scan `context/qa/list-of-tests.md` for existing tests covering the same behavior/AC in the same layer + spec:
-
-- **Same behavior, same layer** → UPDATE the existing entry instead of adding a new one.
-- **Broader test that needs splitting** → DEPRECATE the old entry, add focused replacements; annotate the old test file with `@deprecated` using the appropriate comment syntax for the language.
-- **Partial overlap** → keep both, note the relationship in the Notes column.
-
-Append only net-new tests. Format:
-
-```markdown
-| File                 | Test Name          | Layer | Positive/Negative | @regression | Status | Notes |
-| -------------------- | ------------------ | ----- | ----------------- | ----------- | ------ | ----- |
-| path/to/test_file.py | test_function_name | unit  | negative          | yes         | OK     |       |
-```
-
-### Step 7: Report completion status to the caller
+### Step 6: Report completion status to the caller
 
 Return exactly one status token as the final non-whitespace content of your response, wrapped in `[[ ]]` sentinel brackets so it survives any platform metadata that gets appended after the agent's text. The double-bracket envelope is what `/awos:implement` (and downstream parsers like `/awos:verify`) grep for — they extract whatever sits between the matching `[[STATUS:` and `]]`:
 

--- a/registry/agents/testing-expert.md
+++ b/registry/agents/testing-expert.md
@@ -49,6 +49,8 @@ For every positive case, define at least one negative counterpart. Negative case
 
 ### Step 3: Write tests with RED validation
 
+Before writing, scan the existing test tree (the project's `tests/` directory and any co-located test files) for a test already covering the same acceptance criterion in the same layer for this spec. The test files' own `@spec` / `@layer` / `@regression` annotations are the source of truth for what is already covered — there is no separate registry. If an equivalent test already exists, UPDATE it in place instead of adding a duplicate; if a broader test should be split into focused cases, annotate the old one with `@deprecated` (using the language's comment syntax) and add the replacements.
+
 Write tests following this discipline (borrowed from TDD red-green-refactor):
 
 1. Write one test case.


### PR DESCRIPTION
## What

Removes the `context/qa/list-of-tests.md` artifact support from the `testing-expert` agent.

The agent maintained a cumulative `context/qa/list-of-tests.md` registry (one row per net-new test). It appeared without a clear rationale and created a new `context/qa/` directory out of band — surfacing as an unexpected `context/qa/` at commit time.

## Changes to `registry/agents/testing-expert.md`

- Drop the Inputs line referencing `context/qa/list-of-tests.md`.
- Remove the entire **Step 6: Update `context/qa/list-of-tests.md`** (table format + update/deprecate logic).
- Renumber the status-report step **7 → 6**, including its two `(see Step 7)` cross-references.

## Verification

Ran the awos-qa e2e scenario `testing-expert-writes-tests-and-flags-gaps` against this edited agent: **15/15 checks pass** (2m 44s). The agent still writes tests, `@spec`/`@layer` annotations, correct `[[STATUS: COMPLETE]]` / `[[STATUS: BLOCKED]]` envelopes, and GAP markers — it just no longer creates the `context/qa/` artifact.

## Related

Companion PR in awos-qa drops the matching scenario assertions/fixtures (the scenario tracks this agent live via `recruitment.txt`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the testing expert agent instructions to correct step references and refine the workflow sequence.
  * Adjusted guidance to check existing `tests/` coverage first and update relevant tests in place to avoid duplicates.
  * Updated the completion-status guidance so the “report completion status” step appears immediately at/near the status section for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->