### PR TITLE
fix(ci): stop the image scan reusing a stale OS-upgrade layer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,10 @@ jobs:
           tags: |
             ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
             ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
+          # Per-run value so the OS security-upgrade layer is never served
+          # from the cache -- deployed images ship today's patch level.
+          build-args: |
+            SECURITY_REFRESH=${{ github.run_id }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -25,6 +25,10 @@ jobs:
           file: server/Dockerfile
           load: true
           tags: awos-recruitment-mcp:pr-${{ github.event.pull_request.number }}
+          # Per-run value so the OS security-upgrade layer is never served
+          # from the cache -- the scan must see today's patch level.
+          build-args: |
+            SECURITY_REFRESH=${{ github.run_id }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -46,7 +46,15 @@ FROM python:3.12-slim AS runtime
 
 # Upgrade OS packages to pull in security patches not yet present in the
 # base image (e.g. openssl CVE fixes flagged by the Trivy image scan).
-RUN apt-get update \
+#
+# SECURITY_REFRESH busts the build cache for this layer. BuildKit keys a RUN
+# on its expanded command string, which never changes for an apt upgrade, so
+# with a registry cache the layer is restored forever and the image keeps the
+# package versions of the day it was first built. CI passes a per-run value
+# so the upgrade actually re-runs and picks up newly released patches.
+ARG SECURITY_REFRESH=0
+RUN echo "security refresh: ${SECURITY_REFRESH}" \
+    && apt-get update \
     && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Problem

The Image Scan workflow started failing on every PR run since this morning:

```
awos-recruitment-mcp:pr-89 (debian 13.6)
Total: 3 (HIGH: 3, CRITICAL: 0)
libssl3t64 / openssl / openssl-provider-legacy
CVE-2026-14456  HIGH  fixed  3.5.6-1~deb13u2 -> 3.5.7-1~deb13u2
```

The runtime stage already runs `apt-get update && apt-get upgrade -y` for exactly this reason, so the interesting part is the build log:

```
#15 [runtime 2/7] RUN apt-get update     && apt-get upgrade -y     && rm -rf /var/lib/apt/lists/*
#15 CACHED
```

BuildKit keys a `RUN` on its expanded command string. That string never changes for an apt upgrade, so with `cache-from: type=gha` the layer is restored on every build and the image keeps the package versions of the day the layer was first built. Debian published the openssl fix (trixie-security) after that day, so the scan kept seeing the old package no matter how many times the job re-ran.

`deploy.yml` shares the same cache, so production images were shipping the same stale packages.

## Fix

- `server/Dockerfile`: add a `SECURITY_REFRESH` build arg that the upgrade command interpolates, so the layer's cache key changes when the arg does.
- `image-scan.yml` and `deploy.yml`: pass `SECURITY_REFRESH=${{ github.run_id }}`, making the upgrade re-run on every build.

The builder stage (dependency install, ONNX model download) is untouched and stays cached; only the small runtime layers rebuild.

## Verification

This PR touches `server/**`, so the Image Scan workflow runs on it — a green scan here is the proof that the upgrade layer re-runs and picks up `openssl 3.5.7-1~deb13u2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Ensured operating system security updates are refreshed on every deployment and image scan.
  * Reduced the risk of using cached security-update layers in runtime images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->