### PR TITLE
feat(pr-skills): add GitLab support to pr-review and pr-comments-address

### DIFF
--- a/registry/skills/pr-comments-address/SKILL.md
+++ b/registry/skills/pr-comments-address/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-comments-address
-description: Use when working through code-review feedback to apply fixes and replies — "address the PR comments", "reply to CodeRabbit/Codex feedback", "resolve these review threads", "apply this review". Works in two modes. Public mode (default) responds to reviewer feedback on a GitHub pull request you authored — fix, reply, resolve, commit, and push. Local mode — triggered when the request says "locally", "for myself", "apply this review", or "don't post" — applies feedback from a local review file to your working tree, posting nothing to a review platform. Each item gets a proposed fix or reply for your approval first. This is the author's side; to review someone else's PR, use pr-review.
+description: Use when working through code-review feedback to apply fixes and replies — "address the PR comments", "address the MR comments", "reply to CodeRabbit/Codex feedback", "resolve these review threads", "apply this review". Works in two modes. Public mode (default) responds to reviewer feedback on a pull request or merge request you authored, on GitHub or GitLab — fix, reply, resolve, commit, and push. Local mode — triggered when the request says "locally", "for myself", "apply this review", or "don't post" — applies feedback from a local review file to your working tree, posting nothing to a review platform. Each item gets a proposed fix or reply for your approval first. This is the author's side; to review someone else's PR, use pr-review.
 ---
 
 <!-- No `context: fork`: forked skills run as subagents, which cannot use AskUserQuestion — the per-item approval gate this skill is built around. For isolation from other work, invoke this skill in a dedicated session instead. -->
@@ -13,10 +13,22 @@ Work through reviewer feedback with technical rigor over social comfort. Verify 
 
 Decide the mode before starting the workflow, and state it in one line.
 
