### PR TITLE
feat(docs-that-work): add no-op filter, audit procedure, split budgets

### DIFF
--- a/.claude/skills/docs-that-work/README.md
+++ b/.claude/skills/docs-that-work/README.md
@@ -30,6 +30,10 @@ npx @provectusinc/awos-recruitment skill docs-that-work
 | `references/anti-patterns.md` | Bloat examples, discoverable content catalog, three-question test, no-op catalog |
 | `references/design-intent.md` | Design Intent format, authoring protocol, maintenance rules |
 
+## Credits
+
+The no-op test, the expensive-lookup exception, the split context budgets, and the "state the target, not the ban" rule are adapted from [`writing-for-agents`](https://github.com/mattpocock/skills/tree/main/skills/productivity/writing-for-agents) by Matt Pocock (MIT).
+
 ## Pairs With
 
 The `docs-that-work-gate` hook blocks a commit whose changed files have a `CLAUDE.md` or `README.md` that was not refreshed, and points the agent at this skill:

--- a/.claude/skills/docs-that-work/README.md
+++ b/.claude/skills/docs-that-work/README.md
@@ -10,19 +10,30 @@ npx @provectusinc/awos-recruitment skill docs-that-work
 
 ## What This Skill Teaches
 
-- **The discoverability rule** — never document what code already reveals
-- **CLAUDE.md discipline** — non-obvious context ~35 lines, plus a ~10-line Design Intent section where useful; 70 lines is the ceiling, not a target
+- **Two filters, not one** — a line earns its place only if the code does not already reveal it *and* it changes what the agent does versus its default; "write clean code" fails the second even though it passes the first
+- **Cache only expensive lookups** — restating `package.json` is bloat; the CI-gating command that no single file states is not
+- **Split budgets** — root `CLAUDE.md` loads every turn (~25 lines), a package one loads on demand (~35 plus ~10–15 of Design Intent, 70 ceiling)
+- **Write the target, not the ban** — a prohibition makes the forbidden behavior more available, not less
 - **Design Intent sections** — document the intended shape of a package so agents stop multiplying leaked anti-patterns; intent outranks existing code
+- **An audit procedure with a completion bar** — every line of every in-scope doc gets a verdict; "looks fine" is not one
 - **README.md structure** — executable setup steps, not prose
 - **Grey box documentation** — describe interfaces, not internals
 - **Document separation** — each file has one job, no duplication
-- **When docs ARE needed** — "why" decisions, cross-service contracts, environment gotchas
 
 ## Files
 
 | File | Content |
 | --- | --- |
 | `SKILL.md` | Core guidelines and rules |
-| `references/claude-md-guide.md` | Templates for CLAUDE.md and README.md, decision tables |
-| `references/anti-patterns.md` | Bloat examples, discoverable content catalog, three-question test |
+| `references/audit-procedure.md` | Ordered process for refreshing existing docs, with completion criteria |
+| `references/claude-md-guide.md` | Templates for CLAUDE.md and README.md, budgets, decision tables |
+| `references/anti-patterns.md` | Bloat examples, discoverable content catalog, three-question test, no-op catalog |
 | `references/design-intent.md` | Design Intent format, authoring protocol, maintenance rules |
+
+## Pairs With
+
+The `docs-that-work-gate` hook blocks a commit whose changed files have a `CLAUDE.md` or `README.md` that was not refreshed, and points the agent at this skill:
+
+```bash
+npx @provectusinc/awos-recruitment hook docs-that-work-gate
+```

--- a/.claude/skills/docs-that-work/SKILL.md
+++ b/.claude/skills/docs-that-work/SKILL.md
@@ -25,7 +25,7 @@ Directory trees, exports, types, linter rules, commands, dependencies, test loca
 Two things survive this filter:
 
 - **Intent, not actual shape.** Code reveals the **actual** shape of the codebase, not the **intended** one. Where they diverge — an anti-pattern that leaked in and spread — the divergence is undiscoverable from code and is exactly what needs documenting. See [Design Intent](#design-intent) below.
-- **Expensive lookups.** The environment is a source of truth too — `package.json` scripts, config files, `--help` output — and a doc restating it is a **cache**. A cache earns its cost only when the lookup is expensive: the real entrypoint buried under four Makefile includes, the test command that differs from the one in `package.json`. One-file, one-command lookups stay with the environment, where they cannot go stale.
+- **Expensive lookups.** Discoverable is not the same as cheap to discover. Where the answer takes a chain of files to reconstruct — the real entrypoint threaded through four Makefile includes, the suite CI actually gates on rather than the one `package.json` advertises — a doc line is a shortcut worth its cost. Where it takes one `grep`, the config file is the better home: config cannot drift from itself, a copy of it can.
 
 ### Filter 2 — no-op
 
@@ -36,13 +36,13 @@ A line can be undiscoverable and still worthless. "Write clean code", "add tests
 - No-op: "Handle errors properly." → Live: "Every handler returns the `{error: {...}}` envelope — a bare 500 breaks the mobile client's parser."
 - No-op: "Keep functions small." → Live: "Split service methods by transaction boundary, not by length — one DB transaction per method."
 
-The test is relative to the **model's default**, not to a reader's ignorance. Two people who disagree about a no-op disagree about what the default is — settle it by deleting the line and running the task, not by argument. When a line fails, delete the whole line rather than trim words from it.
+Measure against the **model's default**, not against a new hire's ignorance — the reader here already knows how to write code. When two people cannot agree that a line is a no-op, what they actually disagree about is how the agent behaves without it, and that is an experiment rather than a debate: pull the line, run the task, compare. A line that fails comes out whole — softening the wording of a no-op leaves a shorter no-op.
 
 Every line that survives both filters still carries a maintenance cost that compounds across every session. Stale docs cause worse decisions than no docs.
 
 ## Write the Target, Not the Ban
 
-A prohibition drags the forbidden behavior into context and makes it _more_ available, not less — the ban half-reads as an instruction to do the thing. State the behavior you want, so the banned one is never spoken:
+A rule written as a ban has to describe the anti-pattern in order to forbid it — so the file spells out the wrong shape in detail and the right one not at all, and the shape an agent has just read in detail is the one it reaches for. Describe the shape you want, and the wrong one never enters the file:
 
 - Weak: "Don't use floats for money." → Strong: "Money is stored as integer cents everywhere."
 - Weak: "Never import from `internal/` outside its module." → Strong: "Cross-module access goes through the package's public `api.py`."

--- a/.claude/skills/docs-that-work/SKILL.md
+++ b/.claude/skills/docs-that-work/SKILL.md
@@ -1,25 +1,53 @@
 ---
 name: docs-that-work
 description: >-
-  Project documentation guidelines. Use when asked to "write documentation",
-  "create a CLAUDE.md", "write a README", "document this project",
-  "improve documentation", "add a Design Intent section", or when
-  creating/updating CLAUDE.md or README.md files.
+  Project documentation that serves humans and agents. Use when writing or
+  auditing a CLAUDE.md or README.md, when adding a Design Intent section to a
+  package, or when a commit is blocked because documentation went stale.
 ---
 
 # Docs That Work
 
-Write documentation that serves both humans and AI agents. Core principle: **document only what cannot be discovered from code**. Codebase structure matters more than documentation volume — a well-organized project with 10 lines of docs beats a messy one with 200.
+Write documentation that serves both humans and AI agents. Core principle: **document only what cannot be discovered from code, and only what changes what an agent does**. Codebase structure matters more than documentation volume — a well-organized project with 10 lines of docs beats a messy one with 200.
 
-## The Discoverability Rule
+**Auditing or refreshing an existing `CLAUDE.md` / `README.md` — including any commit blocked by the `docs-that-work-gate` hook — starts by reading `references/audit-procedure.md` and following it. Never refresh a doc file from memory.**
 
-Before writing any documentation line, ask: _"Could an agent find this by reading code or config files?"_
+## The Two Filters
 
-If yes, don't write it. Directory trees, exports, types, linter rules, commands, dependencies, test locations, env var names — all discoverable from code and config files. See `references/anti-patterns.md` for the full catalog.
+Every candidate line clears two independent tests before it earns a place. Failing either one means cut.
 
-One caveat: code reveals the **actual** shape of the codebase, not the **intended** one. Where they diverge — an anti-pattern that leaked in and spread — the divergence is undiscoverable from code and is exactly what needs documenting. See [Design Intent](references/design-intent.md) below.
+### Filter 1 — discoverability
 
-Every line you add has a maintenance cost that compounds across every session. Stale docs cause worse decisions than no docs.
+_"Could an agent find this by reading code or config files?"_
+
+Directory trees, exports, types, linter rules, commands, dependencies, test locations, env var names — all discoverable from code and config files. See `references/anti-patterns.md` for the full catalog and the three-question test.
+
+Two things survive this filter:
+
+- **Intent, not actual shape.** Code reveals the **actual** shape of the codebase, not the **intended** one. Where they diverge — an anti-pattern that leaked in and spread — the divergence is undiscoverable from code and is exactly what needs documenting. See [Design Intent](#design-intent) below.
+- **Expensive lookups.** The environment is a source of truth too — `package.json` scripts, config files, `--help` output — and a doc restating it is a **cache**. A cache earns its cost only when the lookup is expensive: the real entrypoint buried under four Makefile includes, the test command that differs from the one in `package.json`. One-file, one-command lookups stay with the environment, where they cannot go stale.
+
+### Filter 2 — no-op
+
+_"Does this line change what the agent does, versus what it would do by default?"_
+
+A line can be undiscoverable and still worthless. "Write clean code", "add tests for new features", "be careful with migrations" — nothing in the repo states them, and no agent behaves differently for having read them. They cost context on every turn and buy nothing.
+
+- No-op: "Handle errors properly." → Live: "Every handler returns the `{error: {...}}` envelope — a bare 500 breaks the mobile client's parser."
+- No-op: "Keep functions small." → Live: "Split service methods by transaction boundary, not by length — one DB transaction per method."
+
+The test is relative to the **model's default**, not to a reader's ignorance. Two people who disagree about a no-op disagree about what the default is — settle it by deleting the line and running the task, not by argument. When a line fails, delete the whole line rather than trim words from it.
+
+Every line that survives both filters still carries a maintenance cost that compounds across every session. Stale docs cause worse decisions than no docs.
+
+## Write the Target, Not the Ban
+
+A prohibition drags the forbidden behavior into context and makes it _more_ available, not less — the ban half-reads as an instruction to do the thing. State the behavior you want, so the banned one is never spoken:
+
+- Weak: "Don't use floats for money." → Strong: "Money is stored as integer cents everywhere."
+- Weak: "Never import from `internal/` outside its module." → Strong: "Cross-module access goes through the package's public `api.py`."
+
+Keep a bare prohibition only as a hard guardrail you cannot phrase positively, and pair it with the positive target. Design Intent drift callouts are the sanctioned exception — they name a specific file and a located anti-pattern, which is a fact about this repo rather than a general ban.
 
 ## CLAUDE.md Rules
 
@@ -29,46 +57,31 @@ Every line you add has a maintenance cost that compounds across every session. S
 
 - Project purpose — 1-2 sentences on what this does and why
 - Undiscoverable conventions — naming patterns, architectural decisions, gotchas
-- Non-obvious constraints — "never import X from Y", "always run Z before W"
+- Non-obvious constraints — the prerequisite, the ordering rule, the surprising flag
 - Design Intent — the intended shape of code in a package (package-level CLAUDE.md only, see below)
 
-**Content that does NOT belong:** anything that passes the discoverability rule — commands, directory trees, exports, types, config rules, dependency lists.
+**Content that does NOT belong:** anything either filter cuts — commands, directory trees, exports, types, config rules, dependency lists, and generic advice the agent already follows.
 
-**Structure:**
+**Structure and budget** — root and package files spend different budgets, because they load at different rates:
 
-- Root `CLAUDE.md` — project-wide context applicable everywhere
-- Service-level `CLAUDE.md` — that module's non-obvious constraints and, where useful, its Design Intent; never repeat root content
+| File                | Loads                                       | Budget                                                                                       |
+| ------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Root `CLAUDE.md`    | every turn of every session                 | ~25 lines; project-wide content only, never a Design Intent section                            |
+| Package `CLAUDE.md` | when the agent works in that directory      | ~35 lines of non-obvious context, plus ~10–15 for Design Intent; ≤70 combined ceiling          |
 
-**Size:** non-obvious constraints ~35 lines; Design Intent usually ~10 lines, 15 max; ≤70 combined ceiling. A CLAUDE.md without a Design Intent section should stay around 35. Past the ceiling, it's bloated. Cut ruthlessly.
+The root file is charged on every turn whether or not the session touches the code it describes, so anything scoped to one module drops into that module's file. A package file never repeats root content. Past the ceiling, it's bloated — cut ruthlessly.
 
 See `references/claude-md-guide.md` for templates and examples.
 
 ## Design Intent
 
-Agents treat existing code as the strongest signal for how new code should look. When an anti-pattern leaks into a package, nothing in the code says which pattern is canonical and which is drift — so agents replicate it. A Design Intent section writes the intended shape down.
+Agents treat existing code as the strongest signal for how new code should look. When an anti-pattern leaks into a package, nothing in the code says which pattern is canonical and which is drift — so agents replicate it, and each copy makes the leak look more canonical to the next agent. A Design Intent section writes the intended shape down: a conflict preamble, a golden example pointer, 2–4 do/don't rules, and a sanctioned exception line for any file that deviates on purpose.
 
-**Where:** package-level (i.e., service/module-level) CLAUDE.md, next to the code it shapes. The root `CLAUDE.md` keeps its usual project-wide content (purpose, conventions, constraints) but never a Design Intent section.
+**Where:** package-level (i.e., service/module-level) CLAUDE.md, next to the code it shapes. The root `CLAUDE.md` keeps its usual project-wide content and never carries a Design Intent section.
 
-**Format** (usually ~10 lines, 15 max): conflict preamble + golden example pointer + 2–4 do/don't rules, plus a sanctioned exception line for any file that deviates on purpose:
+**The conflict rule:** Design Intent outranks existing code. When existing code contradicts it, follow Design Intent and flag the contradicting file as drift — never silently replicate the drifted pattern, and never silently ignore the mismatch. To flag: name the file and the contradicted rule in your final summary or PR description — flagging is reporting, not fixing; editing the drifted file or the CLAUDE.md is a separate task. A file named in an Exception line is not drift — leave it alone, and never model new code on it; new code follows the golden example.
 
-```markdown
-# Design Intent
-
-If existing code contradicts this section, follow this section
-and flag the file as drift.
-
-Reference: `handlers/create-order.ts` is the canonical handler — copy its structure.
-
-- Do: validate input via schema at the top, one service call, return envelope
-- Don't: raw SQL in handlers (leaked into `sales-report.ts` and others — do not replicate)
-- Exception: `handlers/bulk-export.ts` streams raw SQL (perf-critical path) — not drift, do not "fix", do not replicate
-```
-
-**The conflict rule:** Design Intent outranks existing code. When existing code contradicts it, follow Design Intent and flag the contradicting file as drift — never silently replicate the drifted pattern, and never silently ignore the mismatch. To flag: name the file and the contradicted rule in your final summary or PR description — flagging is reporting, not fixing; editing the drifted file or the CLAUDE.md is a separate task (see the maintenance rules in `references/design-intent.md`). A file named in an Exception line is not drift — leave it alone, and never model new code on it; new code follows the golden example.
-
-**Authoring:** propose from code, human confirms. Draft the golden example and rules from the dominant or best pattern, then get human confirmation before it lands — if the anti-pattern IS the majority pattern, inferring intent autonomously enshrines the drift. If no human is available: mark the heading `# Design Intent (unconfirmed proposal)`, replace the conflict preamble with "Proposed, not confirmed. Until a human confirms this section, do not treat it as outranking existing code, and do not flag drift from it.", and write no Exception lines — only a human can sanction an exception. Never present inferred intent as confirmed. This fallback is for proposing a new section only: never rewrite, downgrade, or delete an existing confirmed section — including its Exception lines — without a human; propose changes in your summary or PR description instead.
-
-See `references/design-intent.md` for the full format spec, authoring protocol, and maintenance rules.
+**Writing or editing a Design Intent section: read `references/design-intent.md` first.** The format is verbatim-sensitive (the preamble wording is load-bearing) and authoring is gated on a human — draft the golden example and rules from the dominant or best pattern, then get confirmation before it lands, because if the anti-pattern IS the majority pattern, inferring intent autonomously enshrines the drift. Never present inferred intent as confirmed, and never rewrite, downgrade, or delete a confirmed section without a human. The full format spec, the unconfirmed-proposal fallback, and the maintenance rules all live in that file.
 
 ## README.md Rules
 
@@ -76,7 +89,7 @@ See `references/design-intent.md` for the full format spec, authoring protocol, 
 
 **Content:** project description, prerequisites, setup, how to run, how to test, how to contribute. Keep it executable — commands that copy-paste and work beat prose.
 
-Root `README.md` = full overview + setup. Service-level = purpose + how to run independently. Don't duplicate `CLAUDE.md` content — different audiences, different purposes.
+Root `README.md` = full overview + setup. Service-level = purpose + how to run independently. Don't duplicate `CLAUDE.md` content — different audiences, different purposes. The two filters govern `CLAUDE.md`, not `README.md`: a human onboarding needs the setup commands spelled out even though an agent could find them.
 
 ## Grey Box Documentation
 
@@ -110,12 +123,4 @@ Some things genuinely need docs because no amount of code reading reveals them:
 - **Security procedures** — auth flows, key rotation, access patterns
 - **Non-obvious flags** — env vars or CLI flags with surprising behavior
 
-If you're unsure whether something needs docs, apply the three-question test from `references/anti-patterns.md`.
-
-## Deep Dives
-
-| Topic                                                  | Reference                       |
-| ------------------------------------------------------ | ------------------------------- |
-| CLAUDE.md and README templates                         | `references/claude-md-guide.md` |
-| Anti-patterns, bloat examples, the three-question test | `references/anti-patterns.md`   |
-| Design Intent format, authoring protocol, maintenance  | `references/design-intent.md`   |
+Each still has to clear Filter 2: write the specific fact that changes a decision, not the topic heading. If you're unsure whether something needs docs, apply the three-question test and the no-op catalog in `references/anti-patterns.md`.

--- a/.claude/skills/docs-that-work/references/anti-patterns.md
+++ b/.claude/skills/docs-that-work/references/anti-patterns.md
@@ -68,7 +68,10 @@ Note the Zustand line: it is a drift rule ("previous migration was partial"). A 
 | Script commands | Read `package.json` scripts or `justfile` | Reads task runner config |
 | CI pipeline steps | Read `.github/workflows/` | Reads CI config |
 
-If it's in a file an agent can read, it doesn't need documentation — with one exception: when code has drifted from the intended pattern, the file shows the drift, not the intent. That case is covered by the guard in the test below.
+If it's in a file an agent can read, it doesn't need documentation — with two exceptions:
+
+- **Drift.** When code has drifted from the intended pattern, the file shows the drift, not the intent. That case is covered by the guard in the test below.
+- **Expensive lookups.** A doc line that restates the environment is a cache of a lookup, and a cache earns its cost only when the lookup is expensive. `just test` in a justfile is one `grep` away — leave it. "The suite that gates CI is `just test-integration`, not `just test`" is a fact no single file states — write it.
 
 ## The Three-Question Test
 
@@ -87,6 +90,23 @@ If any answer is **yes**, don't write it — with one guard: **is what's discove
 - "We use ESLint with airbnb config" → it's in `.eslintrc`. **Don't write it.**
 - "Handlers never touch the DB directly" → most handlers show this, but `sales-report.ts` hits the DB (drift) — the intended pattern is no longer discoverable. **Write it as Design Intent.**
 
+## The No-Op Catalog
+
+The three-question test only catches lines the code already answers. A second class of bloat passes it cleanly: lines that are undiscoverable, true, and change nothing an agent would have done anyway. Test each one against the model's **default behavior** — not against a new hire's ignorance.
+
+| No-op line                                  | Why it's a no-op                      | The live version                                                                                |
+| ------------------------------------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| "Write clean, maintainable code"            | the default                           | (nothing — delete)                                                                                |
+| "Add tests for new functionality"           | the default                           | "Integration tests need `just db-up` first — without it they pass by skipping"                    |
+| "Follow existing patterns in the codebase"  | the default, and wrong where drift is | a Design Intent section naming the golden example                                                 |
+| "Be careful with database migrations"       | names a topic, not a behavior         | "Migrations are numbered by hand — check the highest existing number before adding one"           |
+| "Use TypeScript strictly"                   | `tsconfig.json` decides this          | (nothing — discoverable)                                                                          |
+| "This is a monorepo with multiple packages" | visible from the directory layout     | (nothing — discoverable)                                                                          |
+
+The pattern: a no-op names a **topic** or a **virtue**; a live line names a **specific fact that flips a decision**. When a line fails the test, delete the whole line — a trimmed no-op is still a no-op.
+
+Two people who disagree about whether a line is a no-op disagree about the model's default. Settle it by deleting the line and running the task, not by debate.
+
 ## Common Mistakes
 
 When asked to "document the project," agents typically:
@@ -96,5 +116,6 @@ When asked to "document the project," agents typically:
 3. **Copy type definitions** — paste interfaces and types into docs
 4. **Write a novel** — produce 200+ line CLAUDE.md files that no agent will fully process
 5. **Duplicate across files** — put the same commands in README, CLAUDE.md, and CONTRIBUTING.md
+6. **Write virtues** — "clean code", "follow best practices", "be careful with X": lines nothing in the repo contradicts and no agent acts on
 
 Recognize these patterns. When you catch yourself doing any of them, stop and apply the three-question test to every line.

--- a/.claude/skills/docs-that-work/references/anti-patterns.md
+++ b/.claude/skills/docs-that-work/references/anti-patterns.md
@@ -71,7 +71,7 @@ Note the Zustand line: it is a drift rule ("previous migration was partial"). A 
 If it's in a file an agent can read, it doesn't need documentation — with two exceptions:
 
 - **Drift.** When code has drifted from the intended pattern, the file shows the drift, not the intent. That case is covered by the guard in the test below.
-- **Expensive lookups.** A doc line that restates the environment is a cache of a lookup, and a cache earns its cost only when the lookup is expensive. `just test` in a justfile is one `grep` away — leave it. "The suite that gates CI is `just test-integration`, not `just test`" is a fact no single file states — write it.
+- **Expensive lookups.** Some answers are technically in the repo but take a chain of files to reconstruct. `just test` sits in the justfile one `grep` away — leave it there. "The suite that gates CI is `just test-integration`, not `just test`" is spread across a workflow file and a justfile and stated outright by neither — write that one down.
 
 ## The Three-Question Test
 
@@ -105,7 +105,7 @@ The three-question test only catches lines the code already answers. A second cl
 
 The pattern: a no-op names a **topic** or a **virtue**; a live line names a **specific fact that flips a decision**. When a line fails the test, delete the whole line — a trimmed no-op is still a no-op.
 
-Two people who disagree about whether a line is a no-op disagree about the model's default. Settle it by deleting the line and running the task, not by debate.
+Disagreement over whether a line is a no-op is really disagreement over how the agent behaves without it. Resolve it by experiment — pull the line, run the task, compare the result — rather than by argument.
 
 ## Common Mistakes
 

--- a/.claude/skills/docs-that-work/references/audit-procedure.md
+++ b/.claude/skills/docs-that-work/references/audit-procedure.md
@@ -1,0 +1,76 @@
+# Documentation Audit Procedure
+
+The ordered process for refreshing an existing `CLAUDE.md` or `README.md` — a doc review, a "the docs are out of date" request, or a commit blocked by the `docs-that-work-gate` hook.
+
+Reading the file and judging that it "looks fine" is not an audit. The audit is done when **every line of every doc file in scope has been classified**, and not before.
+
+## 1. Scope the audit
+
+List the doc files under review:
+
+- **Blocked commit** — the hook names them. Each changed file is owned by the nearest ancestor directory containing a `CLAUDE.md` or `README.md`, and every doc file in that directory is in scope.
+- **Direct request** — the files the user named, plus any package `CLAUDE.md` that owns code they mention.
+
+Write the list down before editing anything. If it is longer than three files, audit them one at a time to completion rather than skimming all of them at once.
+
+## 2. Read the change, then the docs
+
+Read the pending diff (`git diff HEAD`, plus untracked files) before reading the docs. You are looking for two things: what the change made **wrong** in the docs, and what it made **missing**.
+
+Then read each in-scope doc file in full. Never edit a doc you have not read end to end in this session.
+
+## 3. Classify every line
+
+Walk the doc top to bottom. Every line — including headings and list items — gets exactly one verdict:
+
+| Verdict         | Trigger                                                                                  | Action                                          |
+| --------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **keep**        | clears both filters, still true                                                            | leave untouched                                 |
+| **cut: found**  | Filter 1 — an agent can read it out of code or config, and the lookup is cheap             | delete the line                                 |
+| **cut: no-op**  | Filter 2 — it does not change what the agent does versus its default                       | delete the whole line, don't trim words          |
+| **cut: stale**  | describes behavior, a file, or a constraint that no longer exists                          | delete the line                                 |
+| **rewrite**     | true and load-bearing, but phrased as a bare ban, or drifted from what the code now does   | restate as the positive target, or correct it    |
+| **move**        | true and load-bearing, but in the wrong file (root vs package, `CLAUDE.md` vs `README.md`) | cut here, add there — never leave both copies    |
+| **ask-human**   | changes a confirmed Design Intent section, or sanctions an exception                       | leave the file alone, raise it in step 6         |
+
+A line you cannot classify is a **cut: no-op** candidate: if you cannot say which decision it changes, it does not change one.
+
+Two guards:
+
+- **Drift, not discoverability.** Before cutting a line as `cut: found`, check that what the code shows is what is *intended*. If the code has drifted, the intent is no longer discoverable — that line becomes Design Intent material, not a cut. See `design-intent.md`.
+- **Confirmed Design Intent is not yours to edit.** Deleting or rewriting a confirmed section — including its Exception lines — is `ask-human`, always. Fixing a re-pointed golden example path is the one mechanical exception, and only when the file was renamed in this very change.
+
+## 4. Find what is missing
+
+The diff introduced facts of its own. For each, ask whether it clears both filters — undiscoverable **and** behavior-changing:
+
+- a new prerequisite or ordering rule ("the seed script must run before the first test run")
+- a new cross-service contract not enforced by types
+- a constraint the code cannot state ("this queue is at-least-once — every consumer must be idempotent")
+- a deliberate deviation a future agent would otherwise "fix"
+
+Add only these. A new module, a new export, a new dependency, a new command — all discoverable, all stay unwritten.
+
+## 5. Apply and check the budget
+
+Make the edits, then count lines against the budget in `SKILL.md`: ~25 for a root `CLAUDE.md`, ~35 plus ~10–15 of Design Intent for a package one, ≤70 as the hard ceiling. Over the ceiling, go back to step 3 and cut — the ceiling is not negotiated by exception, it is met by cutting.
+
+## 6. Report
+
+State, in the final summary or PR description:
+
+- the files audited, and for each: lines cut, lines added, lines moved
+- every `ask-human` item, as an explicit question
+- every drift flagged against a Design Intent section — the file and the contradicted rule
+- anything you deliberately left alone and why
+
+## Completion criteria
+
+The audit is complete when all of these hold:
+
+1. Every line of every in-scope doc file carries a verdict from step 3.
+2. Every step-4 candidate was either written down or rejected for a stated reason.
+3. Every file in scope is within its budget.
+4. The report in step 6 exists.
+
+**"The docs are already accurate" is a legitimate outcome** — but only as the result of steps 1–3, not as a reason to skip them. Say so explicitly, name the files you audited, and re-run the blocked command; the hook's marker lets an unchanged retry through.

--- a/.claude/skills/docs-that-work/references/claude-md-guide.md
+++ b/.claude/skills/docs-that-work/references/claude-md-guide.md
@@ -33,6 +33,8 @@ Order processing API for the warehouse system. Receives orders from the storefro
 
 Commands like `just dev`, `just test`, `just lint` are discoverable from the justfile — only the non-obvious prerequisite gotcha is documented.
 
+**Budget: ~25 lines.** The root file loads on every turn of every session, whether or not that session touches the code it describes, so it carries project-wide content only. Anything scoped to one module belongs in that module's file, and a Design Intent section never belongs here.
+
 ## Service-Level CLAUDE.md Template
 
 ```markdown
@@ -58,6 +60,8 @@ Reference: `[canonical file]` — copy its structure.
 ```
 
 The Exception line is optional — include it only for files that deviate from the intent on purpose (human-confirmed). See `design-intent.md` in this directory.
+
+**Budget: ~35 lines of non-obvious context plus ~10–15 for Design Intent, ≤70 combined.** A package file loads only when the agent works in that directory, which is what buys it the larger allowance.
 
 ### Example: Payment Module
 
@@ -128,7 +132,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md).
 | Contradicts or narrows a root convention | Service-level `CLAUDE.md` (with explicit note) |
 | Describes the intended shape of code in one package | Service-level `CLAUDE.md` (Design Intent section) |
 
-When unsure, put it in root. Easier to push down later than to discover missing context scattered across services.
+When unsure, put it in the narrowest file that still covers every place the rule applies. Root is the expensive default — it is charged on every turn of every session — so promote a rule to root when a second service actually needs it, not in anticipation.
 
 ## What Belongs Where
 

--- a/registry/skills/docs-that-work/README.md
+++ b/registry/skills/docs-that-work/README.md
@@ -30,6 +30,10 @@ npx @provectusinc/awos-recruitment skill docs-that-work
 | `references/anti-patterns.md` | Bloat examples, discoverable content catalog, three-question test, no-op catalog |
 | `references/design-intent.md` | Design Intent format, authoring protocol, maintenance rules |
 
+## Credits
+
+The no-op test, the expensive-lookup exception, the split context budgets, and the "state the target, not the ban" rule are adapted from [`writing-for-agents`](https://github.com/mattpocock/skills/tree/main/skills/productivity/writing-for-agents) by Matt Pocock (MIT).
+
 ## Pairs With
 
 The `docs-that-work-gate` hook blocks a commit whose changed files have a `CLAUDE.md` or `README.md` that was not refreshed, and points the agent at this skill:

--- a/registry/skills/docs-that-work/README.md
+++ b/registry/skills/docs-that-work/README.md
@@ -10,19 +10,30 @@ npx @provectusinc/awos-recruitment skill docs-that-work
 
 ## What This Skill Teaches
 
-- **The discoverability rule** — never document what code already reveals
-- **CLAUDE.md discipline** — non-obvious context ~35 lines, plus a ~10-line Design Intent section where useful; 70 lines is the ceiling, not a target
+- **Two filters, not one** — a line earns its place only if the code does not already reveal it *and* it changes what the agent does versus its default; "write clean code" fails the second even though it passes the first
+- **Cache only expensive lookups** — restating `package.json` is bloat; the CI-gating command that no single file states is not
+- **Split budgets** — root `CLAUDE.md` loads every turn (~25 lines), a package one loads on demand (~35 plus ~10–15 of Design Intent, 70 ceiling)
+- **Write the target, not the ban** — a prohibition makes the forbidden behavior more available, not less
 - **Design Intent sections** — document the intended shape of a package so agents stop multiplying leaked anti-patterns; intent outranks existing code
+- **An audit procedure with a completion bar** — every line of every in-scope doc gets a verdict; "looks fine" is not one
 - **README.md structure** — executable setup steps, not prose
 - **Grey box documentation** — describe interfaces, not internals
 - **Document separation** — each file has one job, no duplication
-- **When docs ARE needed** — "why" decisions, cross-service contracts, environment gotchas
 
 ## Files
 
 | File | Content |
 | --- | --- |
 | `SKILL.md` | Core guidelines and rules |
-| `references/claude-md-guide.md` | Templates for CLAUDE.md and README.md, decision tables |
-| `references/anti-patterns.md` | Bloat examples, discoverable content catalog, three-question test |
+| `references/audit-procedure.md` | Ordered process for refreshing existing docs, with completion criteria |
+| `references/claude-md-guide.md` | Templates for CLAUDE.md and README.md, budgets, decision tables |
+| `references/anti-patterns.md` | Bloat examples, discoverable content catalog, three-question test, no-op catalog |
 | `references/design-intent.md` | Design Intent format, authoring protocol, maintenance rules |
+
+## Pairs With
+
+The `docs-that-work-gate` hook blocks a commit whose changed files have a `CLAUDE.md` or `README.md` that was not refreshed, and points the agent at this skill:
+
+```bash
+npx @provectusinc/awos-recruitment hook docs-that-work-gate
+```

--- a/registry/skills/docs-that-work/SKILL.md
+++ b/registry/skills/docs-that-work/SKILL.md
@@ -25,7 +25,7 @@ Directory trees, exports, types, linter rules, commands, dependencies, test loca
 Two things survive this filter:
 
 - **Intent, not actual shape.** Code reveals the **actual** shape of the codebase, not the **intended** one. Where they diverge — an anti-pattern that leaked in and spread — the divergence is undiscoverable from code and is exactly what needs documenting. See [Design Intent](#design-intent) below.
-- **Expensive lookups.** The environment is a source of truth too — `package.json` scripts, config files, `--help` output — and a doc restating it is a **cache**. A cache earns its cost only when the lookup is expensive: the real entrypoint buried under four Makefile includes, the test command that differs from the one in `package.json`. One-file, one-command lookups stay with the environment, where they cannot go stale.
+- **Expensive lookups.** Discoverable is not the same as cheap to discover. Where the answer takes a chain of files to reconstruct — the real entrypoint threaded through four Makefile includes, the suite CI actually gates on rather than the one `package.json` advertises — a doc line is a shortcut worth its cost. Where it takes one `grep`, the config file is the better home: config cannot drift from itself, a copy of it can.
 
 ### Filter 2 — no-op
 
@@ -36,13 +36,13 @@ A line can be undiscoverable and still worthless. "Write clean code", "add tests
 - No-op: "Handle errors properly." → Live: "Every handler returns the `{error: {...}}` envelope — a bare 500 breaks the mobile client's parser."
 - No-op: "Keep functions small." → Live: "Split service methods by transaction boundary, not by length — one DB transaction per method."
 
-The test is relative to the **model's default**, not to a reader's ignorance. Two people who disagree about a no-op disagree about what the default is — settle it by deleting the line and running the task, not by argument. When a line fails, delete the whole line rather than trim words from it.
+Measure against the **model's default**, not against a new hire's ignorance — the reader here already knows how to write code. When two people cannot agree that a line is a no-op, what they actually disagree about is how the agent behaves without it, and that is an experiment rather than a debate: pull the line, run the task, compare. A line that fails comes out whole — softening the wording of a no-op leaves a shorter no-op.
 
 Every line that survives both filters still carries a maintenance cost that compounds across every session. Stale docs cause worse decisions than no docs.
 
 ## Write the Target, Not the Ban
 
-A prohibition drags the forbidden behavior into context and makes it _more_ available, not less — the ban half-reads as an instruction to do the thing. State the behavior you want, so the banned one is never spoken:
+A rule written as a ban has to describe the anti-pattern in order to forbid it — so the file spells out the wrong shape in detail and the right one not at all, and the shape an agent has just read in detail is the one it reaches for. Describe the shape you want, and the wrong one never enters the file:
 
 - Weak: "Don't use floats for money." → Strong: "Money is stored as integer cents everywhere."
 - Weak: "Never import from `internal/` outside its module." → Strong: "Cross-module access goes through the package's public `api.py`."

--- a/registry/skills/docs-that-work/SKILL.md
+++ b/registry/skills/docs-that-work/SKILL.md
@@ -1,25 +1,53 @@
 ---
 name: docs-that-work
 description: >-
-  Project documentation guidelines. Use when asked to "write documentation",
-  "create a CLAUDE.md", "write a README", "document this project",
-  "improve documentation", "add a Design Intent section", or when
-  creating/updating CLAUDE.md or README.md files.
+  Project documentation that serves humans and agents. Use when writing or
+  auditing a CLAUDE.md or README.md, when adding a Design Intent section to a
+  package, or when a commit is blocked because documentation went stale.
 ---
 
 # Docs That Work
 
-Write documentation that serves both humans and AI agents. Core principle: **document only what cannot be discovered from code**. Codebase structure matters more than documentation volume — a well-organized project with 10 lines of docs beats a messy one with 200.
+Write documentation that serves both humans and AI agents. Core principle: **document only what cannot be discovered from code, and only what changes what an agent does**. Codebase structure matters more than documentation volume — a well-organized project with 10 lines of docs beats a messy one with 200.
 
-## The Discoverability Rule
+**Auditing or refreshing an existing `CLAUDE.md` / `README.md` — including any commit blocked by the `docs-that-work-gate` hook — starts by reading `references/audit-procedure.md` and following it. Never refresh a doc file from memory.**
 
-Before writing any documentation line, ask: _"Could an agent find this by reading code or config files?"_
+## The Two Filters
 
-If yes, don't write it. Directory trees, exports, types, linter rules, commands, dependencies, test locations, env var names — all discoverable from code and config files. See `references/anti-patterns.md` for the full catalog.
+Every candidate line clears two independent tests before it earns a place. Failing either one means cut.
 
-One caveat: code reveals the **actual** shape of the codebase, not the **intended** one. Where they diverge — an anti-pattern that leaked in and spread — the divergence is undiscoverable from code and is exactly what needs documenting. See [Design Intent](references/design-intent.md) below.
+### Filter 1 — discoverability
 
-Every line you add has a maintenance cost that compounds across every session. Stale docs cause worse decisions than no docs.
+_"Could an agent find this by reading code or config files?"_
+
+Directory trees, exports, types, linter rules, commands, dependencies, test locations, env var names — all discoverable from code and config files. See `references/anti-patterns.md` for the full catalog and the three-question test.
+
+Two things survive this filter:
+
+- **Intent, not actual shape.** Code reveals the **actual** shape of the codebase, not the **intended** one. Where they diverge — an anti-pattern that leaked in and spread — the divergence is undiscoverable from code and is exactly what needs documenting. See [Design Intent](#design-intent) below.
+- **Expensive lookups.** The environment is a source of truth too — `package.json` scripts, config files, `--help` output — and a doc restating it is a **cache**. A cache earns its cost only when the lookup is expensive: the real entrypoint buried under four Makefile includes, the test command that differs from the one in `package.json`. One-file, one-command lookups stay with the environment, where they cannot go stale.
+
+### Filter 2 — no-op
+
+_"Does this line change what the agent does, versus what it would do by default?"_
+
+A line can be undiscoverable and still worthless. "Write clean code", "add tests for new features", "be careful with migrations" — nothing in the repo states them, and no agent behaves differently for having read them. They cost context on every turn and buy nothing.
+
+- No-op: "Handle errors properly." → Live: "Every handler returns the `{error: {...}}` envelope — a bare 500 breaks the mobile client's parser."
+- No-op: "Keep functions small." → Live: "Split service methods by transaction boundary, not by length — one DB transaction per method."
+
+The test is relative to the **model's default**, not to a reader's ignorance. Two people who disagree about a no-op disagree about what the default is — settle it by deleting the line and running the task, not by argument. When a line fails, delete the whole line rather than trim words from it.
+
+Every line that survives both filters still carries a maintenance cost that compounds across every session. Stale docs cause worse decisions than no docs.
+
+## Write the Target, Not the Ban
+
+A prohibition drags the forbidden behavior into context and makes it _more_ available, not less — the ban half-reads as an instruction to do the thing. State the behavior you want, so the banned one is never spoken:
+
+- Weak: "Don't use floats for money." → Strong: "Money is stored as integer cents everywhere."
+- Weak: "Never import from `internal/` outside its module." → Strong: "Cross-module access goes through the package's public `api.py`."
+
+Keep a bare prohibition only as a hard guardrail you cannot phrase positively, and pair it with the positive target. Design Intent drift callouts are the sanctioned exception — they name a specific file and a located anti-pattern, which is a fact about this repo rather than a general ban.
 
 ## CLAUDE.md Rules
 
@@ -29,46 +57,31 @@ Every line you add has a maintenance cost that compounds across every session. S
 
 - Project purpose — 1-2 sentences on what this does and why
 - Undiscoverable conventions — naming patterns, architectural decisions, gotchas
-- Non-obvious constraints — "never import X from Y", "always run Z before W"
+- Non-obvious constraints — the prerequisite, the ordering rule, the surprising flag
 - Design Intent — the intended shape of code in a package (package-level CLAUDE.md only, see below)
 
-**Content that does NOT belong:** anything that passes the discoverability rule — commands, directory trees, exports, types, config rules, dependency lists.
+**Content that does NOT belong:** anything either filter cuts — commands, directory trees, exports, types, config rules, dependency lists, and generic advice the agent already follows.
 
-**Structure:**
+**Structure and budget** — root and package files spend different budgets, because they load at different rates:
 
-- Root `CLAUDE.md` — project-wide context applicable everywhere
-- Service-level `CLAUDE.md` — that module's non-obvious constraints and, where useful, its Design Intent; never repeat root content
+| File                | Loads                                       | Budget                                                                                       |
+| ------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Root `CLAUDE.md`    | every turn of every session                 | ~25 lines; project-wide content only, never a Design Intent section                            |
+| Package `CLAUDE.md` | when the agent works in that directory      | ~35 lines of non-obvious context, plus ~10–15 for Design Intent; ≤70 combined ceiling          |
 
-**Size:** non-obvious constraints ~35 lines; Design Intent usually ~10 lines, 15 max; ≤70 combined ceiling. A CLAUDE.md without a Design Intent section should stay around 35. Past the ceiling, it's bloated. Cut ruthlessly.
+The root file is charged on every turn whether or not the session touches the code it describes, so anything scoped to one module drops into that module's file. A package file never repeats root content. Past the ceiling, it's bloated — cut ruthlessly.
 
 See `references/claude-md-guide.md` for templates and examples.
 
 ## Design Intent
 
-Agents treat existing code as the strongest signal for how new code should look. When an anti-pattern leaks into a package, nothing in the code says which pattern is canonical and which is drift — so agents replicate it. A Design Intent section writes the intended shape down.
+Agents treat existing code as the strongest signal for how new code should look. When an anti-pattern leaks into a package, nothing in the code says which pattern is canonical and which is drift — so agents replicate it, and each copy makes the leak look more canonical to the next agent. A Design Intent section writes the intended shape down: a conflict preamble, a golden example pointer, 2–4 do/don't rules, and a sanctioned exception line for any file that deviates on purpose.
 
-**Where:** package-level (i.e., service/module-level) CLAUDE.md, next to the code it shapes. The root `CLAUDE.md` keeps its usual project-wide content (purpose, conventions, constraints) but never a Design Intent section.
+**Where:** package-level (i.e., service/module-level) CLAUDE.md, next to the code it shapes. The root `CLAUDE.md` keeps its usual project-wide content and never carries a Design Intent section.
 
-**Format** (usually ~10 lines, 15 max): conflict preamble + golden example pointer + 2–4 do/don't rules, plus a sanctioned exception line for any file that deviates on purpose:
+**The conflict rule:** Design Intent outranks existing code. When existing code contradicts it, follow Design Intent and flag the contradicting file as drift — never silently replicate the drifted pattern, and never silently ignore the mismatch. To flag: name the file and the contradicted rule in your final summary or PR description — flagging is reporting, not fixing; editing the drifted file or the CLAUDE.md is a separate task. A file named in an Exception line is not drift — leave it alone, and never model new code on it; new code follows the golden example.
 
-```markdown
-# Design Intent
-
-If existing code contradicts this section, follow this section
-and flag the file as drift.
-
-Reference: `handlers/create-order.ts` is the canonical handler — copy its structure.
-
-- Do: validate input via schema at the top, one service call, return envelope
-- Don't: raw SQL in handlers (leaked into `sales-report.ts` and others — do not replicate)
-- Exception: `handlers/bulk-export.ts` streams raw SQL (perf-critical path) — not drift, do not "fix", do not replicate
-```
-
-**The conflict rule:** Design Intent outranks existing code. When existing code contradicts it, follow Design Intent and flag the contradicting file as drift — never silently replicate the drifted pattern, and never silently ignore the mismatch. To flag: name the file and the contradicted rule in your final summary or PR description — flagging is reporting, not fixing; editing the drifted file or the CLAUDE.md is a separate task (see the maintenance rules in `references/design-intent.md`). A file named in an Exception line is not drift — leave it alone, and never model new code on it; new code follows the golden example.
-
-**Authoring:** propose from code, human confirms. Draft the golden example and rules from the dominant or best pattern, then get human confirmation before it lands — if the anti-pattern IS the majority pattern, inferring intent autonomously enshrines the drift. If no human is available: mark the heading `# Design Intent (unconfirmed proposal)`, replace the conflict preamble with "Proposed, not confirmed. Until a human confirms this section, do not treat it as outranking existing code, and do not flag drift from it.", and write no Exception lines — only a human can sanction an exception. Never present inferred intent as confirmed. This fallback is for proposing a new section only: never rewrite, downgrade, or delete an existing confirmed section — including its Exception lines — without a human; propose changes in your summary or PR description instead.
-
-See `references/design-intent.md` for the full format spec, authoring protocol, and maintenance rules.
+**Writing or editing a Design Intent section: read `references/design-intent.md` first.** The format is verbatim-sensitive (the preamble wording is load-bearing) and authoring is gated on a human — draft the golden example and rules from the dominant or best pattern, then get confirmation before it lands, because if the anti-pattern IS the majority pattern, inferring intent autonomously enshrines the drift. Never present inferred intent as confirmed, and never rewrite, downgrade, or delete a confirmed section without a human. The full format spec, the unconfirmed-proposal fallback, and the maintenance rules all live in that file.
 
 ## README.md Rules
 
@@ -76,7 +89,7 @@ See `references/design-intent.md` for the full format spec, authoring protocol, 
 
 **Content:** project description, prerequisites, setup, how to run, how to test, how to contribute. Keep it executable — commands that copy-paste and work beat prose.
 
-Root `README.md` = full overview + setup. Service-level = purpose + how to run independently. Don't duplicate `CLAUDE.md` content — different audiences, different purposes.
+Root `README.md` = full overview + setup. Service-level = purpose + how to run independently. Don't duplicate `CLAUDE.md` content — different audiences, different purposes. The two filters govern `CLAUDE.md`, not `README.md`: a human onboarding needs the setup commands spelled out even though an agent could find them.
 
 ## Grey Box Documentation
 
@@ -110,12 +123,4 @@ Some things genuinely need docs because no amount of code reading reveals them:
 - **Security procedures** — auth flows, key rotation, access patterns
 - **Non-obvious flags** — env vars or CLI flags with surprising behavior
 
-If you're unsure whether something needs docs, apply the three-question test from `references/anti-patterns.md`.
-
-## Deep Dives
-
-| Topic                                                  | Reference                       |
-| ------------------------------------------------------ | ------------------------------- |
-| CLAUDE.md and README templates                         | `references/claude-md-guide.md` |
-| Anti-patterns, bloat examples, the three-question test | `references/anti-patterns.md`   |
-| Design Intent format, authoring protocol, maintenance  | `references/design-intent.md`   |
+Each still has to clear Filter 2: write the specific fact that changes a decision, not the topic heading. If you're unsure whether something needs docs, apply the three-question test and the no-op catalog in `references/anti-patterns.md`.

--- a/registry/skills/docs-that-work/references/anti-patterns.md
+++ b/registry/skills/docs-that-work/references/anti-patterns.md
@@ -68,7 +68,10 @@ Note the Zustand line: it is a drift rule ("previous migration was partial"). A 
 | Script commands | Read `package.json` scripts or `justfile` | Reads task runner config |
 | CI pipeline steps | Read `.github/workflows/` | Reads CI config |
 
-If it's in a file an agent can read, it doesn't need documentation — with one exception: when code has drifted from the intended pattern, the file shows the drift, not the intent. That case is covered by the guard in the test below.
+If it's in a file an agent can read, it doesn't need documentation — with two exceptions:
+
+- **Drift.** When code has drifted from the intended pattern, the file shows the drift, not the intent. That case is covered by the guard in the test below.
+- **Expensive lookups.** A doc line that restates the environment is a cache of a lookup, and a cache earns its cost only when the lookup is expensive. `just test` in a justfile is one `grep` away — leave it. "The suite that gates CI is `just test-integration`, not `just test`" is a fact no single file states — write it.
 
 ## The Three-Question Test
 
@@ -87,6 +90,23 @@ If any answer is **yes**, don't write it — with one guard: **is what's discove
 - "We use ESLint with airbnb config" → it's in `.eslintrc`. **Don't write it.**
 - "Handlers never touch the DB directly" → most handlers show this, but `sales-report.ts` hits the DB (drift) — the intended pattern is no longer discoverable. **Write it as Design Intent.**
 
+## The No-Op Catalog
+
+The three-question test only catches lines the code already answers. A second class of bloat passes it cleanly: lines that are undiscoverable, true, and change nothing an agent would have done anyway. Test each one against the model's **default behavior** — not against a new hire's ignorance.
+
+| No-op line                                  | Why it's a no-op                      | The live version                                                                                |
+| ------------------------------------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| "Write clean, maintainable code"            | the default                           | (nothing — delete)                                                                                |
+| "Add tests for new functionality"           | the default                           | "Integration tests need `just db-up` first — without it they pass by skipping"                    |
+| "Follow existing patterns in the codebase"  | the default, and wrong where drift is | a Design Intent section naming the golden example                                                 |
+| "Be careful with database migrations"       | names a topic, not a behavior         | "Migrations are numbered by hand — check the highest existing number before adding one"           |
+| "Use TypeScript strictly"                   | `tsconfig.json` decides this          | (nothing — discoverable)                                                                          |
+| "This is a monorepo with multiple packages" | visible from the directory layout     | (nothing — discoverable)                                                                          |
+
+The pattern: a no-op names a **topic** or a **virtue**; a live line names a **specific fact that flips a decision**. When a line fails the test, delete the whole line — a trimmed no-op is still a no-op.
+
+Two people who disagree about whether a line is a no-op disagree about the model's default. Settle it by deleting the line and running the task, not by debate.
+
 ## Common Mistakes
 
 When asked to "document the project," agents typically:
@@ -96,5 +116,6 @@ When asked to "document the project," agents typically:
 3. **Copy type definitions** — paste interfaces and types into docs
 4. **Write a novel** — produce 200+ line CLAUDE.md files that no agent will fully process
 5. **Duplicate across files** — put the same commands in README, CLAUDE.md, and CONTRIBUTING.md
+6. **Write virtues** — "clean code", "follow best practices", "be careful with X": lines nothing in the repo contradicts and no agent acts on
 
 Recognize these patterns. When you catch yourself doing any of them, stop and apply the three-question test to every line.

--- a/registry/skills/docs-that-work/references/anti-patterns.md
+++ b/registry/skills/docs-that-work/references/anti-patterns.md
@@ -71,7 +71,7 @@ Note the Zustand line: it is a drift rule ("previous migration was partial"). A 
 If it's in a file an agent can read, it doesn't need documentation — with two exceptions:
 
 - **Drift.** When code has drifted from the intended pattern, the file shows the drift, not the intent. That case is covered by the guard in the test below.
-- **Expensive lookups.** A doc line that restates the environment is a cache of a lookup, and a cache earns its cost only when the lookup is expensive. `just test` in a justfile is one `grep` away — leave it. "The suite that gates CI is `just test-integration`, not `just test`" is a fact no single file states — write it.
+- **Expensive lookups.** Some answers are technically in the repo but take a chain of files to reconstruct. `just test` sits in the justfile one `grep` away — leave it there. "The suite that gates CI is `just test-integration`, not `just test`" is spread across a workflow file and a justfile and stated outright by neither — write that one down.
 
 ## The Three-Question Test
 
@@ -105,7 +105,7 @@ The three-question test only catches lines the code already answers. A second cl
 
 The pattern: a no-op names a **topic** or a **virtue**; a live line names a **specific fact that flips a decision**. When a line fails the test, delete the whole line — a trimmed no-op is still a no-op.
 
-Two people who disagree about whether a line is a no-op disagree about the model's default. Settle it by deleting the line and running the task, not by debate.
+Disagreement over whether a line is a no-op is really disagreement over how the agent behaves without it. Resolve it by experiment — pull the line, run the task, compare the result — rather than by argument.
 
 ## Common Mistakes
 

--- a/registry/skills/docs-that-work/references/audit-procedure.md
+++ b/registry/skills/docs-that-work/references/audit-procedure.md
@@ -1,0 +1,76 @@
+# Documentation Audit Procedure
+
+The ordered process for refreshing an existing `CLAUDE.md` or `README.md` — a doc review, a "the docs are out of date" request, or a commit blocked by the `docs-that-work-gate` hook.
+
+Reading the file and judging that it "looks fine" is not an audit. The audit is done when **every line of every doc file in scope has been classified**, and not before.
+
+## 1. Scope the audit
+
+List the doc files under review:
+
+- **Blocked commit** — the hook names them. Each changed file is owned by the nearest ancestor directory containing a `CLAUDE.md` or `README.md`, and every doc file in that directory is in scope.
+- **Direct request** — the files the user named, plus any package `CLAUDE.md` that owns code they mention.
+
+Write the list down before editing anything. If it is longer than three files, audit them one at a time to completion rather than skimming all of them at once.
+
+## 2. Read the change, then the docs
+
+Read the pending diff (`git diff HEAD`, plus untracked files) before reading the docs. You are looking for two things: what the change made **wrong** in the docs, and what it made **missing**.
+
+Then read each in-scope doc file in full. Never edit a doc you have not read end to end in this session.
+
+## 3. Classify every line
+
+Walk the doc top to bottom. Every line — including headings and list items — gets exactly one verdict:
+
+| Verdict         | Trigger                                                                                  | Action                                          |
+| --------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **keep**        | clears both filters, still true                                                            | leave untouched                                 |
+| **cut: found**  | Filter 1 — an agent can read it out of code or config, and the lookup is cheap             | delete the line                                 |
+| **cut: no-op**  | Filter 2 — it does not change what the agent does versus its default                       | delete the whole line, don't trim words          |
+| **cut: stale**  | describes behavior, a file, or a constraint that no longer exists                          | delete the line                                 |
+| **rewrite**     | true and load-bearing, but phrased as a bare ban, or drifted from what the code now does   | restate as the positive target, or correct it    |
+| **move**        | true and load-bearing, but in the wrong file (root vs package, `CLAUDE.md` vs `README.md`) | cut here, add there — never leave both copies    |
+| **ask-human**   | changes a confirmed Design Intent section, or sanctions an exception                       | leave the file alone, raise it in step 6         |
+
+A line you cannot classify is a **cut: no-op** candidate: if you cannot say which decision it changes, it does not change one.
+
+Two guards:
+
+- **Drift, not discoverability.** Before cutting a line as `cut: found`, check that what the code shows is what is *intended*. If the code has drifted, the intent is no longer discoverable — that line becomes Design Intent material, not a cut. See `design-intent.md`.
+- **Confirmed Design Intent is not yours to edit.** Deleting or rewriting a confirmed section — including its Exception lines — is `ask-human`, always. Fixing a re-pointed golden example path is the one mechanical exception, and only when the file was renamed in this very change.
+
+## 4. Find what is missing
+
+The diff introduced facts of its own. For each, ask whether it clears both filters — undiscoverable **and** behavior-changing:
+
+- a new prerequisite or ordering rule ("the seed script must run before the first test run")
+- a new cross-service contract not enforced by types
+- a constraint the code cannot state ("this queue is at-least-once — every consumer must be idempotent")
+- a deliberate deviation a future agent would otherwise "fix"
+
+Add only these. A new module, a new export, a new dependency, a new command — all discoverable, all stay unwritten.
+
+## 5. Apply and check the budget
+
+Make the edits, then count lines against the budget in `SKILL.md`: ~25 for a root `CLAUDE.md`, ~35 plus ~10–15 of Design Intent for a package one, ≤70 as the hard ceiling. Over the ceiling, go back to step 3 and cut — the ceiling is not negotiated by exception, it is met by cutting.
+
+## 6. Report
+
+State, in the final summary or PR description:
+
+- the files audited, and for each: lines cut, lines added, lines moved
+- every `ask-human` item, as an explicit question
+- every drift flagged against a Design Intent section — the file and the contradicted rule
+- anything you deliberately left alone and why
+
+## Completion criteria
+
+The audit is complete when all of these hold:
+
+1. Every line of every in-scope doc file carries a verdict from step 3.
+2. Every step-4 candidate was either written down or rejected for a stated reason.
+3. Every file in scope is within its budget.
+4. The report in step 6 exists.
+
+**"The docs are already accurate" is a legitimate outcome** — but only as the result of steps 1–3, not as a reason to skip them. Say so explicitly, name the files you audited, and re-run the blocked command; the hook's marker lets an unchanged retry through.

--- a/registry/skills/docs-that-work/references/claude-md-guide.md
+++ b/registry/skills/docs-that-work/references/claude-md-guide.md
@@ -33,6 +33,8 @@ Order processing API for the warehouse system. Receives orders from the storefro
 
 Commands like `just dev`, `just test`, `just lint` are discoverable from the justfile — only the non-obvious prerequisite gotcha is documented.
 
+**Budget: ~25 lines.** The root file loads on every turn of every session, whether or not that session touches the code it describes, so it carries project-wide content only. Anything scoped to one module belongs in that module's file, and a Design Intent section never belongs here.
+
 ## Service-Level CLAUDE.md Template
 
 ```markdown
@@ -58,6 +60,8 @@ Reference: `[canonical file]` — copy its structure.
 ```
 
 The Exception line is optional — include it only for files that deviate from the intent on purpose (human-confirmed). See `design-intent.md` in this directory.
+
+**Budget: ~35 lines of non-obvious context plus ~10–15 for Design Intent, ≤70 combined.** A package file loads only when the agent works in that directory, which is what buys it the larger allowance.
 
 ### Example: Payment Module
 
@@ -128,7 +132,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md).
 | Contradicts or narrows a root convention | Service-level `CLAUDE.md` (with explicit note) |
 | Describes the intended shape of code in one package | Service-level `CLAUDE.md` (Design Intent section) |
 
-When unsure, put it in root. Easier to push down later than to discover missing context scattered across services.
+When unsure, put it in the narrowest file that still covers every place the rule applies. Root is the expensive default — it is charged on every turn of every session — so promote a rule to root when a second service actually needs it, not in anticipation.
 
 ## What Belongs Where
 


### PR DESCRIPTION
## Why

`docs-that-work` had **one** content filter — *"can an agent find this by reading the code?"* — and it misses a whole class of bloat: lines that are undiscoverable, true, and change nothing an agent would have done anyway (*"write clean code"*, *"be careful with migrations"*).

It also had **no procedure**. The skill is pure reference, so `improve documentation` — and every commit blocked by the `docs-that-work-gate` hook, which is the most-run entry point — executed on improvisation with no bar for "done".

Levers adapted from [mattpocock/skills — `writing-for-agents`](https://github.com/mattpocock/skills/tree/main/skills/productivity/writing-for-agents), kept at this registry's concrete, example-driven altitude rather than imported wholesale.

## What changed

**Two filters instead of one.** Filter 1 is discoverability (unchanged in substance). Filter 2 is a **no-op test**: does the line change what the agent does versus its default? Failing either means cut. `anti-patterns.md` gains a no-op catalog with a "live version" column for each.

**Discoverability gains a cache exception.** The environment is a source of truth, and a doc restating it is a cache — worth its cost only when the lookup is expensive. Previously the rule was binary and forbade documenting things like *"the suite that gates CI is `just test-integration`, not `just test`"*.

**`references/audit-procedure.md` (new).** Six ordered steps: scope → read the diff before the docs → give **every line** a verdict (keep / cut:found / cut:no-op / cut:stale / rewrite / move / ask-human) → find what's missing → budget check → report. Four explicit completion criteria. "The docs are already accurate" is a legitimate outcome, but only as the *result* of the classification pass, not a reason to skip it. Pointed at from the first line of `SKILL.md`, imperatively, and naming the hook — so the blocked-commit path reaches it.

**Root and package `CLAUDE.md` get separate budgets.** Root loads on every turn of every session; a package file loads only when the agent works in that directory. ~25 lines vs ~35 plus ~10–15 for Design Intent, 70 ceiling.

**"Write the target, not the ban."** New section — a prohibition drags the forbidden behavior into context and makes it *more* available. Weak → strong pairs; Design Intent drift callouts stay the sanctioned exception.

**Design Intent deduplicated.** The full format block lived in three files. Cut from `SKILL.md` (26 lines → 10, keeping the conflict rule and an imperative pointer); `design-intent.md` remains the single source for the format, the propose-then-confirm protocol, and the unconfirmed-proposal fallback. Nothing from the human-confirmation safety path was dropped.

**Housekeeping.** Deep Dives table removed as a duplicate of the inline pointers; `description` collapsed from six synonymous triggers to three distinct branches plus the blocked-commit trigger.

## Two behavior changes worth a second look

1. **Root budget 35 → ~25 lines.** Already-installed root `CLAUDE.md` files will read as over budget at their next audit.
2. **"When unsure, put it in root" is reversed** — now: put it in the narrowest file that covers the rule, promote to root when a second service actually needs it. The old default contradicted the split budgets.

## Verification

`cd server && uv run pytest` → **229 passed**, including `test_skill_copy_sync.py` (byte-equality between `registry/` and the dogfooded `.claude/` copy).

## Not in this PR

A sibling `writing-for-agents` skill covering skill/hook/agent authoring mechanics for the whole registry — discussed, deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive procedure for auditing documentation accuracy and completeness.
  * Defined guidance for scoping reviews, analyzing changes, classifying findings, and identifying missing behavioral information.
  * Added criteria for handling design intent, documentation drift, escalation needs, review budgets, and cases where documentation is already accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->