-- **public** (default): respond to feedback on a GitHub PR **you authored**. Fetch unresolved threads and comments, then fix, reply, resolve, commit, and push. Uses [references/github.md](references/github.md).
+- **public** (default): respond to feedback on a PR **you authored**. Fetch unresolved threads and comments, then fix, reply, resolve, commit, and push. Uses the platform reference selected below.
 - **local**: apply feedback that lives **on your machine** — a local review file (e.g. one written by pr-review's local mode) or feedback the user pastes. Edit the working tree only; nothing leaves the machine. Use this when the request says "locally", "for myself", "apply this review", "don't post", or points at a review file. Uses [references/local.md](references/local.md).
 
 **Choosing:** if the request signals local (the trigger words above, or names a review file), use local. If it references a PR (URL or `owner/repo#N`), use public. If ambiguous, ask with `AskUserQuestion`, offering Public as the default.
+
+## Platform (public mode)
+
+Resolve the platform before step 1 and state it alongside the mode. Take the first signal that answers:
+
+1. the host in the PR/MR URL the user gave;
+2. the host of the repo's `git remote` (`git remote get-url origin`);
+3. which CLI is authenticated (`gh auth status` / `glab auth status`).
+
+`github.com` or a GitHub Enterprise host → [references/github.md](references/github.md). `gitlab.com` or a self-managed GitLab host → [references/gitlab.md](references/gitlab.md). If the signals conflict or none resolves, ask with `AskUserQuestion` — never guess, since the wrong reference fetches nothing or replies in the wrong place.
+
+The workflow below is platform-agnostic and names operations (`preflight`, `checkout-pr`, `fetch-working-set`, `reply-to-thread`, `resolve-thread`); the selected reference defines them. It says "PR" throughout — on GitLab read merge request, `<NUM>` as the MR `iid`, and "thread" as discussion. Local mode needs none of this.
 
 Treat automated reviewers (CodeRabbit, Codex, Bito, Sonar, and similar) as suggestions to evaluate, not directives — many of their comments are mechanical and some are confidently wrong. Agreement is earned on the merits.
 
@@ -37,7 +49,7 @@ Treat automated reviewers (CodeRabbit, Codex, Bito, Sonar, and similar) as sugge
 
 ### 1. Gather feedback items
 
-- **public:** run `preflight`, `checkout-pr`, and `fetch-working-set` from [references/github.md](references/github.md). `checkout-pr` handles the branch: if you're **already on the PR's head branch**, stay put and just pull to the tip — a worktree would be redundant. Otherwise it defaults to an **isolated git worktree**, so the user's current branch and working tree stay untouched — only check the branch out in place if the user asked for that (e.g. they want to review or run it in their main working tree). If the working set is empty, say "Nothing new to address" and stop.
+- **public:** run `preflight`, `checkout-pr`, and `fetch-working-set` from the platform reference (selected above). `checkout-pr` handles the branch: if you're **already on the PR's head branch**, stay put and just pull to the tip — a worktree would be redundant. Otherwise it defaults to an **isolated git worktree**, so the user's current branch and working tree stay untouched — only check the branch out in place if the user asked for that (e.g. they want to review or run it in their main working tree). If the working set is empty, say "Nothing new to address" and stop.
 - **local:** run `read-feedback` from [references/local.md](references/local.md) to load the review file or pasted text into discrete items.
 
 ### 2. Triage in a fresh subagent

--- a/registry/skills/pr-comments-address/SKILL.md
+++ b/registry/skills/pr-comments-address/SKILL.md
@@ -20,13 +20,13 @@ Decide the mode before starting the workflow, and state it in one line.
 
 ## Platform (public mode)
 
-Resolve the platform before step 1 and state it alongside the mode. Take the first signal that answers:
+Resolve the platform before step 1 and state it alongside the mode. Resolve in this precedence order, taking the first that answers — a later signal never overrides an earlier one:
 
 1. the host in the PR/MR URL the user gave;
 2. the host of the repo's `git remote` (`git remote get-url origin`);
 3. which CLI is authenticated (`gh auth status` / `glab auth status`).
 
-`github.com` or a GitHub Enterprise host → [references/github.md](references/github.md). `gitlab.com` or a self-managed GitLab host → [references/gitlab.md](references/gitlab.md). If the signals conflict or none resolves, ask with `AskUserQuestion` — never guess, since the wrong reference fetches nothing or replies in the wrong place.
+`github.com` or a GitHub Enterprise host → [references/github.md](references/github.md). `gitlab.com` or a self-managed GitLab host → [references/gitlab.md](references/gitlab.md). If none of the three resolves, ask with `AskUserQuestion` — never guess, since the wrong reference fetches nothing or replies in the wrong place.
 
 The workflow below is platform-agnostic and names operations (`preflight`, `checkout-pr`, `fetch-working-set`, `reply-to-thread`, `resolve-thread`); the selected reference defines them. It says "PR" throughout — on GitLab read merge request, `<NUM>` as the MR `iid`, and "thread" as discussion. Local mode needs none of this.
 

--- a/registry/skills/pr-comments-address/references/github.md
+++ b/registry/skills/pr-comments-address/references/github.md
@@ -1,6 +1,6 @@
 # GitHub operations — pr-comments-address
 
-> **Part of:** [pr-comments-address](../SKILL.md). The GitHub commands for the receiving workflow in **public mode**, keyed by operation name. Local mode never runs any of these — it stays on the working tree and never invokes `gh` or posts to the platform. Keying by operation name keeps the SKILL workflow platform-agnostic, so similar reference files could be added for other review platforms (GitLab, Azure DevOps, …) and selected by the PR URL host if that's ever needed.
+> **Part of:** [pr-comments-address](../SKILL.md). The GitHub commands for the receiving workflow in **public mode**, keyed by operation name. Local mode never runs any of these — it stays on the working tree and never invokes `gh` or posts to the platform. Keying by operation name keeps the SKILL workflow platform-agnostic: [gitlab.md](gitlab.md) implements the same operations for GitLab, and the SKILL selects between them by host.
 
 ## preflight
 

--- a/registry/skills/pr-comments-address/references/gitlab.md
+++ b/registry/skills/pr-comments-address/references/gitlab.md
@@ -1,0 +1,137 @@
+# GitLab operations — pr-comments-address
+
+> **Part of:** [pr-comments-address](../SKILL.md). The GitLab commands for the receiving workflow in **public mode**, keyed by the same operation names as [github.md](github.md) — so the SKILL workflow stays platform-agnostic and only this file changes. Local mode never runs any of these — it stays on the working tree and never invokes `glab` or posts to the platform.
+
+## Terminology
+
+| SKILL says | GitLab means |
+|---|---|
+| PR, `<NUM>` | merge request (MR), its `iid` (the number in the URL, **not** the global `id`) |
+| `<OWNER>/<REPO>` | the project path, possibly nested (`group/subgroup/project`); URL-encoded as `$PROJECT` for API calls |
+| review thread | **discussion** (`discussion_id`) |
+| top-level comment | a discussion with `individual_note: true` |
+| thread is outdated | the note's `position.head_sha` no longer matches the MR head |
+
+```sh
+PROJECT=$(printf %s '<GROUP>/<PROJECT>' | jq -sRr @uri)   # nested paths encode to group%2Fsub%2Fproject
+IID=<MR_IID>
+```
+
+For a self-managed instance, add `--hostname <host>` to every `glab api` call, or work inside a clone of that instance's repo where `glab` reads the host from the git remote.
+
+## Transport: glab first, MCP as fallback
+
+**Use `glab`.** Every recipe here is a `glab` command, and `glab api` covers what the porcelain doesn't. Prefer it whenever `glab auth status` succeeds.
+
+**Fall back to a GitLab MCP server only if `glab` is missing or unauthenticated.** Do not hardcode MCP tool names — GitLab MCP servers differ widely in coverage. List the connected server's tools, map them onto this file's operation names, and use the match. Fetching discussions is usually covered; replying and resolving often are not.
+
+**Never silently skip an operation with no MCP tool.** Say which operation can't run and stop. Half-applied feedback — fixes committed but replies never posted — is worse than not starting, because the reviewer sees silence on threads you actually addressed.
+
+## preflight
+
+```sh
+glab auth status                                   # bail with "run glab auth login" if not authed
+ME=$(glab api user | jq -r .username)              # filters "comments not yet replied to by me"
+git rev-parse --is-inside-work-tree >/dev/null     # confirm we're in a git repo
+glab repo view -F json --jq .path_with_namespace   # must equal the MR's project path
+```
+
+(`glab api` has no `--jq` flag — pipe through `jq`. `glab repo view` and `glab mr view` do have it.)
+
+If the repo identity doesn't match the MR's project, warn and ask whether to `cd` into the clone or clone fresh. Don't silently `glab repo clone` — it may land in the wrong place.
+
+## checkout-pr
+
+**Already on the MR's source branch?** Then don't create anything — `git pull --ff-only` to the tip and work in place. A worktree only earns its cost when a checkout would otherwise disturb a *different* branch; when you're already on the right one it's just clutter.
+
+**Otherwise, default to an isolated worktree.** Don't switch the current branch in place — the user may have work in progress there. Add a detached worktree, then let `glab mr checkout` set up the MR's source branch inside it (this handles fork remotes and sets tracking, so step 5's `git push` still targets the MR source branch):
+
+```sh
+git worktree add --detach <dir>   # <dir> defaults to the sibling ../<repo>-mr-<IID>
+cd <dir>
+glab mr checkout $IID             # MR source branch, fork-aware
+git pull --ff-only                # move to the tip
+```
+
+`<dir>` defaults to the sibling `../<repo>-mr-<IID>`; if the user names a target directory, use that instead. Tell the user the worktree path. Remove it when done (`git worktree remove <path>`) unless they want to keep it.
+
+**In place — only if the user asked** (e.g. they want to review or run it in their main working tree):
+
+```sh
+glab mr checkout $IID
+git pull --ff-only
+```
+
+If an in-place checkout reports uncommitted changes, stop and tell the user. Don't stash automatically, and never reach for `glab mr checkout --force` — it resets the local branch and discards exactly the work-in-progress you were protecting. Their work outranks this workflow.
+
+## fetch-working-set
+
+One paginated call returns every discussion — diff threads and top-level notes alike:
+
+```sh
+glab api --paginate "projects/$PROJECT/merge_requests/$IID/discussions"
+```
+
+Each discussion has `id`, `individual_note`, and `notes[]` carrying `id`, `author.username`, `body`, `created_at`, `resolvable`, `resolved`, `system`, and `position` (with `new_path`, `new_line`, `old_line`, and the `head_sha` the note was written against).
+
+A scannable digest of what's still open:
+
+```sh
+glab api --paginate "projects/$PROJECT/merge_requests/$IID/discussions" | jq -r --arg me "$ME" '
+  .[] | select(all(.notes[]; .system | not)) | . as $d
+  | ($d.notes | last) as $last | $d.notes[0] as $first
+  | select($last.author.username != $me)
+  | "discussion=\($d.id)  \($first.position.new_path // "(top-level)"):\($first.position.new_line // "-")  resolved=\($first.resolved // false)  last=\($last.author.username): \($last.body[0:140])"'
+```
+
+Build the working set:
+
+- **Discussions with a position (review threads):** any whose latest note author is not `$ME` — **don't filter on `resolved` alone.** A resolved discussion can mean "fixed" or just "someone replied and closed it without a code change"; the latter still needs handling. Keep the unresolved ones, and also surface resolved ones whose last word isn't yours for a quick judgment — keep the ones you never actually acted on, drop the genuinely handled.
+- **Top-level comments** (`individual_note: true`, no position) where the latest author isn't `$ME` and `$ME` hasn't already replied below.
+- **Skip system notes** (`system: true`) — those are GitLab's own activity entries ("changed target branch", "added 1 commit"), not feedback.
+
+**Outdated threads count too** — they still need a reply or resolution. GitLab has no `isOutdated` flag: compare a thread's `position.head_sha` against the MR's current head (`glab api "projects/$PROJECT/merge_requests/$IID" | jq -r .diff_refs.head_sha`). When they differ, the anchored line has moved or vanished — the note's `position` (`old_line` / `new_line` / paths) plus reading the file at `path` is what locates the code the reviewer meant. There is no stored diff hunk to fall back on.
+
+`<DISCUSSION_ID>` for `reply-to-thread` and `resolve-thread` is the discussion's `id` — a hex string, not a number.
+
+## reply-to-thread
+
+```sh
+glab api -X POST "projects/$PROJECT/merge_requests/$IID/discussions/<DISCUSSION_ID>/notes" -f body='<reply>'
+```
+
+## reply-to-top-level
+
+GitLab models top-level comments as discussions too, so the same endpoint threads a reply underneath one — no quoting workaround needed:
+
+```sh
+glab api -X POST "projects/$PROJECT/merge_requests/$IID/discussions/<DISCUSSION_ID>/notes" -f body='<reply>'
+```
+
+To add a fresh top-level comment that isn't a reply to anything:
+
+```sh
+glab mr note $IID -m '<comment>'
+```
+
+## resolve-thread
+
+```sh
+glab api -X PUT "projects/$PROJECT/merge_requests/$IID/discussions/<DISCUSSION_ID>" -F resolved=true
+```
+
+Only `resolvable` discussions can be resolved — diff threads are, plain top-level comments are not. If a `dismiss-resolve` item turns out to be an unresolvable top-level note, post the short reply and note in the summary that GitLab has nothing to resolve there.
+
+## Failure modes
+
+| Symptom | Handling |
+|---|---|
+| `glab auth status` fails | Bail with "run `glab auth login`" — or `glab auth login --hostname <host>` for self-managed. |
+| `glab mr checkout` → "would overwrite local changes" | Stop, surface the conflict, let the user decide. Never `--force`. |
+| `PUT .../discussions/<id>` → "Discussion cannot be resolved" | Not resolvable (top-level note). Reply only; say so in the summary. |
+| `PUT .../discussions/<id>` → already resolved | Fine, continue. |
+| Reply → 404 "Discussion Not Found" | Deleted upstream, or an `id` from a different MR. Skip and note it in the summary. |
+| Every discussion looks like noise | You're reading system notes — filter `system: true` out. |
+| `git push` rejected (non-fast-forward) | Fetch and integrate (rebase or merge, per the project's convention), ask before re-pushing. Never force-push. |
+| Push rejected by a protected-branch rule | The MR source branch is protected for your role. Stop and tell the user; don't retry with `--force`. |
+| MR `iid` vs `id` confusion (404 on a number that exists) | Every endpoint here takes the **iid** — the number in the MR's URL. |

--- a/registry/skills/pr-comments-address/references/gitlab.md
+++ b/registry/skills/pr-comments-address/references/gitlab.md
@@ -13,11 +13,14 @@
 | thread is outdated | the note's `position.head_sha` no longer matches the MR head |
 
 ```sh
+HOST=<host from the MR URL>                              # e.g. gitlab.com, or your self-managed host
+export GITLAB_HOST="$HOST"                               # pins every glab call below to the MR's instance
 PROJECT=$(printf %s '<GROUP>/<PROJECT>' | jq -sRr @uri)   # nested paths encode to group%2Fsub%2Fproject
 IID=<MR_IID>
+MR_URL="https://$HOST/<GROUP>/<PROJECT>"                  # -R accepts a full URL; use it for the porcelain
 ```
 
-For a self-managed instance, add `--hostname <host>` to every `glab api` call, or work inside a clone of that instance's repo where `glab` reads the host from the git remote.
+**Pin the host explicitly — `glab` never infers it from the MR you were given.** Every `glab` command resolves its instance from the current git remote, `GITLAB_HOST`, or the saved config, so a worktree whose remote points elsewhere silently targets the wrong GitLab. `export GITLAB_HOST="$HOST"` covers `glab api`, `glab auth status`, and the porcelain (`mr checkout`, `mr note`), which have **no `--hostname` flag** — only `-R`.
 
 ## Transport: glab first, MCP as fallback
 
@@ -30,13 +33,15 @@ For a self-managed instance, add `--hostname <host>` to every `glab api` call, o
 ## preflight
 
 ```sh
-glab auth status                                   # bail with "run glab auth login" if not authed
-ME=$(glab api user | jq -r .username)              # filters "comments not yet replied to by me"
-git rev-parse --is-inside-work-tree >/dev/null     # confirm we're in a git repo
-glab repo view -F json --jq .path_with_namespace   # must equal the MR's project path
+glab auth status --hostname "$HOST"                        # bail with "run glab auth login" if not authed
+ME=$(glab api --hostname "$HOST" user | jq -r .username)   # filters "comments not yet replied to by me"
+git rev-parse --is-inside-work-tree >/dev/null             # confirm we're in a git repo
+glab repo view -F json --jq .web_url                       # host AND path must both match the MR's
 ```
 
 (`glab api` has no `--jq` flag — pipe through `jq`. `glab repo view` and `glab mr view` do have it.)
+
+Compare `web_url`, not `path_with_namespace`: the path alone is not an identity. `gitlab.com/acme/api` and `gitlab.internal/acme/api` share it, and since the auth check above resolves whatever host `glab` is configured for, a path-only comparison can pass while you're pointed at an entirely different instance's project of the same name. The full URL settles host and path in one check.
 
 If the repo identity doesn't match the MR's project, warn and ask whether to `cd` into the clone or clone fresh. Don't silently `glab repo clone` — it may land in the wrong place.
 
@@ -49,7 +54,7 @@ If the repo identity doesn't match the MR's project, warn and ask whether to `cd
 ```sh
 git worktree add --detach <dir>   # <dir> defaults to the sibling ../<repo>-mr-<IID>
 cd <dir>
-glab mr checkout $IID             # MR source branch, fork-aware
+glab mr checkout $IID -R "$MR_URL"   # MR source branch, fork-aware
 git pull --ff-only                # move to the tip
 ```
 
@@ -58,7 +63,7 @@ git pull --ff-only                # move to the tip
 **In place — only if the user asked** (e.g. they want to review or run it in their main working tree):
 
 ```sh
-glab mr checkout $IID
+glab mr checkout $IID -R "$MR_URL"
 git pull --ff-only
 ```
 
@@ -78,8 +83,9 @@ A scannable digest of what's still open:
 
 ```sh
 glab api --paginate "projects/$PROJECT/merge_requests/$IID/discussions" | jq -r --arg me "$ME" '
-  .[] | select(all(.notes[]; .system | not)) | . as $d
-  | ($d.notes | last) as $last | $d.notes[0] as $first
+  .[] | (.notes | map(select(.system != true))) as $notes
+  | select($notes | length > 0) | . as $d
+  | ($notes | last) as $last | $notes[0] as $first
   | select($last.author.username != $me)
   | "discussion=\($d.id)  \($first.position.new_path // "(top-level)"):\($first.position.new_line // "-")  resolved=\($first.resolved // false)  last=\($last.author.username): \($last.body[0:140])"'
 ```
@@ -88,7 +94,7 @@ Build the working set:
 
 - **Discussions with a position (review threads):** any whose latest note author is not `$ME` — **don't filter on `resolved` alone.** A resolved discussion can mean "fixed" or just "someone replied and closed it without a code change"; the latter still needs handling. Keep the unresolved ones, and also surface resolved ones whose last word isn't yours for a quick judgment — keep the ones you never actually acted on, drop the genuinely handled.
 - **Top-level comments** (`individual_note: true`, no position) where the latest author isn't `$ME` and `$ME` hasn't already replied below.
-- **Skip system notes** (`system: true`) — those are GitLab's own activity entries ("changed target branch", "added 1 commit"), not feedback.
+- **Skip system notes** (`system: true`) — those are GitLab's own activity entries ("changed target branch", "added 1 commit"), not feedback. **Filter them out of `notes[]`; never discard a discussion because it contains one.** GitLab appends a system note *inside* a human diff thread whenever the anchored line moves ("changed this line in version N of the diff"), so a whole-discussion test like `select(all(.notes[]; .system | not))` drops exactly the threads that have been through review churn — measured on a real MR, that test kept 11 of 44 live threads and silently lost 33, several with the reviewer's reply as the last word. Filter the notes, then judge the discussion by what remains, as the recipe above does.
 
 **Outdated threads count too** — they still need a reply or resolution. GitLab has no `isOutdated` flag: compare a thread's `position.head_sha` against the MR's current head (`glab api "projects/$PROJECT/merge_requests/$IID" | jq -r .diff_refs.head_sha`). When they differ, the anchored line has moved or vanished — the note's `position` (`old_line` / `new_line` / paths) plus reading the file at `path` is what locates the code the reviewer meant. There is no stored diff hunk to fall back on.
 
@@ -97,21 +103,28 @@ Build the working set:
 ## reply-to-thread
 
 ```sh
-glab api -X POST "projects/$PROJECT/merge_requests/$IID/discussions/<DISCUSSION_ID>/notes" -f body='<reply>'
+BODY=$(cat <reply-file>)
+glab api -X POST "projects/$PROJECT/merge_requests/$IID/discussions/<DISCUSSION_ID>/notes" -f body="$BODY"
 ```
+
+**Build the body in a variable; don't inline it.** Replies are prose, prose contains apostrophes, and a single `'` inside `-f body='…'` closes the quote and mangles the command. Write the approved reply to a file (or a heredoc) and pass it by variable.
+
+`glab`'s field flags are the **inverse of `gh`'s**: `-F/--field` expands a leading `@` as a filename, `-f/--raw-field` sends the value literally. So `-f body=@reply.md` posts the string `@reply.md`, and `-F body=@reply.md` is what reads the file.
 
 ## reply-to-top-level
 
 GitLab models top-level comments as discussions too, so the same endpoint threads a reply underneath one — no quoting workaround needed:
 
 ```sh
-glab api -X POST "projects/$PROJECT/merge_requests/$IID/discussions/<DISCUSSION_ID>/notes" -f body='<reply>'
+BODY=$(cat <reply-file>)
+glab api -X POST "projects/$PROJECT/merge_requests/$IID/discussions/<DISCUSSION_ID>/notes" -f body="$BODY"
 ```
 
 To add a fresh top-level comment that isn't a reply to anything:
 
 ```sh
-glab mr note $IID -m '<comment>'
+BODY=$(cat <comment-file>)
+glab mr note $IID -R "$MR_URL" -m "$BODY"
 ```
 
 ## resolve-thread

--- a/registry/skills/pr-review/SKILL.md
+++ b/registry/skills/pr-review/SKILL.md
@@ -20,13 +20,13 @@ Decide the mode before starting the workflow, and state it in one line — the w
 
 ## Platform (public mode)
 
-Resolve the platform before step 1 and state it alongside the mode. Take the first signal that answers:
+Resolve the platform before step 1 and state it alongside the mode. Resolve in this precedence order, taking the first that answers — a later signal never overrides an earlier one:
 
 1. the host in the PR/MR URL the user gave;
 2. the host of the repo's `git remote` (`git remote get-url origin`);
 3. which CLI is authenticated (`gh auth status` / `glab auth status`).
 
-`github.com` or a GitHub Enterprise host → [references/github.md](references/github.md). `gitlab.com` or a self-managed GitLab host → [references/gitlab.md](references/gitlab.md). If the signals conflict or none resolves, ask with `AskUserQuestion` — never guess, since the wrong reference posts nothing or posts to the wrong place.
+`github.com` or a GitHub Enterprise host → [references/github.md](references/github.md). `gitlab.com` or a self-managed GitLab host → [references/gitlab.md](references/gitlab.md). If none of the three resolves, ask with `AskUserQuestion` — never guess, since the wrong reference posts nothing or posts to the wrong place.
 
 The workflow below is platform-agnostic and names operations (`preflight`, `fetch-pr-context`, `create-draft-review`, …); the selected reference defines them. It says "PR" throughout — on GitLab read merge request, and `<NUM>` as the MR `iid`. Local mode needs none of this.
 

--- a/registry/skills/pr-review/SKILL.md
+++ b/registry/skills/pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review
-description: Use when authoring a code review of a pull request — "review this PR", "do a code review on PR #N", "review my branch", "leave review comments". Works in two modes. Public mode (default) reviews someone else's PR on the hosting platform and posts the result as a draft review for your approval. Local mode — triggered when the request says "locally", "for myself", "just my branch", or "don't post" — reviews your own working branch and writes the review to a file, posting nothing to a review platform. Finds issues by orchestrating the code-review and pr-review-toolkit plugins, drafts in a human voice with no severity badges, and gates everything on your approval. This is the reviewer's side; to respond to feedback on a PR you authored, use pr-comments-address.
+description: Use when authoring a code review of a pull request or merge request — "review this PR", "do a code review on PR #N", "review this MR", "review my branch", "leave review comments". Works in two modes. Public mode (default) reviews someone else's PR/MR on the hosting platform — GitHub or GitLab — and posts the result as a draft review for your approval. Local mode — triggered when the request says "locally", "for myself", "just my branch", or "don't post" — reviews your own working branch and writes the review to a file, posting nothing to a review platform. Finds issues by orchestrating the code-review and pr-review-toolkit plugins, drafts in a human voice with no severity badges, and gates everything on your approval. This is the reviewer's side; to respond to feedback on a PR you authored, use pr-comments-address.
 ---
 
 <!-- No `context: fork`: a forked skill runs as a subagent, and subagents cannot use AskUserQuestion — the results gate in step 5 depends on it. (The Agent tool is not the constraint: subagents can dispatch nested subagents, so the step 2 engines would run fine.) For isolation from other work, invoke this skill in a dedicated session instead. -->
@@ -13,10 +13,22 @@ Produce a code review that reads like a sharp human wrote it and opens a convers
 
 Decide the mode before starting the workflow, and state it in one line — the workflow branches on it.
 
-- **public** (default): review a PR **someone else authored** on the hosting platform. Read the existing conversation, post the result as a **draft (pending) review** the user finalizes and submits. This is the primary use. Uses the platform reference, selected by the PR URL's host — [references/github.md](references/github.md) for GitHub (the only one so far).
+- **public** (default): review a PR **someone else authored** on the hosting platform. Read the existing conversation, post the result as a **draft (pending) review** the user finalizes and submits. This is the primary use. Uses the platform reference selected below.
 - **local**: review **your own working branch** for yourself. Nothing is posted or published — produce the review as a file. Use this when the request says "locally", "for myself", "just my branch", "don't post", or otherwise targets in-progress work rather than someone else's PR. The built-in `/review`-style tools also do this, but less reliably and without the human-gated, house-style flow here. Uses [references/local.md](references/local.md).
 
 **Choosing:** if the request clearly signals local (the trigger words above, or a bare branch with no PR), use local. If it clearly targets a specific remote PR (a PR URL or `owner/repo#N`), use public. If it's ambiguous, ask with `AskUserQuestion`, offering Public as the default.
+
+## Platform (public mode)
+
+Resolve the platform before step 1 and state it alongside the mode. Take the first signal that answers:
+
+1. the host in the PR/MR URL the user gave;
+2. the host of the repo's `git remote` (`git remote get-url origin`);
+3. which CLI is authenticated (`gh auth status` / `glab auth status`).
+
+`github.com` or a GitHub Enterprise host → [references/github.md](references/github.md). `gitlab.com` or a self-managed GitLab host → [references/gitlab.md](references/gitlab.md). If the signals conflict or none resolves, ask with `AskUserQuestion` — never guess, since the wrong reference posts nothing or posts to the wrong place.
+
+The workflow below is platform-agnostic and names operations (`preflight`, `fetch-pr-context`, `create-draft-review`, …); the selected reference defines them. It says "PR" throughout — on GitLab read merge request, and `<NUM>` as the MR `iid`. Local mode needs none of this.
 
 This skill orchestrates existing review engines rather than reinventing analysis (both modes). It depends on two plugins and degrades gracefully if absent — see [references/analysis.md](references/analysis.md):
 
@@ -44,7 +56,7 @@ Review voice and formatting rules are in [references/house-style.md](references/
 ### 1. Gather the change and context
 
 - **both modes:** if the request links or references an off-platform discussion — a Slack thread, meeting notes, a roadmap or ticket, a design doc — read it **before** analysis (via whatever tool or link gives you access). It carries the change's intent and any decisions already settled, which the diff and the on-platform threads don't show; reviewing without it risks re-raising something the author and reviewer already worked out elsewhere.
-- **public:** run `preflight`, `fetch-pr-context`, and `fetch-existing-comments` from the platform reference (selected in Modes), **before** any analysis — so you know what the PR does, what's already been said, which threads are open, and whether you (or the user) have reviewed it before. `fetch-existing-comments` includes an explicit pass to list your own prior comments; do it — they're the easiest set to duplicate. When the existing conversation is large, don't read the raw dump yourself: hand it to a subagent that returns a structured scratchpad — open threads, settled points, your own prior comments, each with `path:line` — and run that digest in parallel with fetching the diff. It's extraction, not judgment, so a small/fast model suffices if agent dispatch lets you pick one; with no agent dispatch, compact it inline. Either way the scratchpad, not the raw conversation, is what the analysis pass carries. Comment only on lines the PR changed.
+- **public:** run `preflight`, `fetch-pr-context`, and `fetch-existing-comments` from the platform reference (selected above), **before** any analysis — so you know what the PR does, what's already been said, which threads are open, and whether you (or the user) have reviewed it before. `preflight` also settles **whether draft delivery is available on this platform and instance** — carry that answer to step 5, which needs it before it can ask the user anything. `fetch-existing-comments` includes an explicit pass to list your own prior comments; do it — they're the easiest set to duplicate. When the existing conversation is large, don't read the raw dump yourself: hand it to a subagent that returns a structured scratchpad — open threads, settled points, your own prior comments, each with `path:line` — and run that digest in parallel with fetching the diff. It's extraction, not judgment, so a small/fast model suffices if agent dispatch lets you pick one; with no agent dispatch, compact it inline. Either way the scratchpad, not the raw conversation, is what the analysis pass carries. Comment only on lines the PR changed.
 - **local:** run `resolve-base` and `get-local-diff` from [references/local.md](references/local.md). There's no existing conversation to fetch.
 
 ### 2. Find issues
@@ -85,6 +97,8 @@ Print the complete draft **as message text** — summary, architectural notes, a
 
 **Pre-gate protocol — the draft is the step 4 file, not your memory.** Present it by printing the file's full content as message text, then call `AskUserQuestion` — and always include the file path in the question itself ("full draft in `review/pr-<N>-draft.md`"), so even if the print gets squeezed out, the user opens the draft in their editor from the path alone. The documented failure of this step (three sessions running): composing the draft in thinking, then gating on "the draft is above" while the message contains nothing — your memory of having printed is not evidence; only the `Write` call from step 4 and text visible in this turn are. If there is no step 4 file, you have no draft: go back and write it.
 
+**Check delivery capability before you ask, not after.** `preflight` established whether this platform and instance support a draft. If they don't (a GitLab instance without the Draft Notes API, a token missing the scope, an MCP fallback with no draft tool), **the options below are wrong as written** — "Proceed" would publish the review immediately under a label the user read as "draft". Say plainly in the gate that draft delivery isn't available here and why, then offer **publish now** (post the findings and summary for real, right away) or **write to a file and post nothing** (local mode's artifact, so nothing reaches the platform) — and let the user pick with full knowledge of what lands. Never present a publishing action as a draft.
+
 - **Proceed** — deliver as-is (post the draft review, or write the file).
 - **Back findings with external sources** (optional) — before delivering, run the evidence pass: for each contestable finding, verify against a trusted source (official docs, the language/library spec, a high-signal StackOverflow answer, an issue in the project's own hosted repo — GitHub/GitLab/Gerrit/… — or, for an architectural claim about how the system fits together, the project's own sibling repos and artifacts, not just external docs), attach the link in the comment, and **drop claims you can't substantiate**. "Substantiate" means verified against the code or the spec — a project-specific finding grounded in the diff stands on its own and needs no external citation. Then re-present the revised draft and return to this gate — don't deliver until the user picks Proceed.
 - **Change something** — take the user's edits (reword, drop, split a point into its own inline comment, re-anchor), restate, and confirm.
@@ -93,7 +107,7 @@ Respect the user's granularity choices — don't fold a distinct observation int
 
 ### 6. Deliver
 
-- **public:** first run `find-pending-review`. If a draft already exists, apply the **never-destroy rule** (don't delete or recreate it — stop and ask; it may hold the user's own comments). Otherwise `create-draft-review` — a pending review the user submits in the platform UI, the **default**. Only if the user explicitly chose to submit now, `submit-review` with the verdict. Send any approved `reply-to-thread` replies. Verify the draft's summary body actually posted.
+- **public:** first run `find-pending-review`. If a draft already exists, apply the **never-destroy rule** (never delete or recreate it — it may hold the user's own comments; stop and ask, or append if the platform supports it and the user agrees). Otherwise `create-draft-review` — a pending review the user submits in the platform UI, the **default**. Only if the user explicitly chose to submit now, `submit-review` with the verdict. Send any approved `reply-to-thread` replies. Verify the summary actually posted, in whatever form the platform carries it. If the gate established that drafts aren't available here, deliver what the user chose there instead — publish now, or write the file and post nothing.
 - **local:** `write-review-file` and print the path. Nothing is sent anywhere.
 
 Posting/saving is automated after approval; judgment is not. In public mode, if the platform rejects a comment for an out-of-diff line, move it into the summary body and retry rather than dropping it silently.

--- a/registry/skills/pr-review/references/github.md
+++ b/registry/skills/pr-review/references/github.md
@@ -1,6 +1,6 @@
 # GitHub operations — pr-review (public mode)
 
-> **Part of:** [pr-review](../SKILL.md). The GitHub commands for **public mode** (reviewing a real GitHub PR), keyed by operation name. Local mode uses [local.md](local.md) instead and runs none of these — it never invokes `gh` or posts to the platform. Keying by operation name keeps the SKILL workflow platform-agnostic, so similar reference files could be added for other review platforms (GitLab, Azure DevOps, …) and selected by the PR URL host if that's ever needed.
+> **Part of:** [pr-review](../SKILL.md). The GitHub commands for **public mode** (reviewing a real GitHub PR), keyed by operation name. Local mode uses [local.md](local.md) instead and runs none of these — it never invokes `gh` or posts to the platform. Keying by operation name keeps the SKILL workflow platform-agnostic: [gitlab.md](gitlab.md) implements the same operations for GitLab, and the SKILL selects between them by host.
 
 ## preflight
 

--- a/registry/skills/pr-review/references/gitlab.md
+++ b/registry/skills/pr-review/references/gitlab.md
@@ -18,11 +18,14 @@ GitLab's model differs from GitHub's in names more than in substance. Throughout
 Set these once and reuse them in every recipe below:
 
 ```sh
+HOST=<host from the MR URL>                              # e.g. gitlab.com, or your self-managed host
+export GITLAB_HOST="$HOST"                               # pins every glab call below to the MR's instance
 PROJECT=$(printf %s '<GROUP>/<PROJECT>' | jq -sRr @uri)   # nested paths encode to group%2Fsub%2Fproject
 IID=<MR_IID>
+MR_URL="https://$HOST/<GROUP>/<PROJECT>"                  # -R accepts a full URL; use it for the porcelain
 ```
 
-For a self-managed instance, add `--hostname <host>` to every `glab api` call (or run inside a clone of that instance's repo, where `glab` picks the host up from the git remote).
+**Pin the host explicitly — `glab` never infers it from the MR you were given.** Every `glab` command resolves its instance from the current git remote, `GITLAB_HOST`, or the saved config, so running in a directory whose remote points elsewhere (or nowhere) silently targets the wrong GitLab — and this skill's `preflight` deliberately doesn't clone, so there's often no matching remote at all. `export GITLAB_HOST="$HOST"` covers all of it: `glab api`, `glab auth status`, and the porcelain (`mr view`, `mr diff`, `mr approve`, `mr note`), which have **no `--hostname` flag** — only `-R`. Belt and braces: pass `--hostname "$HOST"` on `glab api`/`glab auth status` and `-R "$MR_URL"` on the porcelain, both shown in the recipes below.
 
 ## Transport: glab first, MCP as fallback
 
@@ -35,13 +38,24 @@ For a self-managed instance, add `--hostname <host>` to every `glab api` call (o
 ## preflight
 
 ```sh
-glab auth status                            # bail with "run glab auth login" if not authed
-ME=$(glab api user | jq -r .username)       # to detect your own prior notes and draft notes
+glab auth status --hostname "$HOST"                          # bail with "run glab auth login" if not authed
+ME=$(glab api --hostname "$HOST" user | jq -r .username)     # to detect your own prior notes and draft notes
 ```
 
 (`glab api` has no `--jq` flag — pipe through `jq`. `glab mr view` does have `--jq`.)
 
-You're reviewing someone else's MR — don't check out the branch or modify project files. Read the diff through the API. (The one write allowed is the skill's own draft artifact in `review/` — that's your output, not the project's code.)
+You're reviewing someone else's MR — never switch the user's branch or modify project files. The one write allowed in their tree is the skill's own draft artifact in `review/` — that's your output, not the project's code.
+
+**A read-only checkout at MR head is allowed, and step 2 needs one.** The diff alone doesn't let the analysis engines judge a finding against its surrounding code, so put the head commit in a detached worktree outside the user's tree, hand the engines that path, and remove it when the review is delivered:
+
+```sh
+git fetch origin "refs/merge-requests/$IID/head:refs/mr/$IID"   # GitLab's MR head refspec
+git worktree add --detach <scratch-dir> "refs/mr/$IID"
+# … engines read from <scratch-dir> …
+git worktree remove --force <scratch-dir> && git update-ref -d "refs/mr/$IID"
+```
+
+Nothing here touches the user's branch or working tree, and the worktree is read-only by convention — tell the engines not to edit inside it.
 
 ### Draft-notes capability probe — run this here, before any analysis
 
@@ -49,11 +63,16 @@ Unlike GitHub, draft delivery on GitLab can be unavailable on a given instance o
 
 ```sh
 glab api "projects/$PROJECT/merge_requests/$IID/draft_notes" >/dev/null 2>&1 && DRAFTS=yes || DRAFTS=no
+
+# The GET above proves only that you can READ. Drafting is a write:
+glab api "personal_access_tokens/self" | jq -r '.scopes | join(",")'   # needs `api`; `read_api` is read-only
 ```
 
-If the exit status is ambiguous, re-run with `-i` and read the HTTP status line — a 404 and a 403 mean different things (see Failure modes) and the user can act on the difference.
+**A passing GET is not a passing POST.** GitLab's `api` scope grants read *and* write, while `read_api` grants read only — so a read-only token sails through the probe and then 403s on the first draft note, after the whole analysis pass has already run. `personal_access_tokens/self` reports the scopes without writing anything; require `api` there rather than inferring write access from the GET. Even then, treat `DRAFTS=yes` as **provisional until the first draft POST succeeds** — and if that POST fails, you're in the `DRAFTS=no` branch below, not in an error state to push past.
 
-The Draft Notes API is Free-tier and available on GitLab.com, Self-Managed and Dedicated, so `DRAFTS=yes` is the normal case. `DRAFTS=no` means an instance too old for the endpoint, a token without the scope, or an MCP-only fallback with no draft tool.
+If the probe's exit status is ambiguous, re-run with `-i` and read the HTTP status line — a 404 and a 403 mean different things (see Failure modes) and the user can act on the difference.
+
+The Draft Notes API is Free-tier and available on GitLab.com, Self-Managed and Dedicated, so `DRAFTS=yes` is the normal case. `DRAFTS=no` means the endpoint is absent, the token can't write, or an MCP-only fallback with no draft tool.
 
 Carry the result into step 5:
 
@@ -63,8 +82,8 @@ Carry the result into step 5:
 ## fetch-pr-context
 
 ```sh
-glab mr view $IID -R <GROUP>/<PROJECT> -F json --jq '{iid, title, author: .author.username, source_branch, target_branch, web_url}'
-glab mr diff $IID -R <GROUP>/<PROJECT>      # the unified diff under review
+glab mr view $IID -R "$MR_URL" -F json --jq '{iid, title, author: .author.username, source_branch, target_branch, web_url}'
+glab mr diff $IID -R "$MR_URL"              # the unified diff under review
 ```
 
 The diff defines the review surface: comment only on lines this MR added or modified.
@@ -98,18 +117,22 @@ Use it to skip points already raised, decide which open threads to agree with or
 
 ```sh
 glab api --paginate "projects/$PROJECT/merge_requests/$IID/notes" \
-  | jq -r --arg me "$ME" '[.[] | select(.author.username==$me)] | max_by(.created_at) | .created_at // "none"'
+  | jq -sr --arg me "$ME" 'add | [.[] | select(.author.username==$me)] | max_by(.created_at) | .created_at // "none"'
 ```
+
+The `jq -s | add` matters: **`glab api --paginate` emits one JSON array per page, not one merged array.** A bare `max_by` therefore reports a "most recent" per page rather than overall — slurp and concatenate before any aggregate.
 
 If that returns a timestamp, diff against what changed since it.
 
 **Your own prior comments are part of this conversation — surface them first.** A pass you (or the user) already made on this MR is the set most easily duplicated, and "existing comments" reads too easily as "other people's / the bot's". Before scanning what anyone else said, list `$ME`'s own notes explicitly:
 
 ```sh
-glab api --paginate "projects/$PROJECT/merge_requests/$IID/notes" | jq -r --arg me "$ME" '
-  .[] | select(.author.username==$me)
-  | "\(.position.new_path // "(no position)"):\(.position.new_line // "-")  note=\(.id)  \(.body[0:100])"'
+glab api --paginate "projects/$PROJECT/merge_requests/$IID/discussions" | jq -r --arg me "$ME" '
+  .[] | . as $d | .notes[] | select(.author.username==$me and (.system | not))
+  | "\(.position.new_path // "(no position)"):\(.position.new_line // "-")  discussion=\($d.id)  note=\(.id)  \(.body[0:100])"'
 ```
+
+List these from `/discussions`, not `/notes`. Both return the same notes, but a note object from `/notes` carries **no `discussion_id`** — so a `note=<id>` from there can't be turned into the `<DISCUSSION_ID>` that `reply-to-thread` needs, which is exactly what the next paragraph tells you to do with it.
 
 Treat each as a thread to build on, not a line to re-open: if a finding lands on a `path:line` you already commented on, plan a `reply-to-thread` on that existing discussion rather than a second thread. A prior comment may sit in a **resolved** discussion (the author already fixed it) — resolved still means "already raised", so don't re-flag it; at most acknowledge the fix or add a genuinely new angle as a reply.
 
@@ -128,7 +151,9 @@ glab api "projects/$PROJECT/merge_requests/$IID/draft_notes" | jq -r '
   .[] | "\(.id)  \(.position.new_path // "(no position)"):\(.position.new_line // "-")  \(.note[0:100])"'
 ```
 
-**Never-destroy rule.** If this returns rows, drafts already exist. Unlike GitHub, GitLab needs no delete-then-recreate — each draft note is created independently, so `create-draft-review` **appends** to the existing set. That makes destruction unnecessary, and therefore forbidden: never call `DELETE .../draft_notes/<id>` without explicit approval.
+**Record the count this returns as `BASELINE`** — `create-draft-review` verifies against it, since your notes are added to whatever is already there.
+
+**Never-destroy rule.** If this returns rows, drafts already exist. Unlike GitHub, GitLab needs no delete-then-recreate — each draft note is created independently, so `create-draft-review` **appends** to the existing set, and an individual note can be revised in place with `update-draft-note` below. That makes destruction unnecessary, and therefore forbidden: never call `DELETE .../draft_notes/<id>` without explicit approval.
 
 Do still tell the user what's already there before appending, and confirm — publishing is all-or-nothing (`bulk_publish` publishes *every* pending draft note, including theirs), so your review can't be submitted without carrying their drafts along with it. If they'd rather not mix the two, let them publish or delete their own drafts first.
 
@@ -159,13 +184,26 @@ glab api -X POST "projects/$PROJECT/merge_requests/$IID/draft_notes" \
   --form 'note=<summary + architectural notes, in house style>'
 ```
 
-`bulk_publish` also accepts a summary at submit time (see below) — but the user, not you, runs the submit, so the positionless draft note is what actually guarantees the summary reaches the MR. Post it either way, and still print the verbatim summary in step 7.
+`bulk_publish` also accepts a summary at submit time (see below) — but the user, not you, runs the submit, so the positionless draft note is what actually guarantees the summary reaches the MR. Post it here, and still print the verbatim summary in step 7. **Once it exists, don't also pass `note=` to `bulk_publish`** — that would post the same text a second time as a separate summary note.
 
-After creating, confirm the drafts landed — re-run `find-pending-review` and check the count matches what you posted, including the summary note. Report the count to the user with the MR URL; GitLab shows pending drafts in the MR's **Changes** tab, and publishing is a button there ("Submit review"), or:
+After creating, confirm the drafts landed — re-run `find-pending-review` and check the count is `BASELINE + <findings> + 1` for the summary note. It is not equal to what you posted: pre-existing drafts are appended to, never replaced, so comparing against the posted count alone reports a phantom failure for any user who had drafts of their own. Report the count to the user with the MR URL; GitLab shows pending drafts in the MR's **Changes** tab, and publishing is a button there ("Submit review"), or:
 
 ```sh
 glab api -X POST "projects/$PROJECT/merge_requests/$IID/draft_notes/bulk_publish"
 ```
+
+## update-draft-note
+
+Revising a draft note you already posted — the user reworded a finding at the gate, or a later round changes the summary. Edit it in place; this is the sanctioned alternative to the delete-and-recreate the never-destroy rule forbids:
+
+```sh
+BODY=$(cat <revised-note-file>)
+glab api -X PUT "projects/$PROJECT/merge_requests/$IID/draft_notes/<DRAFT_NOTE_ID>" --form "note=$BODY"
+```
+
+Ids come from `find-pending-review`. The position is preserved — you're replacing the text, not re-anchoring it. Build the body in a variable rather than inlining it: review prose contains apostrophes, and one of them inside `--form 'note=…'` truncates the note at the quote.
+
+**Amending after delivery still requires the gate.** A user asking for a change approves the *action*, not the wording — print the revised text and get approval before the `PUT`, exactly as at first delivery.
 
 ## submit-review
 
@@ -173,17 +211,29 @@ Only when the user explicitly chooses to submit now instead of leaving drafts. `
 
 ```sh
 glab api -X POST "projects/$PROJECT/merge_requests/$IID/draft_notes/bulk_publish" \
-  --form 'note=<summary>' \
   --form 'reviewer_state=requested_changes'
+  # --form 'note=<summary>'   ← ONLY if no positionless summary draft exists; otherwise it double-posts
 ```
 
-`reviewer_state` is `reviewed` or `requested_changes`. Per GitLab's docs it "does not record a formal approval" — approving is a separate call, and it's the one verdict the user must choose explicitly:
+`note=` here creates a summary note *in addition to* publishing the drafts. `create-draft-review` normally already posted the summary as a positionless draft, so passing it again lands the same text twice — include it only when there's no summary draft to publish (the user is submitting their own hand-written drafts, or the summary POST failed).
+
+`reviewer_state` is `reviewed` or `requested_changes` — the sample above is not a fixed verdict; the user picks it, per the SKILL's step 6. Per GitLab's docs it "does not record a formal approval" — approving is a separate call, and it's the one verdict the user must choose explicitly:
 
 ```sh
-glab mr approve $IID -R <GROUP>/<PROJECT>
+glab mr approve $IID -R "$MR_URL"
 ```
 
-If `DRAFTS=no`, there is nothing to publish and this operation doesn't apply — the user chose publish-now at the adapted gate, so post each finding as a real discussion instead (same `--form position[...]` fields as `create-draft-review`, against `.../discussions`, with `body=` in place of `note=`), and post the summary with `glab mr note $IID -m '<summary>'`.
+### The `DRAFTS=no` publish-now path
+
+If `DRAFTS=no` there is nothing to publish, so this operation doesn't apply: the user chose publish-now at the adapted gate and each finding goes up as a **real, immediately visible discussion** (same `--form position[...]` fields as `create-draft-review`, against `.../discussions`, with `body=` in place of `note=`).
+
+That difference matters. Drafts are atomic — the user submits them as one review — but this path is N separate live posts, so a failure halfway leaves the author looking at inline criticism with no summary and no verdict. Run it as a procedure, not a loop:
+
+1. Keep a **posted / remaining** list as you go, and post the findings before the summary.
+2. **Stop at the first failure** — don't continue down the list. A partial review is a state to escape, not to extend.
+3. Fold every unposted finding **verbatim** into the summary note, so nothing approved at the gate is silently dropped.
+4. Post the summary on **both** paths, success and abort, with `BODY=$(cat <summary-file>)` and `glab mr note $IID -R "$MR_URL" -m "$BODY"` — on the abort path it's what tells the author the review is incomplete and why.
+5. Verify the count of posted discussions against the approved set, the same check `create-draft-review` does, and report any shortfall to the user explicitly.
 
 ## reply-to-thread
 
@@ -198,8 +248,11 @@ glab api -X POST "projects/$PROJECT/merge_requests/$IID/draft_notes" \
 To reply immediately instead (when there are no drafts to keep it with):
 
 ```sh
-glab api -X POST "projects/$PROJECT/merge_requests/$IID/discussions/<DISCUSSION_ID>/notes" -f body='<reply>'
+BODY=$(cat <reply-file>)
+glab api -X POST "projects/$PROJECT/merge_requests/$IID/discussions/<DISCUSSION_ID>/notes" -f body="$BODY"
 ```
+
+Build the body in a variable rather than inlining it — an apostrophe in review prose closes `-f body='…'` early and mangles the call. Note `glab`'s flags are the inverse of `gh`'s here: `-F/--field` expands a leading `@` as a filename, `-f/--raw-field` sends it literally, so `-f body=@file` posts the string `@file`.
 
 Don't resolve other people's discussions — you're the reviewer, not the author. (A draft note can carry `resolve_discussion=true`; don't use it here.)
 
@@ -208,8 +261,9 @@ Don't resolve other people's discussions — you're the reviewer, not the author
 | Symptom | Handling |
 |---|---|
 | `glab auth status` fails | Bail with "run `glab auth login`" — or, for a self-managed host, `glab auth login --hostname <host>`. |
-| Draft-notes probe returns 404 | `DRAFTS=no` — instance predates the endpoint. Adapt the step 5 gate (publish now vs file only); never call it a draft. |
-| Draft-notes probe returns 401/403 | `DRAFTS=no` — the token lacks `api` scope (a read-only token can fetch but not draft). Say which, so the user can fix it and retry rather than losing the draft path silently. |
+| Draft-notes probe returns 404 | Endpoint absent, wrong project/iid, or a project this token can't see — GitLab returns 404 rather than 403 to avoid leaking existence. Check which before concluding; only the first is genuinely `DRAFTS=no`. Adapt the step 5 gate; never call a publish a draft. |
+| Draft-notes probe returns 401/403 | Likely a token without `api` scope (`read_api` reads but cannot write) — confirm with `personal_access_tokens/self` rather than assuming. Say which, so the user can fix it and retry rather than losing the draft path silently. |
+| First draft POST 403s after a passing probe | The probe only proved read access. Treat it as `DRAFTS=no`, return to the gate with the publish-now / file-only choice, and don't retry the drafts. |
 | `find-pending-review` returns rows | Drafts already exist and may be the user's. Append, never delete — and tell them first, since `bulk_publish` will publish theirs too. |
 | Draft/discussion POST 400 "Note position is invalid" | The SHAs are stale or the line isn't in the diff. Refetch `diff_refs` and retry once; if it still fails, move the finding into the summary rather than dropping it. |
 | Draft/discussion POST 400 on `line_range` | Multi-line anchoring — degrade to a single-line comment and describe the span in the text. |

--- a/registry/skills/pr-review/references/gitlab.md
+++ b/registry/skills/pr-review/references/gitlab.md
@@ -1,0 +1,219 @@
+# GitLab operations — pr-review (public mode)
+
+> **Part of:** [pr-review](../SKILL.md). The GitLab commands for **public mode** (reviewing a real GitLab merge request), keyed by the same operation names as [github.md](github.md) — so the SKILL workflow stays platform-agnostic and only this file changes. Local mode uses [local.md](local.md) instead and runs none of these — it never invokes `glab` or posts to the platform.
+
+## Terminology
+
+GitLab's model differs from GitHub's in names more than in substance. Throughout the SKILL body, read:
+
+| SKILL says | GitLab means |
+|---|---|
+| PR, `<NUM>` | merge request (MR), its `iid` (the per-project number in the URL, **not** the global `id`) |
+| `<OWNER>/<REPO>` | the project path, possibly nested (`group/subgroup/project`); URL-encoded as `$PROJECT` for API calls |
+| pending review draft | the MR's set of **draft notes** — per-author, unpublished, published together |
+| review comment thread | **discussion** (`discussion_id`); a top-level comment is a discussion with `individual_note: true` |
+| summary body | the `note` passed to `bulk_publish` at submit time |
+| verdict | `reviewer_state` on `bulk_publish` (`reviewed` / `requested_changes`), or a separate approve call |
+
+Set these once and reuse them in every recipe below:
+
+```sh
+PROJECT=$(printf %s '<GROUP>/<PROJECT>' | jq -sRr @uri)   # nested paths encode to group%2Fsub%2Fproject
+IID=<MR_IID>
+```
+
+For a self-managed instance, add `--hostname <host>` to every `glab api` call (or run inside a clone of that instance's repo, where `glab` picks the host up from the git remote).
+
+## Transport: glab first, MCP as fallback
+
+**Use `glab`.** Every recipe here is a `glab` command, and `glab api` covers what the porcelain doesn't. Prefer it whenever `glab auth status` succeeds.
+
+**Fall back to a GitLab MCP server only if `glab` is missing or unauthenticated.** Do not hardcode MCP tool names — GitLab MCP servers differ widely in which operations they expose. Instead: list the connected GitLab server's tools, map them onto the operation names in this file, and use the match. Read operations (`fetch-pr-context`, `fetch-existing-comments`) are usually covered; draft notes usually are not.
+
+**Never silently skip an operation with no MCP tool.** If the fallback can't perform an operation, say which one and stop — for `create-draft-review` specifically, that means draft delivery is unavailable and the step 5 gate must be adapted (see `preflight`). A review that posts nothing is a failure the user needs to hear about, not a quiet no-op.
+
+## preflight
+
+```sh
+glab auth status                            # bail with "run glab auth login" if not authed
+ME=$(glab api user | jq -r .username)       # to detect your own prior notes and draft notes
+```
+
+(`glab api` has no `--jq` flag — pipe through `jq`. `glab mr view` does have `--jq`.)
+
+You're reviewing someone else's MR — don't check out the branch or modify project files. Read the diff through the API. (The one write allowed is the skill's own draft artifact in `review/` — that's your output, not the project's code.)
+
+### Draft-notes capability probe — run this here, before any analysis
+
+Unlike GitHub, draft delivery on GitLab can be unavailable on a given instance or token, and the step 5 results gate needs to know **before** it asks the user how to proceed. Probe once:
+
+```sh
+glab api "projects/$PROJECT/merge_requests/$IID/draft_notes" >/dev/null 2>&1 && DRAFTS=yes || DRAFTS=no
+```
+
+If the exit status is ambiguous, re-run with `-i` and read the HTTP status line — a 404 and a 403 mean different things (see Failure modes) and the user can act on the difference.
+
+The Draft Notes API is Free-tier and available on GitLab.com, Self-Managed and Dedicated, so `DRAFTS=yes` is the normal case. `DRAFTS=no` means an instance too old for the endpoint, a token without the scope, or an MCP-only fallback with no draft tool.
+
+Carry the result into step 5:
+
+- **`DRAFTS=yes`** — the gate's options are unchanged; delivery creates draft notes the user publishes themselves.
+- **`DRAFTS=no`** — **there is no draft delivery on this MR.** Say so in the gate itself and change its options: the only ways to deliver are publishing the discussions now or writing the review to a file and posting nothing. Never present "proceed" as a draft when it would publish — the user is approving publication, and must be told that's what they're approving.
+
+## fetch-pr-context
+
+```sh
+glab mr view $IID -R <GROUP>/<PROJECT> -F json --jq '{iid, title, author: .author.username, source_branch, target_branch, web_url}'
+glab mr diff $IID -R <GROUP>/<PROJECT>      # the unified diff under review
+```
+
+The diff defines the review surface: comment only on lines this MR added or modified.
+
+**Also capture the diff refs now** — every inline comment position needs all three SHAs, and there's no way to anchor a finding without them:
+
+```sh
+glab api "projects/$PROJECT/merge_requests/$IID" | jq '.diff_refs'   # {base_sha, start_sha, head_sha}
+```
+
+```sh
+# Fallback if diff_refs is absent: the newest MR version carries the same three SHAs under different names.
+glab api "projects/$PROJECT/merge_requests/$IID/versions" | jq '.[0] | {base_commit_sha, start_commit_sha, head_commit_sha}'
+```
+
+Bind them as `BASE_SHA`, `START_SHA`, `HEAD_SHA`. They must come from the MR's **current** head — refetch after any push, or positions will be rejected.
+
+## fetch-existing-comments
+
+Run **before** drafting, so you engage prior threads and never repeat a point someone already made. One paginated call returns every discussion, resolved or not, with the position that anchors it:
+
+```sh
+glab api --paginate "projects/$PROJECT/merge_requests/$IID/discussions" | jq -r '
+  .[] | . as $d | .notes[0] as $first |
+  "\($first.position.new_path // "(no position)"):\($first.position.new_line // "-")  discussion=\($d.id)  resolved=\($first.resolved // false)  \($first.author.username): \($first.body[0:120])"'
+```
+
+Each discussion carries `id` (the `<DISCUSSION_ID>` used by `reply-to-thread`), `individual_note`, and `notes[]` with `author.username`, `body`, `created_at`, `resolvable`, `resolved`, and `position`.
+
+Use it to skip points already raised, decide which open threads to agree with or push back on, and detect a re-review. GitLab has **no review object** with a `submittedAt` — a re-review is instead detected from the timestamp of your own most recent published note:
+
+```sh
+glab api --paginate "projects/$PROJECT/merge_requests/$IID/notes" \
+  | jq -r --arg me "$ME" '[.[] | select(.author.username==$me)] | max_by(.created_at) | .created_at // "none"'
+```
+
+If that returns a timestamp, diff against what changed since it.
+
+**Your own prior comments are part of this conversation — surface them first.** A pass you (or the user) already made on this MR is the set most easily duplicated, and "existing comments" reads too easily as "other people's / the bot's". Before scanning what anyone else said, list `$ME`'s own notes explicitly:
+
+```sh
+glab api --paginate "projects/$PROJECT/merge_requests/$IID/notes" | jq -r --arg me "$ME" '
+  .[] | select(.author.username==$me)
+  | "\(.position.new_path // "(no position)"):\(.position.new_line // "-")  note=\(.id)  \(.body[0:100])"'
+```
+
+Treat each as a thread to build on, not a line to re-open: if a finding lands on a `path:line` you already commented on, plan a `reply-to-thread` on that existing discussion rather than a second thread. A prior comment may sit in a **resolved** discussion (the author already fixed it) — resolved still means "already raised", so don't re-flag it; at most acknowledge the fix or add a genuinely new angle as a reply.
+
+Who has already approved is separate from the notes, and worth knowing before you draft a verdict:
+
+```sh
+glab api "projects/$PROJECT/merge_requests/$IID/approvals" | jq '{approved: .approved, by: [.approved_by[].user.username]}'
+```
+
+## find-pending-review
+
+Draft notes are **per-author** — this returns only your own, and they may be the **user's own hand-written drafts**. Always look before delivering:
+
+```sh
+glab api "projects/$PROJECT/merge_requests/$IID/draft_notes" | jq -r '
+  .[] | "\(.id)  \(.position.new_path // "(no position)"):\(.position.new_line // "-")  \(.note[0:100])"'
+```
+
+**Never-destroy rule.** If this returns rows, drafts already exist. Unlike GitHub, GitLab needs no delete-then-recreate — each draft note is created independently, so `create-draft-review` **appends** to the existing set. That makes destruction unnecessary, and therefore forbidden: never call `DELETE .../draft_notes/<id>` without explicit approval.
+
+Do still tell the user what's already there before appending, and confirm — publishing is all-or-nothing (`bulk_publish` publishes *every* pending draft note, including theirs), so your review can't be submitted without carrying their drafts along with it. If they'd rather not mix the two, let them publish or delete their own drafts first.
+
+## create-draft-review
+
+**Default delivery in public mode** when `DRAFTS=yes`. Each finding is one draft note, unpublished until the user publishes them. Post them one call at a time; GitLab's own docs pass the position as bracketed form fields, which is what `glab api --form` sends:
+
+```sh
+glab api -X POST "projects/$PROJECT/merge_requests/$IID/draft_notes" \
+  --form 'note=<finding, in house style>' \
+  --form 'position[position_type]=text' \
+  --form "position[base_sha]=$BASE_SHA" \
+  --form "position[start_sha]=$START_SHA" \
+  --form "position[head_sha]=$HEAD_SHA" \
+  --form 'position[old_path]=src/foo.py' \
+  --form 'position[new_path]=src/foo.py' \
+  --form 'position[new_line]=42'
+```
+
+- `new_line` is the line in the MR's head version. For a line that only exists before the change (a deletion), send `position[old_line]` instead; for a line present in both, sending both is safest.
+- `old_path` is required even when the file wasn't renamed — set it equal to `new_path`.
+- **Multi-line findings degrade to single-line.** GitLab anchors ranges with `position[line_range][start|end][line_code]`, where a line code is a per-file hash the API doesn't hand you directly. Don't fabricate one: anchor the comment at the range's most relevant line and describe the span in the comment text ("lines 10–14 …").
+
+**The summary has no home on a GitLab draft note.** GitHub's pending review carries a `body`; GitLab's draft notes don't. Post the summary as its own **positionless** draft note so the user can see it alongside the inline drafts:
+
+```sh
+glab api -X POST "projects/$PROJECT/merge_requests/$IID/draft_notes" \
+  --form 'note=<summary + architectural notes, in house style>'
+```
+
+`bulk_publish` also accepts a summary at submit time (see below) — but the user, not you, runs the submit, so the positionless draft note is what actually guarantees the summary reaches the MR. Post it either way, and still print the verbatim summary in step 7.
+
+After creating, confirm the drafts landed — re-run `find-pending-review` and check the count matches what you posted, including the summary note. Report the count to the user with the MR URL; GitLab shows pending drafts in the MR's **Changes** tab, and publishing is a button there ("Submit review"), or:
+
+```sh
+glab api -X POST "projects/$PROJECT/merge_requests/$IID/draft_notes/bulk_publish"
+```
+
+## submit-review
+
+Only when the user explicitly chooses to submit now instead of leaving drafts. `bulk_publish` publishes every pending draft note **and** carries the summary and the verdict:
+
+```sh
+glab api -X POST "projects/$PROJECT/merge_requests/$IID/draft_notes/bulk_publish" \
+  --form 'note=<summary>' \
+  --form 'reviewer_state=requested_changes'
+```
+
+`reviewer_state` is `reviewed` or `requested_changes`. Per GitLab's docs it "does not record a formal approval" — approving is a separate call, and it's the one verdict the user must choose explicitly:
+
+```sh
+glab mr approve $IID -R <GROUP>/<PROJECT>
+```
+
+If `DRAFTS=no`, there is nothing to publish and this operation doesn't apply — the user chose publish-now at the adapted gate, so post each finding as a real discussion instead (same `--form position[...]` fields as `create-draft-review`, against `.../discussions`, with `body=` in place of `note=`), and post the summary with `glab mr note $IID -m '<summary>'`.
+
+## reply-to-thread
+
+When your review engages an existing discussion (agree, build on, or push back), keep the reply **in the draft set** so it publishes atomically with the rest of the review:
+
+```sh
+glab api -X POST "projects/$PROJECT/merge_requests/$IID/draft_notes" \
+  --form 'note=<reply>' \
+  --form 'in_reply_to_discussion_id=<DISCUSSION_ID>'
+```
+
+To reply immediately instead (when there are no drafts to keep it with):
+
+```sh
+glab api -X POST "projects/$PROJECT/merge_requests/$IID/discussions/<DISCUSSION_ID>/notes" -f body='<reply>'
+```
+
+Don't resolve other people's discussions — you're the reviewer, not the author. (A draft note can carry `resolve_discussion=true`; don't use it here.)
+
+## Failure modes
+
+| Symptom | Handling |
+|---|---|
+| `glab auth status` fails | Bail with "run `glab auth login`" — or, for a self-managed host, `glab auth login --hostname <host>`. |
+| Draft-notes probe returns 404 | `DRAFTS=no` — instance predates the endpoint. Adapt the step 5 gate (publish now vs file only); never call it a draft. |
+| Draft-notes probe returns 401/403 | `DRAFTS=no` — the token lacks `api` scope (a read-only token can fetch but not draft). Say which, so the user can fix it and retry rather than losing the draft path silently. |
+| `find-pending-review` returns rows | Drafts already exist and may be the user's. Append, never delete — and tell them first, since `bulk_publish` will publish theirs too. |
+| Draft/discussion POST 400 "Note position is invalid" | The SHAs are stale or the line isn't in the diff. Refetch `diff_refs` and retry once; if it still fails, move the finding into the summary rather than dropping it. |
+| Draft/discussion POST 400 on `line_range` | Multi-line anchoring — degrade to a single-line comment and describe the span in the text. |
+| `bulk_publish` rejects `reviewer_state=requested_changes` | Not available on this tier or version. Retry with `reviewed` and put the verdict in the summary text. |
+| `glab mr approve` → "cannot approve your own merge request" | You're the author; drop the approve and publish with `reviewer_state=reviewed`. |
+| A prior published note by `$ME` exists | Re-review: comment only on what changed since its `created_at`; don't re-flag addressed points. |
+| MR `iid` vs `id` confusion (404 on a number that exists) | Every endpoint here takes the **iid** — the number in the MR's URL. |


### PR DESCRIPTION
## What

Adds GitLab as a second supported review platform for the `pr-review` and `pr-comments-address` skills, usable through the `glab` CLI and through a connected GitLab MCP server.

## Why this is additive, not a rewrite

Both skills already split the platform-independent workflow (`SKILL.md`) from platform commands (`references/github.md`), keyed by **operation name** — `preflight`, `fetch-pr-context`, `create-draft-review`, `resolve-thread`, and so on. Both `github.md` headers said in as many words that reference files for other platforms could be added and selected by the PR URL host. This PR takes that hook.

Each skill gains a `references/gitlab.md` implementing **exactly the same operation names** as its `github.md`. No workflow step is added, removed, or reordered, and `local.md` is untouched — local mode never talks to a platform.

## Design decisions

**Transport: `glab` first, MCP as fallback.** Recipes are `glab` commands (`glab api` covers what the porcelain doesn't). A GitLab MCP server is used only when `glab` is missing or unauthenticated. MCP tool names are **discovered, not hardcoded** — GitLab MCP servers differ widely in coverage, and hardcoding one server's names would silently break against another. An operation with no matching MCP tool stops the workflow with an explanation rather than being skipped, since half-delivered review work (fixes committed, replies never posted) is worse than not starting.

**Draft-first is preserved.** GitLab's Draft Notes API maps onto GitHub's pending review better than expected: one draft note per finding, plus a positionless draft note carrying the summary (GitLab draft notes have no summary field of their own), and `bulk_publish` supplies both the summary and the reviewer state at submit time. Replies to existing discussions ride along as drafts via `in_reply_to_discussion_id`, so they publish atomically with the review — the same effect `github.md` gets through GraphQL.

**Draft availability is probed before the gate, not discovered at delivery.** Draft delivery can be unavailable — an instance predating the endpoint, a token without `api` scope, or an MCP-only fallback with no draft tool. `preflight` probes for it and carries the answer to the step 5 results gate, which **changes its own options** when drafts are unavailable: it says so plainly and offers *publish now* or *write to a file and post nothing*. The user is never offered a "draft" that would in fact publish immediately.

**Never-destroy, adapted.** GitLab needs no delete-then-recreate, since draft notes are created independently and can be appended to. That makes destruction unnecessary and therefore forbidden. One GitLab-specific consequence is documented: `bulk_publish` publishes *every* pending draft note including the user's own, so the user is told what is already there before anything is appended.

**Platform selection.** Both `SKILL.md` files gain a Platform section resolving GitHub vs GitLab from the PR/MR URL host, then the git remote, then which CLI is authenticated — and asking with `AskUserQuestion` when those conflict, rather than guessing. Frontmatter descriptions are de-hardcoded from GitHub and pick up MR trigger wording.

## Documented degradations

Multi-line comments need `position[line_range]` line codes that the API doesn't hand you, so they degrade to a single-line anchor with the span described in the comment text. `reviewer_state=requested_changes` falls back to `reviewed` where the tier rejects it. You can't approve your own MR. Self-managed hosts go through `--hostname`. Each is in the relevant Failure modes table with the symptom that surfaces it.

## Verification

- Endpoints, parameters, tier availability, and the bracketed `position[...]` form-field syntax were checked against current GitLab documentation rather than recalled — including confirming the Draft Notes API is Free tier on GitLab.com, Self-Managed and Dedicated, and that `bulk_publish` accepts both a summary `note` and `reviewer_state`.
- `glab` invocations and flags checked against local `glab 1.111.0` (notably: `glab api` has no `--jq`, so JSON filtering pipes through `jq`).
- Operation headings verified to match one-for-one between each skill's `github.md` and `gitlab.md`.
- `server/` test suite: 229 passed, including the registry and skill-frontmatter validation tests.

**Not verified by execution:** no GitLab remote or GitLab MCP server was available, so no recipe has been run end to end against a live merge request.

## Follow-up (not in this PR)

`registry/mcp/gitlab.yaml` points at `@modelcontextprotocol/server-gitlab`, which is archived and exposes no MR note or discussion tools — it cannot drive either skill. The discovery-based fallback routes around it, but the entry should be repointed. Filing separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitLab support for pull request comment handling and code reviews.
  * Added automatic platform detection from review URLs, repository remotes, or authenticated command-line tools.
  * Added GitLab workflows for discussions, approvals, draft reviews, replies, and thread resolution.
  * Added fallback options when draft review notes are unavailable, including immediate publication or file-only output.

* **Documentation**
  * Expanded guidance with GitLab terminology, authentication, setup, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->